### PR TITLE
store,cluster: handle timestamps properly

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -133,6 +133,6 @@ func runCompact(
 		})
 	}
 
-	level.Info(logger).Log("msg", "starting query node")
+	level.Info(logger).Log("msg", "starting compact node")
 	return nil
 }

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -144,6 +144,7 @@ func main() {
 		level.Error(logger).Log("msg", "running command failed", "err", err)
 		os.Exit(1)
 	}
+	level.Info(logger).Log("exiting")
 }
 
 func interrupt(cancel <-chan struct{}) error {

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -133,6 +133,6 @@ func runQuery(
 		})
 	}
 
-	level.Info(logger).Log("msg", "starting query node")
+	level.Info(logger).Log("msg", "starting query node", "peer", peer.Name())
 	return nil
 }

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -83,7 +83,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 			*dataDir,
 			*grpcAddr,
 			*httpAddr,
-			p.SetTimestamps,
+			p,
 			uint64(*indexCacheSize),
 			uint64(*chunkPoolSize),
 		)
@@ -102,7 +102,7 @@ func runStore(
 	dataDir string,
 	grpcAddr string,
 	httpAddr string,
-	gossipTimestampsFn func(mint int64, maxt int64),
+	peer *cluster.Peer,
 	indexCacheSizeBytes uint64,
 	chunkPoolSizeBytes uint64,
 ) error {
@@ -120,7 +120,6 @@ func runStore(
 			logger,
 			reg,
 			bkt,
-			gossipTimestampsFn,
 			dataDir,
 			indexCacheSizeBytes,
 			chunkPoolSizeBytes,
@@ -135,6 +134,7 @@ func runStore(
 				if err := gs.SyncBlocks(ctx); err != nil {
 					level.Warn(logger).Log("msg", "syncing blocks failed", "err", err)
 				}
+				peer.SetTimestamps(gs.TimeRange())
 				return nil
 			})
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -233,7 +233,6 @@ func (p *Peer) SetTimestamps(mint int64, maxt int64) {
 	s.Metadata.MinTime = mint
 	s.Metadata.MaxTime = maxt
 	p.data[p.Name()] = s
-
 }
 
 // Leave the cluster, waiting up to timeout.

--- a/pkg/cluster/stores.go
+++ b/pkg/cluster/stores.go
@@ -104,6 +104,12 @@ func (s *StoreSet) Update(ctx context.Context) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
+	for k, conn := range s.conns {
+		if _, ok := conns[k]; !ok {
+			conn.Close()
+		}
+	}
+
 	s.stores = stores
 	s.conns = conns
 

--- a/pkg/cluster/stores.go
+++ b/pkg/cluster/stores.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 
-	"time"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
@@ -21,155 +19,100 @@ import (
 
 // StoreSet maintains a set of active stores. It is backed by a peer's view of the cluster.
 type StoreSet struct {
-	logger      log.Logger
-	peer        *Peer
-	mtx         sync.RWMutex
-	stores      map[string]*storeInfo
-	grpcMetrics *grpc_prometheus.ClientMetrics
+	logger   log.Logger
+	peer     *Peer
+	dialOpts []grpc.DialOption
+	mtx      sync.RWMutex
+	conns    map[string]*grpc.ClientConn
+	stores   []*query.StoreInfo
 
-	storeNodeConnections  prometheus.Gauge
-	storeNodeDialDuration prometheus.Histogram
-	storeNodeFailedDials  prometheus.Counter
-
-	tracer opentracing.Tracer
+	storeNodeConnections prometheus.Gauge
 }
 
 // NewStoreSet returns a new store backed by the peers view of the cluster.
 func NewStoreSet(logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, peer *Peer) *StoreSet {
-	met := grpc_prometheus.NewClientMetrics()
-
-	met.EnableClientHandlingTimeHistogram(
-		grpc_prometheus.WithHistogramBuckets([]float64{
-			0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4,
-		}),
-	)
-	reg.MustRegister(met)
-
 	storeNodeConnections := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_store_nodes_grpc_connections",
 		Help: "Number indicating current number of gRPC connection to store nodes. This indicates also to how many stores query node have access to.",
 	})
-	storeNodeDialDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name: "thanost_store_node_grpc_dial_seconds",
-		Help: "Histogram of block gRPC dialing latency (seconds) until connection is maintained.",
-	})
-	storeNodeFailedDials := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "thanost_store_node_grpc_dial_failures_total",
-		Help: "Number of failed gRPC dials targeting store node.",
-	})
-	reg.MustRegister(storeNodeConnections)
-	reg.MustRegister(storeNodeDialDuration)
-	reg.MustRegister(storeNodeFailedDials)
+	grpcMets := grpc_prometheus.NewClientMetrics()
 
+	grpcMets.EnableClientHandlingTimeHistogram(
+		grpc_prometheus.WithHistogramBuckets([]float64{
+			0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4,
+		}),
+	)
+	dialOpts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(
+			grpc_middleware.ChainUnaryClient(
+				grpcMets.UnaryClientInterceptor(),
+				tracing.UnaryClientInterceptor(tracer),
+			),
+		),
+		grpc.WithStreamInterceptor(
+			grpc_middleware.ChainStreamClient(
+				grpcMets.StreamClientInterceptor(),
+				tracing.StreamClientInterceptor(tracer),
+			),
+		),
+	}
+
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+	if reg != nil {
+		reg.MustRegister(grpcMets, storeNodeConnections)
+	}
 	return &StoreSet{
-		logger:                logger,
-		peer:                  peer,
-		stores:                map[string]*storeInfo{},
-		grpcMetrics:           met,
-		storeNodeConnections:  storeNodeConnections,
-		storeNodeDialDuration: storeNodeDialDuration,
-		storeNodeFailedDials:  storeNodeFailedDials,
-		tracer:                tracer,
+		logger:               logger,
+		peer:                 peer,
+		dialOpts:             dialOpts,
+		conns:                map[string]*grpc.ClientConn{},
+		storeNodeConnections: storeNodeConnections,
 	}
 }
 
 // Update the store set to the new set of addresses and labels for that addresses.
 // New background processes initiated respect the lifecycle of the given context.
 func (s *StoreSet) Update(ctx context.Context) {
-	// XXX(fabxc): The store as is barely ties into the cluster. This is the only place where
-	// we depend on it. However, in the future this may change when we fetch additional information
-	// about storePeers or make the set self-updating through events rather than explicit calls to Update.
-	storePeers := map[string]PeerState{}
+	var err error
+
+	stores := make([]*query.StoreInfo, 0, len(s.conns))
+	conns := make(map[string]*grpc.ClientConn, len(s.conns))
+
 	for _, ps := range s.peer.PeerStates(PeerTypesStoreAPIs()...) {
-		storePeers[ps.APIAddr] = ps
+		conn, ok := s.conns[ps.APIAddr]
+		if !ok {
+			conn, err = grpc.DialContext(ctx, ps.APIAddr, s.dialOpts...)
+			if err != nil {
+				level.Warn(s.logger).Log("msg", "dialing connection failed; skipping",
+					"store", ps.APIAddr, "err", err)
+				continue
+			}
+		}
+		stores = append(stores, &query.StoreInfo{
+			Addr:    ps.APIAddr,
+			Client:  storepb.NewStoreClient(conn),
+			Labels:  ps.Metadata.Labels,
+			MinTime: ps.Metadata.MinTime,
+			MaxTime: ps.Metadata.MaxTime,
+		})
+		conns[ps.APIAddr] = conn
 	}
 
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	// For each new store peer we create a new gRPC connection.
-	// In every case we also updates the labels from peer state.
-	for addr, state := range storePeers {
-		if _, ok := s.stores[addr]; !ok {
-			level.Debug(s.logger).Log("msg", "grpc dialing", "store", addr)
-
-			startTime := time.Now()
-			conn, err := grpc.DialContext(ctx, addr,
-				grpc.WithInsecure(),
-				grpc.WithUnaryInterceptor(
-					grpc_middleware.ChainUnaryClient(
-						s.grpcMetrics.UnaryClientInterceptor(),
-						tracing.UnaryClientInterceptor(s.tracer),
-					),
-				),
-				grpc.WithStreamInterceptor(
-					grpc_middleware.ChainStreamClient(
-						s.grpcMetrics.StreamClientInterceptor(),
-						tracing.StreamClientInterceptor(s.tracer),
-					),
-				),
-			)
-			if err != nil {
-				s.storeNodeFailedDials.Inc()
-				level.Warn(s.logger).Log("msg", "dialing connection failed; skipping", "store", addr, "err", err)
-				continue
-			}
-
-			s.storeNodeDialDuration.Observe(time.Since(startTime).Seconds())
-			level.Debug(s.logger).Log("msg", "successfully made grpc connection", "store", addr)
-
-			store := &storeInfo{conn: conn}
-			s.stores[addr] = store
-		}
-
-		// Always fetch up-to-date labels propagated in peer state.
-		s.stores[addr].setLabels(state.Metadata.Labels)
-	}
-
-	// Delete stores that no longer exist.
-	for addr, store := range s.stores {
-		if _, ok := storePeers[addr]; !ok {
-			store.conn.Close()
-			level.Info(s.logger).Log("msg", "closing connection for store")
-			delete(s.stores, addr)
-		}
-	}
+	s.stores = stores
+	s.conns = conns
 
 	s.storeNodeConnections.Set(float64(len(s.stores)))
 }
 
 // Get returns a list of all active stores.
-func (s *StoreSet) Get() []query.StoreInfo {
+func (s *StoreSet) Get() []*query.StoreInfo {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
-
-	var res []query.StoreInfo
-	for _, store := range s.stores {
-		res = append(res, store)
-	}
-	return res
-}
-
-type storeInfo struct {
-	conn   *grpc.ClientConn
-	mtx    sync.RWMutex
-	labels []storepb.Label
-}
-
-var _ query.StoreInfo = (*storeInfo)(nil)
-
-func (s *storeInfo) Client() storepb.StoreClient {
-	return storepb.NewStoreClient(s.conn)
-}
-
-func (s *storeInfo) Labels() []storepb.Label {
-	s.mtx.RLock()
-	defer s.mtx.RUnlock()
-	return s.labels
-}
-
-func (s *storeInfo) setLabels(lset []storepb.Label) {
-	s.mtx.Lock()
-	defer s.mtx.Unlock()
-	s.labels = lset
+	return s.stores
 }

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sort"
 	"sync"
@@ -149,7 +148,7 @@ func newQuerier(
 	}
 }
 
-// matchStore returns true iff the given store may hold data for the given label matchers.
+// matchStore returns true if the given store may hold data for the given label matchers.
 func storeMatches(s *StoreInfo, mint, maxt int64, matchers ...*labels.Matcher) bool {
 	if mint > s.MaxTime || maxt < s.MinTime {
 		return false
@@ -185,14 +184,12 @@ func (q *querier) Select(ms ...*labels.Matcher) (storage.SeriesSet, error) {
 		return nil, errors.Wrap(err, "convert matchers")
 	}
 	for _, s := range q.stores {
-		fmt.Println("probe store", s.Addr, "storeRange", s.MinTime, s.MaxTime, "qrange", q.mint, q.maxt)
 		// We might be able to skip the store if its meta information indicates
 		// it cannot have series matching our query.
 		if !storeMatches(s, q.mint, q.maxt, ms...) {
 			continue
 		}
 		store := s
-		fmt.Println("querying store", s.Addr)
 
 		g.Go(func() error {
 			set, err := q.selectSingle(ctx, store.Client, opts.deduplicate, sms...)

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -80,11 +80,7 @@ func TestBucketStore_e2e(t *testing.T) {
 		testutil.Ok(t, os.RemoveAll(dir2))
 	}
 
-	var gossipMinTime, gossipMaxTime int64
-	store, err := NewBucketStore(nil, nil, bkt, func(mint int64, maxt int64) {
-		gossipMinTime = mint
-		gossipMaxTime = maxt
-	}, dir, 100, 0)
+	store, err := NewBucketStore(nil, nil, bkt, dir, 100, 0)
 	testutil.Ok(t, err)
 
 	go func() {
@@ -103,8 +99,9 @@ func TestBucketStore_e2e(t *testing.T) {
 	})
 	testutil.Ok(t, err)
 
-	testutil.Equals(t, minTime, gossipMinTime)
-	testutil.Equals(t, maxTime, gossipMaxTime)
+	mint, maxt := store.TimeRange()
+	testutil.Equals(t, minTime, mint)
+	testutil.Equals(t, maxTime, maxt)
 
 	vals, err := store.LabelValues(ctx, &storepb.LabelValuesRequest{Label: "a"})
 	testutil.Ok(t, err)

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -47,7 +47,7 @@ groups:
 	})
 	defer closeFn()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	expMetrics := []model.Metric{
@@ -78,7 +78,7 @@ groups:
 			"replica":   "2",
 		},
 	}
-	err = runutil.Retry(time.Second, ctx.Done(), func() error {
+	err = runutil.Retry(5*time.Second, ctx.Done(), func() error {
 		qtime := time.Now()
 
 		// The time series written for the firing alerting rule must be queryable.

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"syscall"
 	"testing"
+	"time"
 )
 
 type config struct {
@@ -58,6 +59,7 @@ func spinup(t testing.TB, cfg config) (close func()) {
 			"--cluster.peers", "127.0.0.1:19591",
 			"--log.level", "debug",
 		))
+		time.Sleep(200 * time.Millisecond)
 	}
 
 	for i := 1; i <= cfg.numQueries; i++ {
@@ -70,6 +72,7 @@ func spinup(t testing.TB, cfg config) (close func()) {
 			"--cluster.peers", "127.0.0.1:19591",
 			"--log.level", "debug",
 		))
+		time.Sleep(200 * time.Millisecond)
 	}
 
 	for i := 1; i <= cfg.numRules; i++ {
@@ -100,6 +103,7 @@ func spinup(t testing.TB, cfg config) (close func()) {
 			"--cluster.peers", "127.0.0.1:19591",
 			"--log.level", "debug",
 		))
+		time.Sleep(200 * time.Millisecond)
 	}
 
 	for i := 1; i <= cfg.numAlertmanagers; i++ {


### PR DESCRIPTION
This adds timestamp-based filtering to the querier so it won't always hit the store node for rule evaluations and short-term queries. This does not include minimizing overlapping ranges between store and source nodes yet.

Fixes quite a few bugs along the way, hopefully including the very flaky (and correctly so) rule e2e test.

Removed some metrics in the cluster since we switched to non-blocking dialing a while ago, which made them mostly obsolete/useless.