### PR TITLE
Fix for gRPC max message size (without just increasing it)

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -417,24 +417,40 @@ type seriesEntry struct {
 type bucketSeriesSet struct {
 	set  []seriesEntry
 	i    int
+	chkI int
 	chks []storepb.Chunk
 }
 
 func newBucketSeriesSet(set []seriesEntry) *bucketSeriesSet {
 	return &bucketSeriesSet{
-		set: set,
-		i:   -1,
+		set:  set,
+		i:    -1,
+		chkI: 0,
 	}
 }
 
 func (s *bucketSeriesSet) Next() bool {
-	if s.i >= len(s.set)-1 {
+	const grpcMaxMsgSize = 4 * 1024 * 1024
+
+	if s.i >= len(s.set)-1 && s.chkI == 0 {
 		return false
 	}
-	s.i++
-	s.chks = make([]storepb.Chunk, 0, len(s.set[s.i].chks))
 
-	for _, c := range s.set[s.i].chks {
+	if s.chkI > 0 {
+		s.i++
+	}
+
+	s.chks = make([]storepb.Chunk, 0, len(s.set[s.i].chks[s.chkI:len(s.set[s.i].chks)-1]))
+
+	var bytesCount int
+	for i, c := range s.set[s.i].chks[s.chkI : len(s.set[s.i].chks)-1] {
+		bytesCount += len(c.Chunk.Bytes())
+
+		if bytesCount >= grpcMaxMsgSize {
+			s.chkI += i
+			return true
+		}
+
 		s.chks = append(s.chks, storepb.Chunk{
 			MinTime: c.MinTime,
 			MaxTime: c.MaxTime,
@@ -442,6 +458,8 @@ func (s *bucketSeriesSet) Next() bool {
 			Data:    c.Chunk.Bytes(),
 		})
 	}
+
+	s.chkI = 0
 	return true
 }
 
@@ -451,12 +469,6 @@ func (s *bucketSeriesSet) At() ([]storepb.Label, []storepb.Chunk) {
 
 func (s *bucketSeriesSet) Err() error {
 	return nil
-}
-
-func measureTime(f func() error) (time.Duration, error) {
-	s := time.Now()
-	err := f()
-	return time.Since(s), err
 }
 
 func (s *BucketStore) blockSeries(
@@ -655,7 +667,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		begin := time.Now()
 		var resp storepb.SeriesResponse
 
-		// Merge series set into an union of all block sets. This exposes all blocks are single seriesSet.
+		// Merge series set into an union of all block sets. This exposes all blocks as single seriesSet.
 		// Returned set is can be out of order in terms of series time ranges. It is fixed later on, inside querier.
 		set := storepb.MergeSeriesSets(res...)
 		for set.Next() {


### PR DESCRIPTION
So this is an attempt and showcase how we could go around gRPC max message size (basically just huge TCP messages problem) and discuss how to solve it (https://github.com/improbable-eng/thanos/issues/134) Potential solutions:
A) Split the chunks within series to send smaller messages (this PR)
B) Just increase the gRPC message size limit
C) Downsampling?
D) Block these queries when data is not yet downsampled

I think that with the heavier blocks we will hit the issue always - maybe not if we just turn off the gRPC message size limit - but then we will most likely hit huge latency because of huge messages and timeouts.

Obviously this PR is not completed -> we need querier part that will merge chunks with same label (maybe our current merge will handle that gracefully, but probably not).

What do you think?

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>