### PR TITLE
*: simplify Bucket interface, migrate pkgs

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/improbable-eng/thanos/pkg/compact"
-	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/improbable-eng/thanos/pkg/compact"
+	"github.com/improbable-eng/thanos/pkg/objstore"
+	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
 	"github.com/improbable-eng/thanos/pkg/query/ui"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/oklog/run"
@@ -56,7 +56,7 @@ func runCompact(
 	if err != nil {
 		return errors.Wrap(err, "create GCS client")
 	}
-	bkt := gcs.NewBucket(gcsClient.Bucket(gcsBucket), reg, gcsBucket)
+	bkt := objstore.BucketWithMetrics(gcsBucket, gcs.NewBucket(gcsClient.Bucket(gcsBucket)), reg)
 
 	sy, err := compact.NewSyncer(logger, dataDir, bkt, syncDelay)
 	if err != nil {

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -56,7 +56,9 @@ func runCompact(
 	if err != nil {
 		return errors.Wrap(err, "create GCS client")
 	}
-	bkt := objstore.BucketWithMetrics(gcsBucket, gcs.NewBucket(gcsClient.Bucket(gcsBucket)), reg)
+	var bkt objstore.Bucket
+	bkt = gcs.NewBucket(gcsBucket, gcsClient.Bucket(gcsBucket), reg)
+	bkt = objstore.BucketWithMetrics(gcsBucket, bkt, reg)
 
 	sy, err := compact.NewSyncer(logger, dataDir, bkt, syncDelay)
 	if err != nil {

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -8,11 +9,8 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"syscall"
-
-	"context"
-
 	"runtime/debug"
+	"syscall"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/alert"
 	"github.com/improbable-eng/thanos/pkg/cluster"
+	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/shipper"
@@ -349,7 +350,10 @@ func runRule(
 			return errors.Wrap(err, "create GCS client")
 		}
 
-		bkt := gcs.NewBucket(gcsClient.Bucket(gcsBucket), reg, gcsBucket)
+		var bkt objstore.Bucket
+		bkt = gcs.NewBucket(gcsBucket, gcsClient.Bucket(gcsBucket), reg)
+		bkt = objstore.BucketWithMetrics(gcsBucket, bkt, reg)
+
 		s := shipper.New(logger, nil, dataDir, bkt, func() labels.Labels { return lset })
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -19,14 +19,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/improbable-eng/thanos/pkg/runutil"
-
 	"cloud.google.com/go/storage"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/alert"
 	"github.com/improbable-eng/thanos/pkg/cluster"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
+	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/shipper"
 	"github.com/improbable-eng/thanos/pkg/store"
 	"github.com/improbable-eng/thanos/pkg/store/storepb"

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -10,12 +11,11 @@ import (
 	"sync"
 	"time"
 
-	"math"
-
 	"cloud.google.com/go/storage"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/cluster"
+	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/shipper"
@@ -203,7 +203,7 @@ func runSidecar(
 			return errors.Wrap(err, "create GCS client")
 		}
 
-		bkt := gcs.NewBucket(gcsClient.Bucket(gcsBucket), reg, gcsBucket)
+		bkt := objstore.BucketWithMetrics(gcsBucket, gcs.NewBucket(gcsClient.Bucket(gcsBucket)), reg)
 		s := shipper.New(logger, nil, dataDir, bkt, externalLabels.Get)
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -203,7 +203,10 @@ func runSidecar(
 			return errors.Wrap(err, "create GCS client")
 		}
 
-		bkt := objstore.BucketWithMetrics(gcsBucket, gcs.NewBucket(gcsClient.Bucket(gcsBucket)), reg)
+		var bkt objstore.Bucket
+		bkt = gcs.NewBucket(gcsBucket, gcsClient.Bucket(gcsBucket), reg)
+		bkt = objstore.BucketWithMetrics(gcsBucket, bkt, reg)
+
 		s := shipper.New(logger, nil, dataDir, bkt, externalLabels.Get)
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/cluster"
+	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/store"
@@ -111,9 +112,7 @@ func runStore(
 			return errors.Wrap(err, "create GCS client")
 		}
 
-		var bkt store.Bucket
-		bkt = gcs.NewBucket(gcsClient.Bucket(gcsBucket), reg, gcsBucket)
-		bkt = store.BucketWithMetrics(gcsBucket, bkt, reg)
+		bkt := objstore.BucketWithMetrics(gcsBucket, gcs.NewBucket(gcsClient.Bucket(gcsBucket)), reg)
 
 		gs, err := store.NewBucketStore(
 			logger,

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -112,7 +112,9 @@ func runStore(
 			return errors.Wrap(err, "create GCS client")
 		}
 
-		bkt := objstore.BucketWithMetrics(gcsBucket, gcs.NewBucket(gcsClient.Bucket(gcsBucket)), reg)
+		var bkt objstore.Bucket
+		bkt = gcs.NewBucket(gcsBucket, gcsClient.Bucket(gcsBucket), reg)
+		bkt = objstore.BucketWithMetrics(gcsBucket, bkt, reg)
 
 		gs, err := store.NewBucketStore(
 			logger,

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -3,7 +3,6 @@ package compact
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/prometheus/tsdb/fileutil"
 
 	"github.com/go-kit/kit/log"
@@ -23,26 +23,12 @@ import (
 	"github.com/prometheus/tsdb/labels"
 )
 
-// Bucket represents a readable bucket of data objects.
-type Bucket interface {
-	// Iter calls the given function with each found top-level object name in the bucket.
-	// It exits if the context is canceled or the function returns an error.
-	Iter(ctx context.Context, dir string, f func(name string) error) error
-
-	// Get returns a new reader against the object with the given name.
-	Get(ctx context.Context, name string) (io.ReadCloser, error)
-
-	Upload(ctx context.Context, dst, src string) error
-
-	Delete(ctx context.Context, dir string) error
-}
-
 // Syncer syncronizes block metas from a bucket into a local directory.
 // It sorts them into compaction groups based on equal label sets.
 type Syncer struct {
 	logger    log.Logger
 	dir       string
-	bkt       Bucket
+	bkt       objstore.Bucket
 	syncDelay time.Duration
 	mtx       sync.Mutex
 	groups    map[string]*Group
@@ -50,7 +36,7 @@ type Syncer struct {
 
 // NewSyncer returns a new Syncer for the given Bucket and directory.
 // Blocks must be at least as old as the sync delay for being considered.
-func NewSyncer(logger log.Logger, dir string, bkt Bucket, syncDelay time.Duration) (*Syncer, error) {
+func NewSyncer(logger log.Logger, dir string, bkt objstore.Bucket, syncDelay time.Duration) (*Syncer, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -140,9 +126,8 @@ func (c *Syncer) SyncMetas(ctx context.Context) error {
 		defer os.RemoveAll(tmpdir)
 
 		src := path.Join(name, "meta.json")
-		dst := filepath.Join(tmpdir, "meta.json")
 
-		if err := downloadBucketObject(ctx, c.bkt, dst, src); err != nil {
+		if err := objstore.DownloadFile(ctx, c.bkt, src, tmpdir); err != nil {
 			level.Warn(c.logger).Log("msg", "downloading meta.json failed", "block", id, "err", err)
 			return nil
 		}
@@ -288,8 +273,7 @@ func (c *Syncer) GarbageCollect(ctx context.Context) error {
 
 		level.Info(c.logger).Log("msg", "deleting outdated block", "block", id)
 
-		// NOTE(fabxc): yet another hack due to the fuzzy directory semantics of our Buckets.
-		err := c.bkt.Delete(delCtx, id.String()+"/")
+		err := objstore.DeleteDir(delCtx, c.bkt, id.String())
 		cancel()
 		if err != nil {
 			return errors.Wrapf(err, "delete block %s from bucket", id)
@@ -304,12 +288,12 @@ type Group struct {
 	logger log.Logger
 	mtx    sync.Mutex
 	dir    string
-	bkt    Bucket
+	bkt    objstore.Bucket
 	labels map[string]string
 }
 
 // NewGroup returns a new compaction group.
-func NewGroup(logger log.Logger, bkt Bucket, dir string, labels map[string]string) (*Group, error) {
+func NewGroup(logger log.Logger, bkt objstore.Bucket, dir string, labels map[string]string) (*Group, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -390,7 +374,7 @@ func (cg *Group) Compact(ctx context.Context, comp tsdb.Compactor) (id ulid.ULID
 		ids := filepath.Base(b)
 		dst := filepath.Join(wdir, ids)
 
-		if err := downloadBlock(ctx, cg.bkt, ids, dst); err != nil {
+		if err := objstore.DownloadDir(ctx, cg.bkt, ids, dst); err != nil {
 			return id, errors.Wrapf(err, "download block %s", ids)
 		}
 		compDirs = append(compDirs, dst)
@@ -423,7 +407,7 @@ func (cg *Group) Compact(ctx context.Context, comp tsdb.Compactor) (id ulid.ULID
 
 	begin = time.Now()
 
-	if err = uploadBlock(ctx, cg.bkt, id, bdir); err != nil {
+	if err := objstore.UploadDir(ctx, cg.bkt, bdir, id.String()); err != nil {
 		return id, errors.Wrap(err, "upload block")
 	}
 	level.Debug(cg.logger).Log("msg", "uploaded block", "block", id, "duration", time.Since(begin))
@@ -437,71 +421,6 @@ func (cg *Group) Compact(ctx context.Context, comp tsdb.Compactor) (id ulid.ULID
 		}
 	}
 	return id, nil
-}
-
-func uploadBlock(ctx context.Context, bkt Bucket, id ulid.ULID, dir string) error {
-	err := filepath.Walk(dir, func(src string, fi os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if fi.IsDir() {
-			return nil
-		}
-		target := filepath.Join(id.String(), strings.TrimPrefix(src, dir))
-		return bkt.Upload(ctx, src, target)
-	})
-	if err == nil {
-		return nil
-	}
-	// We don't want to leave partially uploaded directories behind. Cleanup everything related to it
-	// and use a uncanceled context.
-	// Use a fresh context so we always process this.
-	bkt.Delete(context.Background(), dir)
-	return err
-}
-
-func downloadBlock(ctx context.Context, bkt Bucket, id, dst string) error {
-	if err := os.MkdirAll(filepath.Join(dst, "chunks"), 0777); err != nil {
-		return err
-	}
-	objs := []string{"meta.json", "index"}
-
-	err := bkt.Iter(ctx, id+"/chunks/", func(n string) error {
-		objs = append(objs, path.Join("chunks", path.Base(n)))
-		return nil
-	})
-	if err != nil {
-		return errors.Wrap(err, "get chunk object list")
-	}
-
-	for _, o := range objs {
-		err := downloadBucketObject(ctx, bkt, filepath.Join(dst, o), path.Join(id, o))
-		if err != nil {
-			return errors.Wrap(err, "download meta.json")
-		}
-	}
-	return nil
-}
-
-func downloadBucketObject(ctx context.Context, bkt Bucket, dst, src string) error {
-	r, err := bkt.Get(ctx, src)
-	if err != nil {
-		return errors.Wrap(err, "create reader")
-	}
-	defer r.Close()
-
-	f, err := os.Create(dst)
-	if err != nil {
-		return errors.Wrap(err, "create file")
-	}
-	defer func() {
-		f.Close()
-		if err != nil {
-			os.Remove(dst)
-		}
-	}()
-	_, err = io.Copy(f, r)
-	return err
 }
 
 // iterBlocks calls f for each meta.json of block directories in dir.

--- a/pkg/objstore/gcs/gcs.go
+++ b/pkg/objstore/gcs/gcs.go
@@ -4,52 +4,36 @@ package gcs
 import (
 	"context"
 	"io"
-
-	"os"
+	"strings"
 
 	"cloud.google.com/go/storage"
-	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/api/iterator"
 )
 
-const (
-	// Class A operations.
-	opObjectsList  = "objects.list"
-	opObjectInsert = "object.insert"
-
-	// Class B operation.
-	opObjectGet = "object.get"
-)
+// DirDelim is the delimiter used to model a directory structure in an object store bucket.
+const DirDelim = "/"
 
 // Bucket implements the store.Bucket and shipper.Bucket interfaces against GCS.
 type Bucket struct {
 	bkt *storage.BucketHandle
-
-	opsTotal *prometheus.CounterVec
 }
 
 // NewBucket returns a new Bucket against the given bucket handle.
-func NewBucket(b *storage.BucketHandle, r prometheus.Registerer, bucketName string) *Bucket {
-	bkt := &Bucket{bkt: b}
-	bkt.opsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name:        "thanos_objstore_gcs_bucket_operations_total",
-		Help:        "Total number of operations that were executed against a Google Compute Storage bucket.",
-		ConstLabels: prometheus.Labels{"bucket": bucketName},
-	}, []string{"operation"})
-
-	if r != nil {
-		r.MustRegister(bkt.opsTotal)
-	}
-	return bkt
+func NewBucket(b *storage.BucketHandle) *Bucket {
+	return &Bucket{bkt: b}
 }
 
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error) error {
-	b.opsTotal.WithLabelValues(opObjectsList).Inc()
+	// Ensure the object name actually ends with a dir suffix. Otherwise we'll just iterate the
+	// object itself as one prefix item.
+	if dir != "" {
+		dir = strings.TrimSuffix(dir, DirDelim) + DirDelim
+	}
 	it := b.bkt.Objects(ctx, &storage.Query{
 		Prefix:    dir,
-		Delimiter: "/",
+		Delimiter: DirDelim,
 	})
 	for {
 		select {
@@ -72,13 +56,11 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error) err
 
 // Get returns a reader for the given object name.
 func (b *Bucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
-	b.opsTotal.WithLabelValues(opObjectGet).Inc()
 	return b.bkt.Object(name).NewReader(ctx)
 }
 
 // GetRange returns a new range reader for the given object name and range.
 func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
-	b.opsTotal.WithLabelValues(opObjectGet).Inc()
 	return b.bkt.Object(name).NewRangeReader(ctx, off, length)
 }
 
@@ -88,72 +70,27 @@ func (b *Bucket) Handle() *storage.BucketHandle {
 	return b.bkt
 }
 
-// Exists checks if the given directory exists at the remote site (and contains at least one element).
-func (b *Bucket) Exists(ctx context.Context, dir string) (bool, error) {
-	b.opsTotal.WithLabelValues(opObjectsList).Inc()
-	objs := b.bkt.Objects(ctx, &storage.Query{
-		Delimiter: "/",
-		Prefix:    dir,
-	})
-	for {
-		_, err := objs.Next()
-		if err == iterator.Done {
-			return false, nil
-		}
-
-		if err != nil {
-			return false, err
-		}
-
-		// The first object found with the given filter indicates that the directory exists.
+// Exists checks if the given object exists.
+func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
+	if _, err := b.bkt.Object(name).Attrs(ctx); err == nil {
 		return true, nil
+	} else if err != storage.ErrObjectNotExist {
+		return false, err
 	}
+	return false, nil
 }
 
 // Upload writes the file specified in src to remote GCS location specified as target.
-func (b *Bucket) Upload(ctx context.Context, src, target string) error {
-	f, err := os.Open(src)
-	if err != nil {
-		return err
-	}
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	w := b.bkt.Object(name).NewWriter(ctx)
 
-	b.opsTotal.WithLabelValues(opObjectInsert).Inc()
-	w := b.bkt.Object(target).NewWriter(ctx)
-
-	_, err = io.Copy(w, f)
-	if err != nil {
+	if _, err := io.Copy(w, r); err != nil {
 		return err
 	}
 	return w.Close()
 }
 
-// Delete removes all data prefixed with the dir.
-// NOTE: object.Delete operation is free so no worth to increment gcs operations metric.
-func (b *Bucket) Delete(ctx context.Context, dir string) error {
-	b.opsTotal.WithLabelValues(opObjectsList).Inc()
-	objs := b.bkt.Objects(ctx, &storage.Query{
-		Delimiter: "/",
-		Prefix:    dir,
-	})
-	for {
-		oa, err := objs.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		// If the prefix is set, we hit another directory and delete recursively.
-		if oa.Prefix != "" {
-			if err := b.Delete(ctx, oa.Prefix); err != nil {
-				return err
-			}
-			continue
-		}
-		// Otherwise it's an object we can delete directly.
-		if err := b.bkt.Object(oa.Name).Delete(ctx); err != nil {
-			return err
-		}
-	}
-	return nil
+// Delete removes the object with the given name.
+func (b *Bucket) Delete(ctx context.Context, name string) error {
+	return b.bkt.Object(name).Delete(ctx)
 }

--- a/pkg/objstore/gcs/gcs.go
+++ b/pkg/objstore/gcs/gcs.go
@@ -7,7 +7,20 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/api/iterator"
+)
+
+const (
+	// Class A operations.
+	opObjectsList  = "objects.list"
+	opObjectInsert = "object.insert"
+
+	// Class B operation.
+	opObjectGet = "object.get"
+
+	// Free operations.
+	opObjectDelete = "object.delete"
 )
 
 // DirDelim is the delimiter used to model a directory structure in an object store bucket.
@@ -15,17 +28,30 @@ const DirDelim = "/"
 
 // Bucket implements the store.Bucket and shipper.Bucket interfaces against GCS.
 type Bucket struct {
-	bkt *storage.BucketHandle
+	bkt      *storage.BucketHandle
+	opsTotal *prometheus.CounterVec
 }
 
 // NewBucket returns a new Bucket against the given bucket handle.
-func NewBucket(b *storage.BucketHandle) *Bucket {
-	return &Bucket{bkt: b}
+func NewBucket(name string, b *storage.BucketHandle, reg prometheus.Registerer) *Bucket {
+	bkt := &Bucket{
+		bkt: b,
+		opsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name:        "thanos_objstore_gcs_bucket_operations_total",
+			Help:        "Total number of operations that were executed against a Google Compute Storage bucket.",
+			ConstLabels: prometheus.Labels{"bucket": name},
+		}, []string{"operation"}),
+	}
+	if reg != nil {
+		reg.MustRegister()
+	}
+	return bkt
 }
 
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error) error {
+	b.opsTotal.WithLabelValues(opObjectsList).Inc()
 	// Ensure the object name actually ends with a dir suffix. Otherwise we'll just iterate the
 	// object itself as one prefix item.
 	if dir != "" {
@@ -56,11 +82,13 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error) err
 
 // Get returns a reader for the given object name.
 func (b *Bucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	b.opsTotal.WithLabelValues(opObjectGet).Inc()
 	return b.bkt.Object(name).NewReader(ctx)
 }
 
 // GetRange returns a new range reader for the given object name and range.
 func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	b.opsTotal.WithLabelValues(opObjectGet).Inc()
 	return b.bkt.Object(name).NewRangeReader(ctx, off, length)
 }
 
@@ -72,6 +100,8 @@ func (b *Bucket) Handle() *storage.BucketHandle {
 
 // Exists checks if the given object exists.
 func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
+	b.opsTotal.WithLabelValues(opObjectGet).Inc()
+
 	if _, err := b.bkt.Object(name).Attrs(ctx); err == nil {
 		return true, nil
 	} else if err != storage.ErrObjectNotExist {
@@ -82,6 +112,8 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 
 // Upload writes the file specified in src to remote GCS location specified as target.
 func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	b.opsTotal.WithLabelValues(opObjectInsert).Inc()
+
 	w := b.bkt.Object(name).NewWriter(ctx)
 
 	if _, err := io.Copy(w, r); err != nil {
@@ -92,5 +124,7 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
 
 // Delete removes the object with the given name.
 func (b *Bucket) Delete(ctx context.Context, name string) error {
+	b.opsTotal.WithLabelValues(opObjectDelete).Inc()
+
 	return b.bkt.Object(name).Delete(ctx)
 }

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -1,0 +1,258 @@
+package objstore
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Bucket provides read and write access to an object storage bucket.
+type Bucket interface {
+	BucketReader
+
+	// Upload writes the file specified in src to remote GCS location specified as target.
+	Upload(ctx context.Context, name string, r io.Reader) error
+
+	// Delete removes the object with the given names.
+	Delete(ctx context.Context, name string) error
+}
+
+// BucketReader provides read access to an object storage bucket.
+type BucketReader interface {
+	// Iter calls f for each entry in the given directory. The argument to f is the full
+	// object name including the prefix of the inspected directory.
+	Iter(ctx context.Context, dir string, f func(string) error) error
+
+	// Get returns a reader for the given object name.
+	Get(ctx context.Context, name string) (io.ReadCloser, error)
+
+	// GetRange returns a new range reader for the given object name and range.
+	GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error)
+
+	// Exists checks if the given object exists in the bucket.
+	Exists(ctx context.Context, name string) (bool, error)
+}
+
+// UploadDir uploads all files in srcdir to the bucket with into a top-level directory
+// named dstdir.
+func UploadDir(ctx context.Context, bkt Bucket, srcdir, dstdir string) error {
+	df, err := os.Stat(srcdir)
+	if err != nil {
+		return errors.Wrap(err, "stat dir")
+	}
+	if !df.IsDir() {
+		return errors.Errorf("%s is not a directory", srcdir)
+	}
+	return filepath.Walk(srcdir, func(src string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return nil
+		}
+		dst := filepath.Join(dstdir, strings.TrimPrefix(src, srcdir))
+
+		return UploadFile(ctx, bkt, src, dst)
+	})
+}
+
+// UploadFile uploads the file with the given name to the bucket.
+func UploadFile(ctx context.Context, bkt Bucket, src, dst string) error {
+	r, err := os.Open(src)
+	if err != nil {
+		return errors.Wrapf(err, "open file %s", src)
+	}
+	defer r.Close()
+
+	if err := bkt.Upload(ctx, dst, r); err != nil {
+		return errors.Wrapf(err, "upload file %s as %s", src, dst)
+	}
+	return nil
+}
+
+// DirDelim is the delimiter used to model a directory structure in an object store bucket.
+const DirDelim = "/"
+
+// DeleteDir removes all objects prefixed with dir from the bucket.
+func DeleteDir(ctx context.Context, bkt Bucket, dir string) error {
+	bkt.Iter(ctx, dir, func(name string) error {
+		// If we hit a directory, call DeleteDir recursively.
+		if strings.HasSuffix(name, DirDelim) {
+			return DeleteDir(ctx, bkt, name)
+		}
+		return bkt.Delete(ctx, name)
+	})
+	return nil
+}
+
+// DownloadFile downloads the src file from the bucket to dst. If dst is an existing
+// directory, a file with the same name as the source is created in dst.
+func DownloadFile(ctx context.Context, bkt BucketReader, src, dst string) error {
+	if fi, err := os.Stat(dst); err == nil {
+		if fi.IsDir() {
+			dst = filepath.Join(dst, filepath.Base(src))
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	rc, err := bkt.Get(ctx, src)
+	if err != nil {
+		return errors.Wrap(err, "get file")
+	}
+	defer rc.Close()
+
+	f, err := os.Create(dst)
+	if err != nil {
+		return errors.Wrap(err, "create file")
+	}
+	defer func() {
+		f.Close()
+		// Best-effort cleanup.
+		if err != nil {
+			os.Remove(dst)
+		}
+	}()
+	if _, err = io.Copy(f, rc); err != nil {
+		return errors.Wrap(err, "copy object to file")
+	}
+	return nil
+}
+
+// DownloadDir downloads all object found in the directory into the local directory.
+func DownloadDir(ctx context.Context, bkt BucketReader, src, dst string) error {
+	if err := os.MkdirAll(dst, 0777); err != nil {
+		return errors.Wrap(err, "create dir")
+	}
+	err := bkt.Iter(ctx, src, func(name string) error {
+		if strings.HasSuffix(name, DirDelim) {
+			return DownloadDir(ctx, bkt, name, filepath.Join(dst, filepath.Base(name)))
+		}
+		return DownloadFile(ctx, bkt, name, dst)
+	})
+	// Best-effort cleanup if the download failed.
+	if err != nil {
+		os.RemoveAll(dst)
+	}
+	return err
+}
+
+// BucketWithMetrics takes a bucket and registers metrics with the given registry for
+// operations run against the bucket.
+func BucketWithMetrics(name string, b Bucket, r prometheus.Registerer) Bucket {
+	bkt := &metricBucket{
+		bkt: b,
+
+		ops: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name:        "thanos_objstore_bucket_operations_total",
+			Help:        "Total number of operations against a bucket.",
+			ConstLabels: prometheus.Labels{"bucket": name},
+		}, []string{"operation"}),
+
+		opsFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name:        "thanos_objstore_bucket_operation_failures_total",
+			Help:        "Total number of operations against a bucket that failed.",
+			ConstLabels: prometheus.Labels{"bucket": name},
+		}, []string{"operation"}),
+
+		opsDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:        "thanos_objstore_bucket_operation_duration_seconds",
+			Help:        "Duration of operations against the bucket",
+			ConstLabels: prometheus.Labels{"bucket": name},
+			Buckets:     []float64{0.005, 0.01, 0.02, 0.04, 0.08, 0.15, 0.3, 0.6, 1, 1.5, 2.5, 5, 10, 20, 30},
+		}, []string{"operation"}),
+	}
+	if r != nil {
+		r.MustRegister(bkt.ops, bkt.opsFailures, bkt.opsDuration)
+	}
+	return bkt
+}
+
+type metricBucket struct {
+	bkt Bucket
+
+	ops         *prometheus.CounterVec
+	opsFailures *prometheus.CounterVec
+	opsDuration *prometheus.HistogramVec
+}
+
+func (b *metricBucket) Iter(ctx context.Context, dir string, f func(name string) error) error {
+	err := b.bkt.Iter(ctx, dir, f)
+	if err != nil {
+		b.opsFailures.WithLabelValues("iter").Inc()
+	}
+	b.ops.WithLabelValues("iter").Inc()
+
+	return err
+}
+
+func (b *metricBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	start := time.Now()
+
+	rc, err := b.bkt.Get(ctx, name)
+	if err != nil {
+		b.opsFailures.WithLabelValues("upload").Inc()
+	}
+	b.ops.WithLabelValues("upload").Inc()
+	b.opsDuration.WithLabelValues("upload").Observe(time.Since(start).Seconds())
+
+	return rc, err
+}
+
+func (b *metricBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	start := time.Now()
+
+	rc, err := b.bkt.GetRange(ctx, name, off, length)
+	if err != nil {
+		b.opsFailures.WithLabelValues("upload").Inc()
+	}
+	b.ops.WithLabelValues("upload").Inc()
+	b.opsDuration.WithLabelValues("upload").Observe(time.Since(start).Seconds())
+
+	return rc, err
+}
+
+func (b *metricBucket) Exists(ctx context.Context, name string) (bool, error) {
+	start := time.Now()
+
+	ok, err := b.bkt.Exists(ctx, name)
+	if err != nil {
+		b.opsFailures.WithLabelValues("exists").Inc()
+	}
+	b.ops.WithLabelValues("exists").Inc()
+	b.opsDuration.WithLabelValues("exists").Observe(time.Since(start).Seconds())
+
+	return ok, err
+}
+
+func (b *metricBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	start := time.Now()
+
+	err := b.bkt.Upload(ctx, name, r)
+	if err != nil {
+		b.opsFailures.WithLabelValues("upload").Inc()
+	}
+	b.ops.WithLabelValues("upload").Inc()
+	b.opsDuration.WithLabelValues("upload").Observe(time.Since(start).Seconds())
+
+	return err
+}
+
+func (b *metricBucket) Delete(ctx context.Context, name string) error {
+	start := time.Now()
+
+	err := b.bkt.Delete(ctx, name)
+	if err != nil {
+		b.opsFailures.WithLabelValues("delete").Inc()
+	}
+	b.ops.WithLabelValues("delete").Inc()
+	b.opsDuration.WithLabelValues("delete").Observe(time.Since(start).Seconds())
+
+	return err
+}

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -16,10 +16,10 @@ import (
 type Bucket interface {
 	BucketReader
 
-	// Upload writes the file specified in src to remote GCS location specified as target.
+	// Upload the contents of the reader as an object into the bucket.
 	Upload(ctx context.Context, name string, r io.Reader) error
 
-	// Delete removes the object with the given names.
+	// Delete removes the object with the given name.
 	Delete(ctx context.Context, name string) error
 }
 

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -7,9 +7,12 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/improbable-eng/thanos/pkg/objstore"
 
 	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/testutil"
@@ -96,7 +99,7 @@ func TestShipper_UploadBlocks(t *testing.T) {
 			expFiles[id.String()+"/chunks/0001"] = []byte("chunkcontents1")
 			expFiles[id.String()+"/chunks/0002"] = []byte("chunkcontents2")
 		} else {
-			testutil.Ok(t, bucket.Delete(ctx, ids[4].String()))
+			testutil.Ok(t, objstore.DeleteDir(ctx, bucket, ids[4].String()))
 		}
 		// The shipper meta file should show all blocks as uploaded.
 		shipMeta, err := ReadMetaFile(dir)
@@ -111,7 +114,7 @@ func TestShipper_UploadBlocks(t *testing.T) {
 	}
 
 	for id := range expBlocks {
-		ok, _ := bucket.Exists(nil, id.String())
+		ok, _ := bucket.Exists(nil, path.Join(id.String(), "meta.json"))
 		testutil.Assert(t, ok, "block %s was not uploaded", id)
 	}
 	for fn, exp := range expFiles {

--- a/pkg/testutil/objstore.go
+++ b/pkg/testutil/objstore.go
@@ -39,7 +39,7 @@ func NewObjectStoreBucket(t testing.TB) (*gcs.Bucket, func()) {
 	bkt := gcsClient.Bucket(name)
 	Ok(t, bkt.Create(ctx, project, nil))
 
-	return gcs.NewBucket(bkt, nil, name), func() {
+	return gcs.NewBucket(bkt), func() {
 		deleteAllBucket(t, ctx, bkt)
 		cancel()
 		gcsClient.Close()

--- a/pkg/testutil/objstore.go
+++ b/pkg/testutil/objstore.go
@@ -39,7 +39,7 @@ func NewObjectStoreBucket(t testing.TB) (*gcs.Bucket, func()) {
 	bkt := gcsClient.Bucket(name)
 	Ok(t, bkt.Create(ctx, project, nil))
 
-	return gcs.NewBucket(bkt), func() {
+	return gcs.NewBucket(name, bkt, nil), func() {
 		deleteAllBucket(t, ctx, bkt)
 		cancel()
 		gcsClient.Close()


### PR DESCRIPTION
The bucket interface is simplified to the most granular operations. Everything else is handled via helpers in the objstore package. I also concolidated other packages' interface definitions to a single on there.

Since our bucket operations are now so precise, I figured it makes sense again to have an abstract metric wrapper. The actual operations should be a pretty straightforward 1:1 mapping for any object storage backend. Having a single metric makes it easier to share alerting rules and debugging advice etc.