### PR TITLE
 Fetch index information on demand

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -218,10 +218,10 @@
   revision = "6171d00fa712c2f8368e601fa20c131fe37c8e16"
 
 [[projects]]
-  branch = "master"
+  branch = "refpkg2"
   name = "github.com/prometheus/tsdb"
-  packages = [".","chunks","fileutil","labels"]
-  revision = "ad3c4849a99729a9c10a55b3ba4c0ad146d2446a"
+  packages = [".","chunkenc","chunks","fileutil","index","labels"]
+  revision = "abd68925295f6e2ddce0c54bf2680d0c42549cd6"
 
 [[projects]]
   branch = "master"
@@ -304,6 +304,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1ae5c79f2ca501ac787403c451a6174a2c6b2664718fb3ee46515c75ef78ed4c"
+  inputs-digest = "db669804d4f8abeed32b8aeb6a2ce31c6860b715bd1dec80ffbb76d10061002e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@
   name = "github.com/grpc-ecosystem/go-grpc-prometheus"
 
 [[constraint]]
-  branch = "master"
+  branch = "refpkg2"
   name = "github.com/prometheus/tsdb"
 
 [[constraint]]

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -59,6 +59,9 @@ func WriteIndexCache(fn string, r *index.Reader) error {
 			if err != nil {
 				return errors.Wrap(err, "get label value")
 			}
+			if len(v) != 1 {
+				return errors.Errorf("unexpected tuple length %d", len(v))
+			}
 			vals = append(vals, v[0])
 		}
 		v.LabelValues[ln] = vals
@@ -106,7 +109,7 @@ func ReadIndexCache(fn string) (
 	postings = make(map[labels.Label]index.Range, len(v.Postings))
 
 	// Most strings we encounter are duplicates. Dedup string objects that we keep
-	// around after the function returns.
+	// around after the function returns to reduce total memory usage.
 	// NOTE(fabxc): it could even make sense to deduplicate globally.
 	getStr := func(s string) string {
 		if cs, ok := strs[s]; ok {

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -1,0 +1,136 @@
+package block
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/tsdb/index"
+	"github.com/prometheus/tsdb/labels"
+)
+
+// IndexCacheFilename is the canonical name for index cache files.
+const IndexCacheFilename = "index.cache.json"
+
+type postingsRange struct {
+	Name, Value string
+	Start, End  int64
+}
+
+type indexCache struct {
+	Symbols     map[uint32]string
+	LabelValues map[string][]string
+	Postings    []postingsRange
+}
+
+// WriteIndexCache writes a cache file containing the first lookup stages
+// for an index file.
+func WriteIndexCache(fn string, r *index.Reader) error {
+	f, err := os.Create(fn)
+	if err != nil {
+		return errors.Wrap(err, "create file")
+	}
+	defer f.Close()
+
+	v := indexCache{
+		Symbols:     r.SymbolTable(),
+		LabelValues: map[string][]string{},
+	}
+
+	// Extract label value indices.
+	lnames, err := r.LabelIndices()
+	if err != nil {
+		return errors.Wrap(err, "read label indices")
+	}
+	for _, lns := range lnames {
+		if len(lns) != 1 {
+			continue
+		}
+		ln := lns[0]
+
+		tpls, err := r.LabelValues(ln)
+		if err != nil {
+			return errors.Wrap(err, "get label values")
+		}
+		vals := make([]string, 0, tpls.Len())
+
+		for i := 0; i < tpls.Len(); i++ {
+			v, err := tpls.At(i)
+			if err != nil {
+				return errors.Wrap(err, "get label value")
+			}
+			vals = append(vals, v[0])
+		}
+		v.LabelValues[ln] = vals
+	}
+
+	// Extract postings ranges.
+	pranges, err := r.PostingsRanges()
+	if err != nil {
+		return errors.Wrap(err, "read postings ranges")
+	}
+	for l, rng := range pranges {
+		v.Postings = append(v.Postings, postingsRange{
+			Name:  l.Name,
+			Value: l.Value,
+			Start: rng.Start,
+			End:   rng.End,
+		})
+	}
+
+	if err := json.NewEncoder(f).Encode(&v); err != nil {
+		return errors.Wrap(err, "encode file")
+	}
+	return nil
+}
+
+// ReadIndexCache reads an index cache file.
+func ReadIndexCache(fn string) (
+	symbols map[uint32]string,
+	lvals map[string][]string,
+	postings map[labels.Label]index.Range,
+	err error,
+) {
+	f, err := os.Open(fn)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "open file")
+	}
+	defer f.Close()
+
+	var v indexCache
+	if err := json.NewDecoder(f).Decode(&v); err != nil {
+		return nil, nil, nil, errors.Wrap(err, "decode file")
+	}
+	strs := map[string]string{}
+	lvals = make(map[string][]string, len(v.LabelValues))
+	postings = make(map[labels.Label]index.Range, len(v.Postings))
+
+	// Most strings we encounter are duplicates. Dedup string objects that we keep
+	// around after the function returns.
+	// NOTE(fabxc): it could even make sense to deduplicate globally.
+	getStr := func(s string) string {
+		if cs, ok := strs[s]; ok {
+			return cs
+		}
+		strs[s] = s
+		return s
+	}
+
+	for o, s := range v.Symbols {
+		v.Symbols[o] = getStr(s)
+	}
+	for ln, vals := range v.LabelValues {
+		for i := range vals {
+			vals[i] = getStr(vals[i])
+		}
+		lvals[getStr(ln)] = vals
+	}
+	for _, e := range v.Postings {
+		l := labels.Label{
+			Name:  getStr(e.Name),
+			Value: getStr(e.Value),
+		}
+		postings[l] = index.Range{Start: e.Start, End: e.End}
+	}
+	return v.Symbols, lvals, postings, nil
+}

--- a/pkg/query/iter.go
+++ b/pkg/query/iter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
-	"github.com/prometheus/tsdb/chunks"
+	"github.com/prometheus/tsdb/chunkenc"
 )
 
 // promSeriesSet implements the SeriesSet interface of the Prometheus storage
@@ -139,7 +139,7 @@ type chunkSeriesIterator struct {
 	maxt, mint int64
 
 	i   int
-	cur chunks.Iterator
+	cur chunkenc.Iterator
 	err error
 }
 
@@ -160,7 +160,7 @@ func newChunkSeriesIterator(cs []storepb.Chunk, mint, maxt int64) storage.Series
 }
 
 func (it *chunkSeriesIterator) openChunk() bool {
-	c, err := chunks.FromData(chunks.EncXOR, it.chunks[it.i].Data)
+	c, err := chunkenc.FromData(chunkenc.EncXOR, it.chunks[it.i].Data)
 	if err != nil {
 		it.err = err
 		return false

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -10,8 +10,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/prometheus/tsdb/chunks"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -19,6 +17,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/tsdb/chunkenc"
 	"google.golang.org/grpc"
 )
 
@@ -264,7 +263,7 @@ func testStoreSeries(t testing.TB, lset labels.Labels, smpls []sample) (s storep
 	for _, l := range lset {
 		s.Labels = append(s.Labels, storepb.Label{Name: l.Name, Value: l.Value})
 	}
-	c := chunks.NewXORChunk()
+	c := chunkenc.NewXORChunk()
 	a, err := c.Appender()
 	testutil.Ok(t, err)
 

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
+	"github.com/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/tsdb/labels"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -22,7 +23,6 @@ import (
 	"github.com/improbable-eng/thanos/pkg/store/prompb"
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/tsdb/chunks"
 )
 
 // PrometheusStore implements the store node API on top of the Prometheus remote read API.
@@ -226,7 +226,8 @@ func extLabelsMatches(extLabels labels.Labels, ms []storepb.LabelMatcher) (bool,
 // encodeChunk translates the sample pairs into a chunk. It takes a minimum timestamp
 // and drops all samples before that one.
 func (p *PrometheusStore) encodeChunk(ss []prompb.Sample, mint int64) (storepb.Chunk_Encoding, []byte, error) {
-	c := chunks.NewXORChunk()
+	c := chunkenc.NewXORChunk()
+
 	a, err := c.Appender()
 	if err != nil {
 		return 0, nil, err

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/prometheus/prometheus/pkg/timestamp"
-	"github.com/prometheus/tsdb/chunks"
+	"github.com/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/tsdb/labels"
 )
 
@@ -67,7 +67,7 @@ func TestPrometheusStore_Series(t *testing.T) {
 	c := srv.series[0].Chunks[0]
 	testutil.Equals(t, storepb.Chunk_XOR, c.Type)
 
-	chk, err := chunks.FromData(chunks.EncXOR, c.Data)
+	chk, err := chunkenc.FromData(chunkenc.EncXOR, c.Data)
 	testutil.Ok(t, err)
 
 	samples := expandChunk(chk.Iterator())
@@ -79,7 +79,7 @@ type sample struct {
 	v float64
 }
 
-func expandChunk(cit chunks.Iterator) (res []sample) {
+func expandChunk(cit chunkenc.Iterator) (res []sample) {
 	for cit.Next() {
 		t, v := cit.At()
 		res = append(res, sample{t, v})

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/tsdb/chunks"
 
 	"github.com/prometheus/tsdb"
+	"github.com/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/tsdb/labels"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -101,7 +101,8 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSer
 }
 
 func (s *TSDBStore) encodeChunk(it tsdb.SeriesIterator) (*storepb.Chunk, error) {
-	chk := chunks.NewXORChunk()
+	chk := chunkenc.NewXORChunk()
+
 	app, err := chk.Appender()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
 I still need to adapt/add some tests and want to improve instrumentation. But generally the code is cleaned up now and things work fine in my manual testing. Everything still feels pretty fast.

Still without any caching at all `count(apiserver_request_count)` over 6h (5s scrape interval) returns in about 3 seconds and fetches a total of ~4700 series. For comparison, computing a rate over that bumps it to 5.4 seconds.

@Bplotka