### PR TITLE
Improve testing, handle block labels

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -274,6 +274,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "36d1abfc959a1a727e267a8fbeb3b148d6f9c081e14eb6f2f0130935af8a5ffc"
+  inputs-digest = "ccadd63894c2918adb6d95fcd37ead63d8845cd4eadfadd1c4920e771997434c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -1,0 +1,94 @@
+// Package block contains common functionality for interacting with TSDB blocks
+// in the context of Thanos.
+package block
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/pkg/errors"
+	"github.com/prometheus/tsdb"
+)
+
+// Meta describes the a block's meta. It wraps the known TSDB meta structure and
+// extends it by Thanos-specific fields.
+type Meta struct {
+	Version int `json:"version"`
+
+	tsdb.BlockMeta
+
+	Thanos ThanosMeta `json:"thanos"`
+}
+
+// ThanosMeta holds block meta information specific to Thanos.
+type ThanosMeta struct {
+	Labels map[string]string `json:"labels"`
+}
+
+// MetaFilename is the known JSON filename for meta information.
+const MetaFilename = "meta.json"
+
+// WriteMetaFile writes the given meta into <dir>/meta.json.
+func WriteMetaFile(dir string, meta *Meta) error {
+	// Make any changes to the file appear atomic.
+	path := filepath.Join(dir, MetaFilename)
+	tmp := path + ".tmp"
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "\t")
+
+	if err := enc.Encode(meta); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return renameFile(tmp, path)
+}
+
+// ReadMetaFile reads the given meta from <dir>/meta.json.
+func ReadMetaFile(dir string) (*Meta, error) {
+	b, err := ioutil.ReadFile(filepath.Join(dir, MetaFilename))
+	if err != nil {
+		return nil, err
+	}
+	var m Meta
+
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	if m.Version != 1 {
+		return nil, errors.Errorf("unexpected meta file version %d", m.Version)
+	}
+	return &m, nil
+}
+
+func renameFile(from, to string) error {
+	if err := os.RemoveAll(to); err != nil {
+		return err
+	}
+	if err := os.Rename(from, to); err != nil {
+		return err
+	}
+
+	// Directory was renamed; sync parent dir to persist rename.
+	pdir, err := fileutil.OpenDir(filepath.Dir(to))
+	if err != nil {
+		return err
+	}
+
+	if err = fileutil.Fsync(pdir); err != nil {
+		pdir.Close()
+		return err
+	}
+	return pdir.Close()
+}

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -16,6 +16,7 @@ import (
 
 	"os"
 
+	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 )
 
@@ -87,7 +88,7 @@ func TestShipper_UploadBlocks(t *testing.T) {
 
 		testutil.Ok(t, os.Mkdir(tmp, 0777))
 
-		meta := blockMeta{}
+		meta := block.Meta{}
 		meta.Version = 1
 		meta.ULID = id
 

--- a/pkg/testutil/objstore.go
+++ b/pkg/testutil/objstore.go
@@ -1,0 +1,70 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+
+	"google.golang.org/api/iterator"
+)
+
+// NewObjectStoreBucket creates a new GCS bucket with a random name and a cleanup function
+// that deletes it.
+//
+// TODO(fabxc): define object storage interface and have this method return
+// mocks or actual remote buckets depending on env vars.
+func NewObjectStoreBucket(t testing.TB) (*storage.BucketHandle, func()) {
+	project, ok := os.LookupEnv("GCP_PROJECT")
+	// TODO(fabxc): make it run against a mock store if no actual bucket is configured.
+	if !ok {
+		t.Skip("test can only run against a defined GCP_PROJECT")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	gcsClient, err := storage.NewClient(ctx)
+	Ok(t, err)
+
+	src := rand.NewSource(time.Now().UnixNano())
+	Ok(t, err)
+	name := fmt.Sprintf("test_%s_%x", strings.ToLower(t.Name()), src.Int63())
+
+	bkt := gcsClient.Bucket(name)
+	Ok(t, bkt.Create(ctx, project, nil))
+
+	return bkt, func() {
+		deleteAllBucket(t, ctx, bkt)
+		cancel()
+		gcsClient.Close()
+	}
+}
+
+func deleteAllBucket(t testing.TB, ctx context.Context, bkt *storage.BucketHandle) {
+	var wg sync.WaitGroup
+
+	objs := bkt.Objects(ctx, nil)
+	for {
+		oi, err := objs.Next()
+		if err == iterator.Done {
+			break
+		}
+		Ok(t, err)
+
+		wg.Add(1)
+		go func() {
+			if err := bkt.Object(oi.Name).Delete(ctx); err != nil {
+				t.Logf("deleting object %s failed: %s", oi.Name, err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	Ok(t, bkt.Delete(ctx))
+}


### PR DESCRIPTION
This factors our the test bucket setup and deletes buckets more reliably.

I created `pkg/block` to interact with TSDB blocks. We have minimal custom additions in meta.json right now but that might become more over time.
This is being used in the shipper and now in the store as well.

The rest is correct handling of those meta.json files in `pkg/store`. It's a bit awkward to now also introduce `map[string]string` now as a representation for labels. But writing the 500th variant of `MarshalJSON` for labels is not much better as an alternative.

@Bplotka 