### PR TITLE
shipper: make shipper aware of block layout

### DIFF
--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -4,13 +4,17 @@ package shipper
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
-	"time"
 
+	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/tsdb"
+	"github.com/prometheus/tsdb/labels"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -19,8 +23,8 @@ import (
 
 // Remote represents a remote data store to which directories are uploaded.
 type Remote interface {
-	Exists(ctx context.Context, id string) (bool, error)
-	Upload(ctx context.Context, dir string) error
+	Exists(ctx context.Context, id ulid.ULID) (bool, error)
+	Upload(ctx context.Context, id ulid.ULID, dir string) error
 }
 
 // Shipper watches a directory for matching files and directories and uploads
@@ -30,81 +34,119 @@ type Shipper struct {
 	dir    string
 	remote Remote
 	match  func(os.FileInfo) bool
+	labels func() labels.Labels
 }
 
-// New creates a new shipper.
+// New creates a new shipper that detects new TSDB blocks in dir and uploads them
+// to remote if necessary. It attaches the return value of the labels getter to uploaded data.
 func New(
 	logger log.Logger,
 	metric prometheus.Registerer,
 	dir string,
 	remote Remote,
-	match func(os.FileInfo) bool,
+	lbls func() labels.Labels,
 ) *Shipper {
 	if logger == nil {
 		logger = log.NewNopLogger()
+	}
+	if lbls == nil {
+		lbls = func() labels.Labels { return nil }
 	}
 	return &Shipper{
 		logger: logger,
 		dir:    dir,
 		remote: remote,
-		match:  match,
+		labels: lbls,
 	}
 }
 
-// IsULIDDir returns true if the described file is a directory with a name that is
-// a valid ULID.
-func IsULIDDir(fi os.FileInfo) bool {
-	if !fi.IsDir() {
-		return false
+// Sync performs a single synchronization if the local block data with the remote end.
+func (s *Shipper) Sync(ctx context.Context) {
+	names, err := readDir(s.dir)
+	if err != nil {
+		level.Warn(s.logger).Log("msg", "read dir failed", "err", err)
 	}
-	_, err := ulid.Parse(fi.Name())
-	return err == nil
-}
+	for _, dn := range names {
+		dn = filepath.Join(s.dir, dn)
 
-// Run the shipper.
-func (s *Shipper) Run(ctx context.Context, syncInterval time.Duration) error {
-	tick := time.NewTicker(syncInterval)
-	defer tick.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-tick.C:
-			names, err := readDir(s.dir)
-			if err != nil {
-				level.Warn(s.logger).Log("msg", "read dir failed", "err", err)
-				continue
-			}
-			for _, dn := range names {
-				dn = filepath.Join(s.dir, dn)
-
-				fi, err := os.Stat(dn)
-				if err != nil {
-					level.Warn(s.logger).Log("msg", "open file failed", "err", err)
-					continue
-				}
-				if !s.match(fi) {
-					continue
-				}
-				if err := s.sync(ctx, dn); err != nil {
-					level.Error(s.logger).Log("msg", "shipping failed", "dir", dn, "err", err)
-				}
-			}
+		fi, err := os.Stat(dn)
+		if err != nil {
+			level.Warn(s.logger).Log("msg", "open file failed", "err", err)
+			continue
+		}
+		if !fi.IsDir() {
+			continue
+		}
+		id, err := ulid.Parse(fi.Name())
+		if err != nil {
+			continue
+		}
+		if err := s.sync(ctx, id, dn); err != nil {
+			level.Error(s.logger).Log("msg", "shipping failed", "dir", dn, "err", err)
 		}
 	}
 }
 
-func (s *Shipper) sync(ctx context.Context, dir string) error {
-	ok, err := s.remote.Exists(ctx, dir)
+// blockMeta is regular TSDB block meta extended by Thanos specific information.
+type blockMeta struct {
+	Version int `json:"version"`
+
+	tsdb.BlockMeta
+
+	Thanos thanosBlockMeta `json:"thanos"`
+}
+
+type thanosBlockMeta struct {
+	Labels map[string]string `json:"labels"`
+}
+
+func (s *Shipper) sync(ctx context.Context, id ulid.ULID, dir string) error {
+	meta, err := readMetaFile(dir)
+	if err != nil {
+		return errors.Wrap(err, "read meta file")
+	}
+	// We only ship of the first compacted block level.
+	if meta.Compaction.Level > 1 {
+		return nil
+	}
+	ok, err := s.remote.Exists(ctx, id)
 	if err != nil {
 		return errors.Wrap(err, "check exists")
 	}
 	if ok {
 		return nil
 	}
-	level.Info(s.logger).Log("msg", "upload new block", "dir", dir)
-	return s.remote.Upload(ctx, dir)
+
+	level.Info(s.logger).Log("msg", "upload new block", "id", id)
+
+	// We hard-link the files into a temporary upload directory so we are not affected
+	// by other operations happening against the TSDB directory.
+	updir := filepath.Join(s.dir, "thanos", "upload")
+
+	if err := os.RemoveAll(updir); err != nil {
+		return errors.Wrap(err, "clean upload directory")
+	}
+	if err := os.MkdirAll(updir, 0777); err != nil {
+		return errors.Wrap(err, "create upload dir")
+	}
+	defer os.RemoveAll(updir)
+
+	if err := os.Link(filepath.Join(dir, "index"), filepath.Join(updir, "index")); err != nil {
+		return errors.Wrap(err, "link index file")
+	}
+	if err := os.Link(filepath.Join(dir, "chunks"), filepath.Join(updir, "chunks")); err != nil {
+		return errors.Wrap(err, "link chunk directory")
+	}
+	// Tombstone files are skipped as they should not be used in the Thanos deployment model.
+
+	// Attach current labels and write a new meta file with Thanos extensions.
+	if lset := s.labels(); lset != nil {
+		meta.Thanos.Labels = lset.Map()
+	}
+	if err := writeMetaFile(updir, meta); err != nil {
+		return errors.Wrap(err, "write meta file")
+	}
+	return s.remote.Upload(ctx, id, updir)
 }
 
 // readDir returns the filenames in the given directory in sorted order.
@@ -120,4 +162,66 @@ func readDir(dirpath string) ([]string, error) {
 	}
 	sort.Strings(names)
 	return names, nil
+}
+
+const metaFilename = "meta.json"
+
+func writeMetaFile(dir string, meta *blockMeta) error {
+	// Make any changes to the file appear atomic.
+	path := filepath.Join(dir, metaFilename)
+	tmp := path + ".tmp"
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "\t")
+
+	if err := enc.Encode(meta); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return renameFile(tmp, path)
+}
+
+func readMetaFile(dir string) (*blockMeta, error) {
+	b, err := ioutil.ReadFile(filepath.Join(dir, metaFilename))
+	if err != nil {
+		return nil, err
+	}
+	var m blockMeta
+
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	if m.Version != 1 {
+		return nil, errors.Errorf("unexpected meta file version %d", m.Version)
+	}
+	return &m, nil
+}
+
+func renameFile(from, to string) error {
+	if err := os.RemoveAll(to); err != nil {
+		return err
+	}
+	if err := os.Rename(from, to); err != nil {
+		return err
+	}
+
+	// Directory was renamed; sync parent dir to persist rename.
+	pdir, err := fileutil.OpenDir(filepath.Dir(to))
+	if err != nil {
+		return err
+	}
+
+	if err = fileutil.Fsync(pdir); err != nil {
+		pdir.Close()
+		return err
+	}
+	return pdir.Close()
 }


### PR DESCRIPTION
This makes the shipper and remote components more aware of what they are
uploading. The Shipper now attaches a Thanos specific section to the
meta.json file where it attaches the external labels for the block.

The shipper now stages all files in a separate directory, making it less
vulnearable to other processes messing with the currently uploaded
files.

@Bplotka 