### PR TITLE
query: cleanup unused UI endpoints, remove option struct

### DIFF
--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/prometheus/common/route"
 
 	"github.com/go-kit/kit/log"
-	"github.com/improbable-eng/thanos/pkg/query"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,11 +37,6 @@ import (
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql"
 )
-
-var sampleQueryConfig = query.Config{
-	MaxConcurrentQueries: 21,
-	QueryTimeout:         1 * time.Minute,
-}
 
 func TestEndpoints(t *testing.T) {
 	suite, err := promql.NewTest(t, `
@@ -65,7 +59,6 @@ func TestEndpoints(t *testing.T) {
 	api := &API{
 		queryable:   suite.Storage(),
 		queryEngine: suite.QueryEngine(),
-		cfg:         sampleQueryConfig,
 
 		instantQueryDuration: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		rangeQueryDuration:   prometheus.NewHistogram(prometheus.HistogramOpts{}),
@@ -375,20 +368,6 @@ func TestEndpoints(t *testing.T) {
 		{
 			endpoint: api.series,
 			errType:  errorBadData,
-		},
-		{
-			endpoint: api.dropSeries,
-			errType:  errorInternal,
-		},
-		{
-			endpoint: api.alertmanagers,
-			response: &AlertmanagerDiscovery{},
-		},
-		{
-			endpoint: api.serveConfig,
-			response: &prometheusConfig{
-				YAML: sampleQueryConfig.String(),
-			},
 		},
 	}
 

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -2,14 +2,11 @@ package query
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sort"
 	"sync"
-	"time"
 
 	"github.com/go-kit/kit/log"
-	yaml "gopkg.in/yaml.v1"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
@@ -17,33 +14,9 @@ import (
 	"github.com/improbable-eng/thanos/pkg/tracing"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"golang.org/x/sync/errgroup"
 )
-
-type Config struct {
-	QueryTimeout         time.Duration `yaml:"query_timeout"`
-	MaxConcurrentQueries int           `yaml:"max_conccurent_queries"`
-}
-
-func (c Config) EngineOpts(logger log.Logger) *promql.EngineOptions {
-	return &promql.EngineOptions{
-		Logger:               logger,
-		Timeout:              c.QueryTimeout,
-		MaxConcurrentQueries: c.MaxConcurrentQueries,
-	}
-}
-
-func (c Config) String() string {
-	b, err := yaml.Marshal(c)
-	if err != nil {
-		return fmt.Sprintf("<error creating config string: %s>", err)
-	}
-	return string(b)
-}
-
-var _ promql.Queryable = (*Queryable)(nil)
 
 // StoreInfo holds meta information about a store used by query.
 type StoreInfo interface {


### PR DESCRIPTION
Just some cleanup to align with how we are handling things elsewhere. Gets rid of some dependencies as well.