### PR TITLE
Add basic store metrics, respect context in chunk reader

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -82,7 +82,7 @@ func runStore(
 			return errors.Wrap(err, "create GCS client")
 		}
 
-		gs, err := store.NewGCSStore(logger, gcsClient.Bucket(gcsBucket), dataDir)
+		gs, err := store.NewGCSStore(logger, reg, gcsClient.Bucket(gcsBucket), dataDir)
 		if err != nil {
 			return errors.Wrap(err, "create GCS store")
 		}

--- a/pkg/store/gcs_test.go
+++ b/pkg/store/gcs_test.go
@@ -70,7 +70,7 @@ func TestGCSStore_downloadBlocks(t *testing.T) {
 	dir, err := ioutil.TempDir("", "test-syncBlocks")
 	testutil.Ok(t, err)
 
-	s, err := NewGCSStore(nil, bkt, dir)
+	s, err := NewGCSStore(nil, nil, bkt, dir)
 	testutil.Ok(t, err)
 	defer s.Close()
 
@@ -145,7 +145,7 @@ func TestGCSStore_e2e(t *testing.T) {
 		testutil.Ok(t, os.RemoveAll(dir2))
 	}
 
-	store, err := NewGCSStore(nil, bkt, dir)
+	store, err := NewGCSStore(nil, nil, bkt, dir)
 	testutil.Ok(t, err)
 
 	go store.SyncBlocks(ctx, 100*time.Millisecond)


### PR DESCRIPTION
This also fixes a wrong `defer Close()` call, which should've be called on the GCS object reader. At the same time, this is most likely what caused #66 