### PR TITLE
store: skip postings preloading for unmatching blocks

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -429,10 +429,14 @@ func (s *BucketStore) blockSeries(
 	if err != nil {
 		return nil, stats, err
 	}
+	// If the tree was reduced to the empty postings list, don't preload the registered
+	// leaf postings and return early with an empty result.
+	if lazyPostings == index.EmptyPostings() {
+		return storepb.EmptySeriesSet(), stats, nil
+	}
 	if err := indexr.preloadPostings(); err != nil {
 		return nil, stats, err
 	}
-
 	// Get result postings list by resolving the postings tree.
 	ps, err := index.ExpandPostings(lazyPostings)
 	if err != nil {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/improbable-eng/thanos/pkg/objstore"
-
 	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/improbable-eng/thanos/pkg/testutil"

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -28,6 +28,11 @@ func (emptySeriesSet) Next() bool             { return false }
 func (emptySeriesSet) At() ([]Label, []Chunk) { return nil, nil }
 func (emptySeriesSet) Err() error             { return nil }
 
+// EmptySeriesSet returns a new series set that contains no series.
+func EmptySeriesSet() SeriesSet {
+	return emptySeriesSet{}
+}
+
 // MergeSeriesSets returns a new series set that is the union of the input sets.
 func MergeSeriesSets(all ...SeriesSet) SeriesSet {
 	switch len(all) {


### PR DESCRIPTION
I addressed #154 upstream via https://github.com/prometheus/tsdb/pull/233.
Once it is merged there, these changes will automatically make use of it.

This potentially reduces requests to the object storage significantly.