### PR TITLE
Don't reupload blocks in shipper, simplify timestamps

### DIFF
--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -14,8 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb/fileutil"
 	"github.com/prometheus/tsdb/labels"
-
-	"math"
 
 	"strings"
 
@@ -81,11 +80,7 @@ type Shipper struct {
 	dir     string
 	metrics *metrics
 	bucket  Bucket
-	match   func(os.FileInfo) bool
 	labels  func() labels.Labels
-
-	// MaxTime timestamp does not make sense for sidecar, so we need to gossip minTime only. We always have freshest data.
-	gossipMinTimeFn func(mint int64)
 }
 
 // New creates a new shipper that detects new TSDB blocks in dir and uploads them
@@ -96,7 +91,6 @@ func New(
 	dir string,
 	bucket Bucket,
 	lbls func() labels.Labels,
-	gossipMinTimeFn func(mint int64),
 ) *Shipper {
 	if logger == nil {
 		logger = log.NewNopLogger()
@@ -104,92 +98,85 @@ func New(
 	if lbls == nil {
 		lbls = func() labels.Labels { return nil }
 	}
-	if gossipMinTimeFn == nil {
-		gossipMinTimeFn = func(mint int64) {}
-	}
 	return &Shipper{
-		logger:          logger,
-		dir:             dir,
-		bucket:          bucket,
-		labels:          lbls,
-		gossipMinTimeFn: gossipMinTimeFn,
-		metrics:         newMetrics(r),
+		logger:  logger,
+		dir:     dir,
+		bucket:  bucket,
+		labels:  lbls,
+		metrics: newMetrics(r),
 	}
 }
 
-// Sync performs a single synchronization if the local block data with the remote end.
-// It is not concurrency-safe.
-func (s *Shipper) Sync(ctx context.Context) {
-	names, err := fileutil.ReadDir(s.dir)
-	if err != nil {
-		level.Warn(s.logger).Log("msg", "read dir failed", "err", err)
-	}
-
+// Timestamps returns the minimum timestamp for which data is available and the highest timestamp
+// of blocks that were successfully uploaded.
+func (s *Shipper) Timestamps() (minTime, maxSyncTime int64, err error) {
 	meta, err := ReadMetaFile(s.dir)
 	if err != nil {
-		// If we encounter any error, wipe the meta file (if existant) and proceed.
+		return 0, 0, errors.Wrap(err, "read shipper meta file")
+	}
+	// Build a map of blocks we already uploaded.
+	hasUploaded := make(map[ulid.ULID]struct{}, len(meta.Uploaded))
+	for _, id := range meta.Uploaded {
+		hasUploaded[id] = struct{}{}
+	}
+
+	minTime = math.MaxInt64
+	maxSyncTime = math.MinInt64
+
+	s.iterBlockMetas(func(m *block.Meta) error {
+		if m.MinTime < minTime {
+			minTime = m.MinTime
+		}
+		if _, ok := hasUploaded[m.ULID]; ok && m.MaxTime > maxSyncTime {
+			maxSyncTime = m.MaxTime
+		}
+		return nil
+	})
+	return minTime, maxSyncTime, nil
+}
+
+// Sync performs a single synchronization, which ensures all local blocks have been uploaded
+// to the object bucket once.
+// It is not concurrency-safe.
+func (s *Shipper) Sync(ctx context.Context) {
+	meta, err := ReadMetaFile(s.dir)
+	if err != nil {
+		// If we encounter any error, proceed with an empty meta file and overwrite it later.
 		// The meta file is only used to deduplicate uploads, which are properly handled
 		// by the system if their occur anyway.
 		if !os.IsNotExist(err) {
 			level.Warn(s.logger).Log("msg", "reading meta file failed, removing it", "err", err)
-			os.RemoveAll(filepath.Join(s.dir, MetaFilename))
 		}
 		meta = &Meta{Version: 1}
 	}
 	// Build a map of blocks we already uploaded.
 	hasUploaded := make(map[ulid.ULID]struct{}, len(meta.Uploaded))
-
 	for _, id := range meta.Uploaded {
 		hasUploaded[id] = struct{}{}
 	}
 	// Reset the uploaded slice so we can rebuild it only with blocks that still exist locally.
 	meta.Uploaded = nil
 
-	var oldestBlockMinTime int64 = math.MaxInt64
-	for _, fn := range names {
-		id, err := ulid.Parse(fn)
-		if err != nil {
-			continue
-		}
-		dir := filepath.Join(s.dir, fn)
-
-		fi, err := os.Stat(dir)
-		if err != nil {
-			level.Warn(s.logger).Log("msg", "open file failed", "err", err)
-			continue
-		}
-		if !fi.IsDir() {
-			continue
-		}
-		m, err := block.ReadMetaFile(dir)
-		if err != nil {
-			level.Warn(s.logger).Log("msg", "reading meta file failed", "err", err)
-			continue
-		}
+	s.iterBlockMetas(func(m *block.Meta) error {
 		// Do not sync a block if we already uploaded it. If it is no longer found in the bucket,
 		// it was generally removed by the compaction process.
-		if _, ok := hasUploaded[id]; !ok {
-			if err := s.sync(ctx, m, dir); err != nil {
-				level.Error(s.logger).Log("msg", "shipping failed", "dir", dir, "err", err)
-				continue
+		if _, ok := hasUploaded[m.ULID]; !ok {
+			if err := s.sync(ctx, m); err != nil {
+				level.Error(s.logger).Log("msg", "shipping failed", "block", m.ULID, "err", err)
+				return nil
 			}
 		}
-
-		if m.MinTime < oldestBlockMinTime || oldestBlockMinTime == math.MaxInt64 {
-			oldestBlockMinTime = m.MinTime
-		}
-		meta.Uploaded = append(meta.Uploaded, id)
-	}
-
-	if oldestBlockMinTime != math.MaxInt64 {
-		s.gossipMinTimeFn(oldestBlockMinTime)
-	}
+		meta.Uploaded = append(meta.Uploaded, m.ULID)
+		return nil
+	})
 	if err := WriteMetaFile(s.dir, meta); err != nil {
 		level.Warn(s.logger).Log("msg", "updating meta file failed", "err", err)
 	}
 }
 
-func (s *Shipper) sync(ctx context.Context, meta *block.Meta, dir string) (err error) {
+func (s *Shipper) sync(ctx context.Context, meta *block.Meta) (err error) {
+	dir := filepath.Join(s.dir, meta.ULID.String())
+
 	// We only ship of the first compacted block level.
 	if meta.Compaction.Level > 1 {
 		return nil
@@ -264,6 +251,40 @@ func (s *Shipper) uploadDir(ctx context.Context, id ulid.ULID, dir string) error
 			"msg", "cleanup failed; partial data may be left behind", "dir", dir, "err", err2)
 	}
 	return err
+}
+
+// iterBlockMetas calls f with the block meta for each block found in dir. It logs
+// an error and continues if it cannot access a meta.json file.
+// If f returns an error, the function returns with the same error.
+func (s *Shipper) iterBlockMetas(f func(m *block.Meta) error) error {
+	names, err := fileutil.ReadDir(s.dir)
+	if err != nil {
+		return errors.Wrap(err, "read dir")
+	}
+	for _, n := range names {
+		if _, err := ulid.Parse(n); err != nil {
+			continue
+		}
+		dir := filepath.Join(s.dir, n)
+
+		fi, err := os.Stat(dir)
+		if err != nil {
+			level.Warn(s.logger).Log("msg", "open file failed", "err", err)
+			continue
+		}
+		if !fi.IsDir() {
+			continue
+		}
+		m, err := block.ReadMetaFile(dir)
+		if err != nil {
+			level.Warn(s.logger).Log("msg", "reading meta file failed", "err", err)
+			continue
+		}
+		if err := f(m); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func hardlinkBlock(src, dst string) error {


### PR DESCRIPTION
@Bplotka 

We keep a simple local file in the data dir that we rebuild on every call to `Sync` it contains IDs of all blocks that we already uploaded and that exist locally.

I simplified the timestamp handling a bit. The gossip stuff still leaked into the shipper quite a bit. Now it's a simple function that tells us what the minimum timestamp we have is and up to which timestamp we have synced data (new but not used yet).
The connection to gossip then just happens in `main`.

I moved the test back to use actual GCS for now since I'm not quite confident enough that our in-mem and GCS implementations are equivalent (we just didn't really specify a lot of behavior).
