### PR TITLE
Added labels to peer, added querying external labels as initial step in sidecar.

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/hashicorp/memberlist"
+	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/pkg/errors"
 )
 
@@ -189,6 +190,10 @@ func (p *Peer) Info() map[string]interface{} {
 type PeerState struct {
 	Type    PeerType
 	APIAddr string
+
+	// Every peer can propagate its labels that makes a peer a unique member of the system.
+	// We assume that only Store Type peers will be propagating (external) labels.
+	Labels []storepb.Label
 }
 
 // delegate implements memberlist.Delegate and memberlist.EventDelegate

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -191,8 +191,6 @@ type PeerState struct {
 	Type    PeerType
 	APIAddr string
 
-	// Every peer can propagate its labels that makes a peer a unique member of the system.
-	// We assume that only Store Type peers will be propagating (external) labels.
 	Labels []storepb.Label
 }
 

--- a/pkg/cluster/stores.go
+++ b/pkg/cluster/stores.go
@@ -3,12 +3,10 @@ package cluster
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/query"
-	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"google.golang.org/grpc"
 )
@@ -30,55 +28,40 @@ func NewStoreSet(logger log.Logger, peer *Peer) *StoreSet {
 	}
 }
 
-// Update the store set to the new set of addresses. New background processes initiated respect
-// the lifecycle of the given context.
+// Update the store set to the new set of addresses and labels for that addresses.
+// New background processes initiated respect the lifecycle of the given context.
 func (s *StoreSet) Update(ctx context.Context) {
 	// XXX(fabxc): The store as is barely ties into the cluster. This is the only place where
 	// we depend on it. However, in the future this may change when we fetch additional information
-	// about peers or make the set self-updating through events rather than explicit calls to Update.
-	storeAddresses := map[string]struct{}{}
+	// about storePeers or make the set self-updating through events rather than explicit calls to Update.
+	storePeers := map[string]PeerState{}
 	for _, ps := range s.peer.PeerStates(PeerTypeStore) {
-		storeAddresses[ps.APIAddr] = struct{}{}
+		storePeers[ps.APIAddr] = ps
 	}
 
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	// For each new address we create a new gRPC connection and start a background routine
-	// which updates relevant metadata for the store (e.g. labels).
-	for addr := range storeAddresses {
-		if _, ok := s.stores[addr]; ok {
-			continue
-		}
-		conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithBlock())
-		if err != nil {
-			level.Warn(s.logger).Log("msg", "dialing connection failed; skipping", "store", addr, "err", err)
-			continue
-		}
-		iterCtx, cancel := context.WithCancel(ctx)
-
-		store := &storeInfo{conn: conn, cancel: cancel}
-		s.stores[addr] = store
-
-		go runutil.Repeat(60*time.Second, iterCtx.Done(), func() error {
-			ctx, cancel := context.WithTimeout(iterCtx, 30*time.Second)
-			defer cancel()
-
-			resp, err := storepb.NewStoreClient(store.conn).Info(ctx, &storepb.InfoRequest{})
+	// For each new store peer we create a new gRPC connection.
+	// In every case we also updates the labels from peer state.
+	for addr, state := range storePeers {
+		if _, ok := s.stores[addr]; !ok {
+			conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithBlock())
 			if err != nil {
-				level.Warn(s.logger).Log("msg", "failed fetching store info", "err", err)
-			} else {
-				// Make sure to set labels even with empty label set do make store ready.
-				store.setLabels(resp.Labels)
+				level.Warn(s.logger).Log("msg", "dialing connection failed; skipping", "store", addr, "err", err)
+				continue
 			}
-			return nil
-		})
+			store := &storeInfo{conn: conn}
+			s.stores[addr] = store
+		}
 
+		// Always fetch up-to-date labels propagated in peer state.
+		s.stores[addr].setLabels(state.Labels)
 	}
+
 	// Delete stores that no longer exist.
 	for addr, store := range s.stores {
-		if _, ok := storeAddresses[addr]; !ok {
-			store.cancel()
+		if _, ok := storePeers[addr]; !ok {
 			store.conn.Close()
 			level.Info(s.logger).Log("msg", "closing connection for store")
 			delete(s.stores, addr)
@@ -93,10 +76,6 @@ func (s *StoreSet) Get() []query.StoreInfo {
 
 	var res []query.StoreInfo
 	for _, store := range s.stores {
-		if !store.Ready() {
-			continue
-		}
-
 		res = append(res, store)
 	}
 	return res
@@ -104,22 +83,14 @@ func (s *StoreSet) Get() []query.StoreInfo {
 
 type storeInfo struct {
 	conn   *grpc.ClientConn
-	cancel func()
 	mtx    sync.RWMutex
 	labels []storepb.Label
-	ready  bool
 }
 
 var _ query.StoreInfo = (*storeInfo)(nil)
 
 func (s *storeInfo) Conn() *grpc.ClientConn {
 	return s.conn
-}
-
-func (s *storeInfo) Ready() bool {
-	s.mtx.RLock()
-	defer s.mtx.RUnlock()
-	return s.ready
 }
 
 func (s *storeInfo) Labels() []storepb.Label {
@@ -131,6 +102,5 @@ func (s *storeInfo) Labels() []storepb.Label {
 func (s *storeInfo) setLabels(lset []storepb.Label) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
-	s.ready = true
 	s.labels = lset
 }

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -18,13 +18,10 @@ import (
 
 var _ promql.Queryable = (*Queryable)(nil)
 
-// StoreInfo holds meta information about a store.
+// StoreInfo holds meta information about a store used by query.
 type StoreInfo interface {
 	// Conn returns connection to the store API.
 	Conn() *grpc.ClientConn
-
-	// Ready returns true if store is ready. In our case it is ready, only after labels when set for the first time.
-	Ready() bool
 
 	// Labels returns store labels that should be appended to every metric returned by this store.
 	Labels() []storepb.Label

--- a/pkg/store/promproxy.go
+++ b/pkg/store/promproxy.go
@@ -53,9 +53,6 @@ func NewPrometheusProxy(
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
-	if externalLabels == nil {
-		externalLabels = func() labels.Labels { return nil }
-	}
 	p := &PrometheusProxy{
 		logger:         logger,
 		base:           baseURL,
@@ -134,10 +131,9 @@ func (p *PrometheusProxy) Series(ctx context.Context, r *storepb.SeriesRequest) 
 	res := &storepb.SeriesResponse{
 		Series: make([]storepb.Series, 0, len(m.Data.Result)),
 	}
-	ext := p.externalLabels()
 
 	for _, e := range m.Data.Result {
-		lset := translateAndExtendLabels(e.Metric, ext)
+		lset := translateAndExtendLabels(e.Metric, p.externalLabels())
 		// We generally expect all samples of the requested range to be traversed
 		// so we just encode all samples into one big chunk regardless of size.
 		//

--- a/pkg/store/promproxy.go
+++ b/pkg/store/promproxy.go
@@ -131,9 +131,9 @@ func (p *PrometheusProxy) Series(ctx context.Context, r *storepb.SeriesRequest) 
 	res := &storepb.SeriesResponse{
 		Series: make([]storepb.Series, 0, len(m.Data.Result)),
 	}
-
+	ext := p.externalLabels()
 	for _, e := range m.Data.Result {
-		lset := translateAndExtendLabels(e.Metric, p.externalLabels())
+		lset := translateAndExtendLabels(e.Metric, ext)
 		// We generally expect all samples of the requested range to be traversed
 		// so we just encode all samples into one big chunk regardless of size.
 		//


### PR DESCRIPTION
This actually fixes the races with pushing the metrics without external labels first, but actually it shows a shortcoming of exposing ext labels as unique attribute for store nodes. As it makes sense on sidecar, GCS store node does not necessary query data for same external labels.. also we maybe want to know which one is GCS store, which one is sidecar... so I guess, Peer.Label info for GCS store node needs to be some arbitrary value configured on startup?


Signed-off-by: Bartek Plotka <bwplotka@gmail.com>