### PR TITLE
query: add re-ordering of store input by replica labels

### DIFF
--- a/pkg/query/fanin.go
+++ b/pkg/query/fanin.go
@@ -23,15 +23,15 @@ type storeSeriesSet struct {
 	i      int
 }
 
+func newStoreSeriesSet(s []storepb.Series) *storeSeriesSet {
+	return &storeSeriesSet{series: s, i: -1}
+}
+
 func (s *storeSeriesSet) Next() bool {
 	if s.i >= len(s.series)-1 {
 		return false
 	}
 	s.i++
-	// Skip empty series.
-	if len(s.series[s.i].Chunks) == 0 {
-		return s.Next()
-	}
 	return true
 }
 


### PR DESCRIPTION
To be able to merge series from different replicas efficiently, we need
to align the sequentially in our series set so we can greedily grab them
until a new series is found.

To fully leverage the streaming API, we'd need to push this logic down
into the store servers, which could attach the (external) replica label
in the way we construct it here. For now this is sufficient without
adding API complexity.

@Bplotka 

This is just a very first step, but since it will get reasonably complex, it's probably a good idea to make multiple PRs.