### PR TITLE
vendor: update prometheus/tsdb

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -236,10 +236,10 @@
   revision = "6171d00fa712c2f8368e601fa20c131fe37c8e16"
 
 [[projects]]
-  branch = "refpkg2"
+  branch = "master"
   name = "github.com/prometheus/tsdb"
   packages = [".","chunkenc","chunks","fileutil","index","labels"]
-  revision = "989ef0ac6acc5cf12202c27bfd1fa797dda145f3"
+  revision = "07ef80820ef1250db82f9544f3fcf7f0f63ccee0"
 
 [[projects]]
   branch = "master"
@@ -308,12 +308,6 @@
   version = "v2.2.5"
 
 [[projects]]
-  branch = "v1"
-  name = "gopkg.in/yaml.v1"
-  packages = ["."]
-  revision = "9f9df34309c04878acc86042b16630b0f696e1de"
-
-[[projects]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -322,6 +316,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "16e7ceaea23343acf707218128c3d30e1de4a20c44089357afde87db9ea309c3"
+  inputs-digest = "9b13a107c51e85d17de52bdfb23c12304e0f6838d43991f32aa850ceb8f19ddc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -71,7 +71,7 @@
   name = "github.com/grpc-ecosystem/go-grpc-prometheus"
 
 [[constraint]]
-  branch = "refpkg2"
+  branch = "master"
   name = "github.com/prometheus/tsdb"
 
 [[constraint]]

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -429,10 +429,14 @@ func (s *BucketStore) blockSeries(
 	if err != nil {
 		return nil, stats, err
 	}
+	// If the tree was reduced to the empty postings list, don't preload the registered
+	// leaf postings and return early with an empty result.
+	if lazyPostings == index.EmptyPostings() {
+		return storepb.EmptySeriesSet(), stats, nil
+	}
 	if err := indexr.preloadPostings(); err != nil {
 		return nil, stats, err
 	}
-
 	// Get result postings list by resolving the postings tree.
 	ps, err := index.ExpandPostings(lazyPostings)
 	if err != nil {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/improbable-eng/thanos/pkg/objstore"
-
 	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/improbable-eng/thanos/pkg/testutil"

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -28,6 +28,11 @@ func (emptySeriesSet) Next() bool             { return false }
 func (emptySeriesSet) At() ([]Label, []Chunk) { return nil, nil }
 func (emptySeriesSet) Err() error             { return nil }
 
+// EmptySeriesSet returns a new series set that contains no series.
+func EmptySeriesSet() SeriesSet {
+	return emptySeriesSet{}
+}
+
 // MergeSeriesSets returns a new series set that is the union of the input sets.
 func MergeSeriesSets(all ...SeriesSet) SeriesSet {
 	switch len(all) {


### PR DESCRIPTION
We managed to get all our upstream changes in the other day. So now we can pin our dependency back to master. A few other non-trivial changes have landed there. So for the next rollout we do we should keep an eye out for issues potentially related to that.