### PR TITLE
Improve and test query fanin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -65,7 +65,7 @@
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
-  revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   name = "github.com/googleapis/gax-go"
@@ -203,7 +203,7 @@
   branch = "fabxc"
   name = "github.com/prometheus/tsdb"
   packages = [".","chunks","fileutil","labels"]
-  revision = "a031cf7424079c17746314bc29e3ff907d3b97ba"
+  revision = "542b2be8bb930b1cd00121fca34a56197c829895"
 
 [[projects]]
   branch = "master"
@@ -215,7 +215,7 @@
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
+  revision = "9dfe39835686865bff950a07b394c12a98ddc811"
 
 [[projects]]
   branch = "master"
@@ -256,8 +256,8 @@
 [[projects]]
   name = "google.golang.org/grpc"
   packages = [".","balancer","benchmark/stats","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","stats","status","tap","transport"]
-  revision = "5ffe3083946d5603a0578721101dc8165b1d5b5f"
-  version = "v1.7.2"
+  revision = "401e0e00e4bb830a10496d64cd95e068c5bf50de"
+  version = "v1.7.3"
 
 [[projects]]
   name = "gopkg.in/alecthomas/kingpin.v2"
@@ -269,11 +269,11 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
+  revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "36d1abfc959a1a727e267a8fbeb3b148d6f9c081e14eb6f2f0130935af8a5ffc"
+  inputs-digest = "ccadd63894c2918adb6d95fcd37ead63d8845cd4eadfadd1c4920e771997434c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/query/promadapter.go
+++ b/pkg/query/promadapter.go
@@ -1,31 +1,25 @@
 package query
 
 import (
-	"unsafe"
-
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/tsdb"
-	tsdbLabels "github.com/prometheus/tsdb/labels"
 
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 )
 
 type promSeriesSet struct {
-	set tsdb.SeriesSet
+	set        chunkSeriesSet
+	mint, maxt int64
 }
 
-func (s promSeriesSet) Next() bool         { return s.set.Next() }
-func (s promSeriesSet) Err() error         { return s.set.Err() }
-func (s promSeriesSet) At() storage.Series { return promSeries{s: s.set.At()} }
+func (s promSeriesSet) Next() bool { return s.set.Next() }
+func (s promSeriesSet) Err() error { return s.set.Err() }
 
-type promSeries struct {
-	s tsdb.Series
+func (s promSeriesSet) At() storage.Series {
+	lset, chunks := s.set.At()
+	return newChunkSeries(lset, chunks, s.mint, s.maxt)
 }
-
-func (s promSeries) Labels() labels.Labels            { return toPromLabels(s.s.Labels()) }
-func (s promSeries) Iterator() storage.SeriesIterator { return storage.SeriesIterator(s.s.Iterator()) }
 
 func translateMatcher(m *labels.Matcher) (storepb.LabelMatcher, error) {
 	var t storepb.LabelMatcher_Type
@@ -55,8 +49,4 @@ func translateMatchers(ms ...*labels.Matcher) ([]storepb.LabelMatcher, error) {
 		res = append(res, r)
 	}
 	return res, nil
-}
-
-func toPromLabels(l tsdbLabels.Labels) labels.Labels {
-	return *(*labels.Labels)(unsafe.Pointer(&l))
 }

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/prometheus/tsdb/chunks"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage"
 	"google.golang.org/grpc"
 )
 
@@ -44,6 +48,66 @@ func TestQuerier_LabelValues(t *testing.T) {
 	testutil.Equals(t, expected, vals)
 }
 
+// TestQuerier_Series catches common edge cases encountered when querying multiple store nodes.
+// It is not a subtitute for testing fanin/merge procedures in depth.
+func TestQuerier_Series(t *testing.T) {
+	a := &testStoreClient{
+		series: []storepb.Series{
+			testStoreSeries(t, labels.FromStrings("a", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+			testStoreSeries(t, labels.FromStrings("a", "b"), []sample{{2, 2}, {3, 3}, {4, 4}}),
+		},
+	}
+	b := &testStoreClient{
+		series: []storepb.Series{
+			testStoreSeries(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
+		},
+	}
+	c := &testStoreClient{
+		series: []storepb.Series{
+			testStoreSeries(t, labels.FromStrings("a", "c"), []sample{{100, 1}, {300, 3}, {400, 4}}),
+		},
+	}
+	// Querier clamps the range to [1,300], which should drop some samples of the result above.
+	// The store API allows endpoints to send more data then initially requested.
+	q := newQuerier(nil, context.Background(), []StoreInfo{
+		testStoreInfo{client: a},
+		testStoreInfo{client: b},
+		testStoreInfo{client: c},
+	}, 1, 300)
+	defer q.Close()
+
+	res := q.Select()
+
+	expected := []struct {
+		lset    labels.Labels
+		samples []sample
+	}{
+		{
+			lset:    labels.FromStrings("a", "a"),
+			samples: []sample{{2, 1}, {3, 2}},
+		},
+		{
+			lset:    labels.FromStrings("a", "b"),
+			samples: []sample{{1, 1}, {2, 2}, {3, 3}, {4, 4}},
+		},
+		{
+			lset:    labels.FromStrings("a", "c"),
+			samples: []sample{{100, 1}, {300, 3}},
+		},
+	}
+
+	i := 0
+	for res.Next() {
+		testutil.Equals(t, expected[i].lset, res.At().Labels())
+
+		samples := expandSeries(t, res.At().Iterator())
+		testutil.Equals(t, expected[i].samples, samples)
+
+		i++
+	}
+	testutil.Ok(t, res.Err())
+}
+
 type testStoreInfo struct {
 	labels []storepb.Label
 	client storepb.StoreClient
@@ -57,8 +121,43 @@ func (s testStoreInfo) Client() storepb.StoreClient {
 	return s.client
 }
 
+type sample struct {
+	t int64
+	v float64
+}
+
+func expandSeries(t testing.TB, it storage.SeriesIterator) (res []sample) {
+	for it.Next() {
+		t, v := it.At()
+		res = append(res, sample{t, v})
+	}
+	testutil.Ok(t, it.Err())
+	return res
+}
+
+func testStoreSeries(t testing.TB, lset labels.Labels, smpls []sample) (s storepb.Series) {
+	for _, l := range lset {
+		s.Labels = append(s.Labels, storepb.Label{Name: l.Name, Value: l.Value})
+	}
+	c := chunks.NewXORChunk()
+	a, err := c.Appender()
+	testutil.Ok(t, err)
+
+	for _, smpl := range smpls {
+		a.Append(smpl.t, smpl.v)
+	}
+	s.Chunks = append(s.Chunks, storepb.Chunk{
+		Type:    storepb.Chunk_XOR,
+		MinTime: smpls[0].t,
+		MaxTime: smpls[len(smpls)-1].t,
+		Data:    c.Bytes(),
+	})
+	return s
+}
+
 type testStoreClient struct {
 	values map[string][]string
+	series []storepb.Series
 }
 
 func (s *testStoreClient) Info(ctx context.Context, req *storepb.InfoRequest, _ ...grpc.CallOption) (*storepb.InfoResponse, error) {
@@ -66,7 +165,7 @@ func (s *testStoreClient) Info(ctx context.Context, req *storepb.InfoRequest, _ 
 }
 
 func (s *testStoreClient) Series(ctx context.Context, req *storepb.SeriesRequest, _ ...grpc.CallOption) (*storepb.SeriesResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+	return &storepb.SeriesResponse{Series: s.series}, nil
 }
 
 func (s *testStoreClient) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest, _ ...grpc.CallOption) (*storepb.LabelNamesResponse, error) {

--- a/pkg/store/gcs.go
+++ b/pkg/store/gcs.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -292,26 +291,9 @@ func (r *seriesResult) response() ([]storepb.Series, error) {
 		res = append(res, s)
 	}
 	sort.Slice(res, func(i, j int) bool {
-		return compareLabels(res[i].Labels, res[j].Labels) < 0
+		return storepb.CompareLabels(res[i].Labels, res[j].Labels) < 0
 	})
 	return res, nil
-}
-
-func compareLabels(a, b []storepb.Label) int {
-	l := len(a)
-	if len(b) < l {
-		l = len(b)
-	}
-	for i := 0; i < l; i++ {
-		if d := strings.Compare(a[i].Name, b[i].Name); d != 0 {
-			return d
-		}
-		if d := strings.Compare(a[i].Value, b[i].Value); d != 0 {
-			return d
-		}
-	}
-	// If all labels so far were in common, the set with fewer labels comes first.
-	return len(a) - len(b)
 }
 
 // Series implements the storepb.StoreServer interface.

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -1,0 +1,23 @@
+package storepb
+
+import (
+	"strings"
+)
+
+// CompareLabels compares two sets of labels.
+func CompareLabels(a, b []Label) int {
+	l := len(a)
+	if len(b) < l {
+		l = len(b)
+	}
+	for i := 0; i < l; i++ {
+		if d := strings.Compare(a[i].Name, b[i].Name); d != 0 {
+			return d
+		}
+		if d := strings.Compare(a[i].Value, b[i].Value); d != 0 {
+			return d
+		}
+	}
+	// If all labels so far were in common, the set with fewer labels comes first.
+	return len(a) - len(b)
+}


### PR DESCRIPTION
@Bplotka 

We are now doing all the merging ourselves. But nicely enough we know convert straight from `storepb` to `prometheus/prometheus/storage`. Thereby this package should now not have any deps onto `prometheus/tsdb` directly (just the chunks package).

The main reason is that we not only get overlapping chunks, but also get series set with no time ordering at all, which `prometheus/tsdb` mostly assumes. Later we will need to add more logic for merging series from HA pairs – so having it all here might be good after all.
