### PR TITLE
Increased gRPC max msg size for client recv to the maximum possible (2GB)

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -12,6 +12,8 @@ import (
 	"runtime/debug"
 	"syscall"
 
+	"math"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
@@ -197,6 +199,7 @@ func defaultGRPCServerOpts(logger log.Logger, reg *prometheus.Registry, tracer o
 	}
 	reg.MustRegister(met, panicsTotal)
 	return []grpc.ServerOption{
+		grpc.MaxSendMsgSize(math.MaxInt32),
 		grpc_middleware.WithUnaryServerChain(
 			met.UnaryServerInterceptor(),
 			tracing.UnaryServerInterceptor(tracer),

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -381,6 +381,8 @@ func (s *bucketSeriesSet) Next() bool {
 	s.i++
 	s.chks = make([]storepb.Chunk, 0, len(s.set[s.i].chks))
 
+	// TODO(bplotka): If spotted troubles with gRPC overhead, split chunks to max 4MB chunks if needed. Currently
+	// we have huge limit for message size ~2GB.
 	for _, c := range s.set[s.i].chks {
 		s.chks = append(s.chks, storepb.Chunk{
 			MinTime: c.MinTime,


### PR DESCRIPTION
Signed-off-by: Bartek Plotka <bwplotka@gmail.com>