### PR TITLE
Implement special aggregate chunk type for downsampling

### DIFF
--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -27,7 +27,7 @@ type Meta struct {
 type ThanosMeta struct {
 	Labels     map[string]string `json:"labels"`
 	Downsample struct {
-		Window int64 `json:"window"`
+		Resolution int64 `json:"resolution"`
 	} `json:"downsample"`
 }
 

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -25,7 +25,8 @@ type Meta struct {
 
 // ThanosMeta holds block meta information specific to Thanos.
 type ThanosMeta struct {
-	Labels map[string]string `json:"labels"`
+	Labels             map[string]string `json:"labels"`
+	DownsamplingWindow int64             `json:"downsamplingWindow"`
 }
 
 // MetaFilename is the known JSON filename for meta information.

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -25,8 +25,10 @@ type Meta struct {
 
 // ThanosMeta holds block meta information specific to Thanos.
 type ThanosMeta struct {
-	Labels             map[string]string `json:"labels"`
-	DownsamplingWindow int64             `json:"downsamplingWindow"`
+	Labels     map[string]string `json:"labels"`
+	Downsample struct {
+		Window int64 `json:"window"`
+	} `json:"downsample"`
 }
 
 // MetaFilename is the known JSON filename for meta information.

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -1,0 +1,585 @@
+package downsample
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/prometheus/tsdb/chunkenc"
+
+	"github.com/go-kit/kit/log"
+	"github.com/oklog/ulid"
+	"github.com/pkg/errors"
+	"github.com/prometheus/tsdb"
+	"github.com/prometheus/tsdb/chunks"
+	"github.com/prometheus/tsdb/index"
+	"github.com/prometheus/tsdb/labels"
+)
+
+// Downsample downsamples the given block. It writes a new block into dir and returns its ID.
+func Downsample(
+	ctx context.Context,
+	origMeta *block.Meta,
+	b tsdb.BlockReader,
+	dir string,
+	window int64,
+) (id ulid.ULID, err error) {
+	indexr, err := b.Index()
+	if err != nil {
+		return id, errors.Wrap(err, "open index reader")
+	}
+	defer indexr.Close()
+
+	chunkr, err := b.Chunks()
+	if err != nil {
+		return id, errors.Wrap(err, "open chunk reader")
+	}
+	defer chunkr.Close()
+
+	// Write downsampled data in a custom memory block where we have fine-grained control
+	// over created chunks.
+	// This is necessary since we need to inject special values at the end of chunks for
+	// some aggregations.
+	newb := newMemBlock()
+
+	pall, err := indexr.Postings(index.AllPostingsKey())
+	if err != nil {
+		return id, errors.Wrap(err, "get all postings list")
+	}
+	var (
+		all     []sample
+		chunked [][]sample
+		chks    []chunks.Meta
+	)
+	for pall.Next() {
+		var lset labels.Labels
+		chks = chks[:0]
+		all = all[:0]
+		chunked = chunked[:0]
+
+		// Get series labels and chunks. Downsampled data is sensitive to chunk boundaries
+		// and we need to preserve them to properly downsample previously downsampled data.
+		if err := indexr.Series(pall.At(), &lset, &chks); err != nil {
+			return id, errors.Wrapf(err, "get series %d", pall.At())
+		}
+		for _, c := range chks {
+			chk, err := chunkr.Chunk(c.Ref)
+			if err != nil {
+				return id, errors.Wrapf(err, "get chunk %d", c.Ref)
+			}
+			k := len(all)
+			it := chk.Iterator()
+
+			for it.Next() {
+				t, v := it.At()
+				all = append(all, sample{t, v})
+			}
+			if it.Err() != nil {
+				return id, errors.Wrapf(it.Err(), "expand chunk %d", c.Ref)
+			}
+			chunked = append(chunked, all[k:])
+		}
+		// Raw and already downsampled data need different processing.
+		if origMeta.Thanos.DownsamplingWindow == 0 {
+			for _, s := range downsampleRaw(lset, all, window) {
+				newb.addSeries(s)
+			}
+		} else {
+			s, err := downsampleAggr(lset, all, chunked, window)
+			if err != nil {
+				return id, errors.Wrap(err, "downsample aggregate block")
+			}
+			newb.addSeries(s)
+		}
+	}
+	if pall.Err() != nil {
+		return id, errors.Wrap(pall.Err(), "iterate series set")
+	}
+	rng := origMeta.MaxTime - origMeta.MinTime
+	comp, err := tsdb.NewLeveledCompactor(nil, log.NewNopLogger(), []int64{rng}, nil)
+	if err != nil {
+		return id, errors.Wrap(err, "create compactor")
+	}
+	id, err = comp.Write(dir, newb, origMeta.MinTime, origMeta.MaxTime)
+	if err != nil {
+		return id, errors.Wrap(err, "compact head")
+	}
+	bdir := filepath.Join(dir, id.String())
+
+	meta, err := block.ReadMetaFile(bdir)
+	if err != nil {
+		return id, errors.Wrap(err, "read block meta")
+	}
+	meta.Thanos.Labels = origMeta.Thanos.Labels
+	meta.Thanos.DownsamplingWindow = window
+	meta.Compaction = origMeta.Compaction
+
+	if err := block.WriteMetaFile(bdir, meta); err != nil {
+		return id, errors.Wrap(err, "write block meta")
+	}
+	return id, nil
+}
+
+// memBlock is an in-memory block that implements a subset of the tsdb.BlockReader interface
+// to allow tsdb.LeveledCompactor to persist the data as a block.
+type memBlock struct {
+	// Dummies to implement unused methods.
+	tsdb.IndexReader
+
+	symbols  map[string]struct{}
+	postings []uint64
+	series   []*series
+	chunks   []chunkenc.Chunk
+}
+
+func newMemBlock() *memBlock {
+	return &memBlock{symbols: map[string]struct{}{}}
+}
+
+func (b *memBlock) addSeries(s *series) {
+	sid := uint64(len(b.series))
+	b.postings = append(b.postings, sid)
+	b.series = append(b.series, s)
+
+	for _, l := range s.lset {
+		b.symbols[l.Name] = struct{}{}
+		b.symbols[l.Value] = struct{}{}
+	}
+
+	for i, cm := range s.chunks {
+		cid := uint64(len(b.chunks))
+		s.chunks[i].Ref = cid
+		b.chunks = append(b.chunks, cm.Chunk)
+	}
+}
+
+func (b *memBlock) Postings(name, val string) (index.Postings, error) {
+	allName, allVal := index.AllPostingsKey()
+
+	if name != allName || val != allVal {
+		return nil, errors.New("unsupported call to Postings()")
+	}
+	sort.Slice(b.postings, func(i, j int) bool {
+		return labels.Compare(b.series[b.postings[i]].lset, b.series[b.postings[j]].lset) < 0
+	})
+	return index.NewListPostings(b.postings), nil
+}
+
+func (b *memBlock) Series(id uint64, lset *labels.Labels, chks *[]chunks.Meta) error {
+	if id >= uint64(len(b.series)) {
+		return errors.Wrapf(tsdb.ErrNotFound, "series with ID %d does not exist", id)
+	}
+	s := b.series[id]
+
+	*lset = append((*lset)[:0], s.lset...)
+	*chks = append((*chks)[:0], s.chunks...)
+
+	return nil
+}
+
+func (b *memBlock) Chunk(id uint64) (chunkenc.Chunk, error) {
+	if id >= uint64(len(b.chunks)) {
+		return nil, errors.Wrapf(tsdb.ErrNotFound, "chunk with ID %d does not exist", id)
+	}
+	return b.chunks[id], nil
+}
+
+func (b *memBlock) Symbols() (map[string]struct{}, error) {
+	return b.symbols, nil
+}
+
+func (b *memBlock) SortedPostings(p index.Postings) index.Postings {
+	return p
+}
+
+func (b *memBlock) Index() (tsdb.IndexReader, error) {
+	return b, nil
+}
+
+func (b *memBlock) Chunks() (tsdb.ChunkReader, error) {
+	return b, nil
+}
+
+func (b *memBlock) Tombstones() (tsdb.TombstoneReader, error) {
+	return tsdb.EmptyTombstoneReader(), nil
+}
+
+func (b *memBlock) Close() error {
+	return nil
+}
+
+func downsampleRaw(lset labels.Labels, data []sample, window int64) []*series {
+	if len(data) == 0 {
+		return nil
+	}
+	n := targetChunkSize(len(data))
+
+	countSeries := newAggrSeries(lset, "count", n)
+	sumSeries := newAggrSeries(lset, "sum", n)
+	minSeries := newAggrSeries(lset, "min", n)
+	maxSeries := newAggrSeries(lset, "max", n)
+	counterSeries := newAggrSeries(lset, "counter", 0)
+
+	res := make([]*series, 0, 5)
+
+	if !isCounter(lset) {
+		downsampleSum(sumSeries, data, window)
+		downsampleMin(minSeries, data, window)
+		downsampleMax(maxSeries, data, window)
+		res = append(res, sumSeries, minSeries, maxSeries)
+	}
+	downsampleCount(countSeries, data, window)
+	downsampleCounter(counterSeries, data, window, true)
+	res = append(res, countSeries, counterSeries)
+
+	for _, s := range res {
+		s.close()
+	}
+	return res
+}
+
+func downsampleAggr(lset labels.Labels, all []sample, chunked [][]sample, window int64) (*series, error) {
+	if len(all) == 0 {
+		return nil, nil
+	}
+	metric := lset.Get("__name__")
+	ser := newSeries(lset, targetChunkSize(len(all))+1)
+
+	if strings.HasSuffix(metric, "$sum") {
+		downsampleSum(ser, all, window)
+	} else if strings.HasSuffix(metric, "$count") {
+		// Downsampling a count aggregate is equivalent to downsampling a sum.
+		downsampleSum(ser, all, window)
+	} else if strings.HasSuffix(metric, "$min") {
+		downsampleMin(ser, all, window)
+	} else if strings.HasSuffix(metric, "$max") {
+		downsampleMax(ser, all, window)
+	} else if strings.HasSuffix(metric, "$counter") {
+		downsampleCounterCounter(ser, all, chunked, window)
+	} else {
+		return nil, errors.Errorf("unknown aggregate metric %q", metric)
+	}
+	ser.close()
+	return ser, nil
+}
+
+func aggrLset(lset labels.Labels, aggr string) labels.Labels {
+	res := make(labels.Labels, len(lset))
+	copy(res, lset)
+
+	for i, l := range res {
+		if l.Name == "__name__" {
+			res[i].Value = fmt.Sprintf("%s$%s", l.Value, aggr)
+		}
+	}
+	return res
+}
+
+func isCounter(lset labels.Labels) bool {
+	metric := lset.Get("__name__")
+	return strings.HasSuffix(metric, "_total") ||
+		strings.HasSuffix(metric, "_bucket") ||
+		strings.HasSuffix(metric, "_sum")
+}
+
+func targetChunkSize(l int) int {
+	c := 1
+	for ; l/c > 250; c++ {
+	}
+	return l / c
+}
+
+type sample struct {
+	t int64
+	v float64
+}
+
+// series is a mutable series that creates XOR chunk with a configurable target amount
+// of samples per chunk.
+type series struct {
+	lset   labels.Labels
+	chunks []chunks.Meta
+
+	l, n       int
+	cur        chunkenc.Chunk
+	app        chunkenc.Appender
+	cmin, cmax int64
+}
+
+// newSeries returns a new series and automatically cuts a new chunk after n samples if
+// n is greater than 0.
+func newSeries(lset labels.Labels, n int) *series {
+	return &series{lset: lset, n: n}
+}
+
+// newSeries returns a new series and automatically cuts a new chunk after n samples if
+// n is greater than 0.
+// It extends the metric name of the label set by the aggregation modifier.
+func newAggrSeries(lset labels.Labels, aggr string, n int) *series {
+	return &series{lset: aggrLset(lset, aggr), n: n}
+}
+
+func (s *series) add(t int64, v float64) {
+	if s.n > 0 && s.l >= s.n {
+		s.cut()
+	}
+	if s.cur == nil {
+		s.cur = chunkenc.NewXORChunk()
+		s.cmin = t
+		s.app, _ = s.cur.Appender()
+	}
+	s.app.Append(t, v)
+	s.cmax = t
+}
+
+func (s *series) cut() {
+	s.chunks = append(s.chunks, chunks.Meta{
+		MinTime: s.cmin,
+		MaxTime: s.cmax,
+		Chunk:   s.cur,
+	})
+	s.cur = nil
+}
+
+func (s *series) close() {
+	if s.cur == nil {
+		return
+	}
+	s.chunks = append(s.chunks, chunks.Meta{
+		MinTime: s.cmin,
+		MaxTime: s.cmax,
+		Chunk:   s.cur,
+	})
+}
+
+// downsampleCounter downsamples the data points into the series with the given window.
+// If split is set to false, it will write all result data into a single chunk in the series.
+// It writes a signal sample to the end of each chunk which preservers the last true sample of
+// the input data.
+// If it is called on already downsampled data, the input data must end at such a signaling
+// sample to recursively guarantee the semantics.
+func downsampleCounter(ser *series, data []sample, window int64, split bool) {
+	var (
+		n       = targetChunkSize(len(data))
+		nextT   = int64(-1)
+		lastT   int64
+		lastV   float64
+		counter float64
+	)
+	for i, s := range data {
+		if s.t > nextT {
+			if split && i > 0 && i%n == 0 {
+				// Add signaling sample that indicates what the true last value was
+				// before cutting a new chunk.
+				// For already downsampled series lastV is set to the last value that
+				// series itself added as a signaling sample.
+				ser.add(nextT, lastV)
+				ser.cut()
+			}
+			if nextT != -1 {
+				ser.add(nextT, counter)
+			}
+			nextT = s.t - (s.t % window) + window - 1
+		}
+		if i == 0 {
+			// First sample sets the counter.
+			counter = s.v
+		} else if s.t > lastT {
+			// We ignored samples with no increasing timestamps. This handles signaling samples
+			// in already downsampled counter series.
+			// At breaking points (e.g. chunks) they add a sample with non-increased timestamp
+			// and the true last value, like the one we add ourselves in this function.
+			if s.v < lastV {
+				// Counter reset, correct the value.
+				counter += s.v
+			} else {
+				// Add delta with last value to the counter.
+				counter += s.v - lastV
+			}
+		}
+		lastV = s.v
+		lastT = s.t
+	}
+	ser.add(nextT, counter)
+	// Add signaling sample that indicates what the true last value was.
+	ser.add(nextT, lastV)
+	ser.cut()
+}
+
+func downsampleCounterCounter(ser *series, data []sample, chunked [][]sample, window int64) {
+	// For downsampling an already downsampled counter series, we have to ensure that produced
+	// chunks align with boundaries of input chunks.
+	// Otherwise the signal sample indiciating the last true sample value is not picked correctly.
+	n := targetChunkSize(len(data))
+	k := len(chunked)/(len(data)/n) + 1 // batch size
+
+	for len(chunked) > 0 {
+		j := k
+		if j > len(chunked) {
+			j = len(chunked)
+		}
+		length := 0
+		for _, p := range chunked[:j] {
+			length += len(p)
+		}
+		part := data[:length]
+		data = data[length:]
+		chunked = chunked[j:]
+
+		// Downsample the counter series spanning the chunk batch into a single chunk.
+		downsampleCounter(ser, part, window, false)
+	}
+}
+
+func downsampleCount(ser *series, data []sample, window int64) {
+	nextT := int64(-1)
+	var count int
+
+	for _, s := range data {
+		if s.t > nextT {
+			if nextT != -1 {
+				ser.add(nextT, float64(count))
+			}
+			count = 0
+			nextT = s.t - (s.t % window) + window - 1
+		}
+		count++
+	}
+	ser.add(nextT, float64(count))
+}
+
+func downsampleSum(ser *series, data []sample, window int64) {
+	nextT := int64(-1)
+	var sum float64
+
+	for _, s := range data {
+		if s.t > nextT {
+			if nextT != -1 {
+				ser.add(nextT, sum)
+			}
+			sum = 0
+			nextT = s.t - (s.t % window) + window - 1
+		}
+		sum += s.v
+	}
+	ser.add(nextT, sum)
+}
+
+func downsampleMin(ser *series, data []sample, window int64) {
+	nextT := int64(-1)
+	min := math.MaxFloat64
+
+	for _, s := range data {
+		if s.t > nextT {
+			if nextT != -1 {
+				ser.add(nextT, min)
+			}
+			min = math.MaxFloat64
+			nextT = s.t - (s.t % window) + window - 1
+		}
+		if s.v < min {
+			min = s.v
+		}
+	}
+	ser.add(nextT, min)
+}
+
+func downsampleMax(ser *series, data []sample, window int64) {
+	nextT := int64(-1)
+	max := -math.MaxFloat64
+
+	for _, s := range data {
+		if s.t > nextT {
+			if nextT != -1 {
+				ser.add(nextT, max)
+			}
+			max = -math.MaxFloat64
+			nextT = s.t - (s.t % window) + window - 1
+		}
+		if s.v > max {
+			max = s.v
+		}
+	}
+	ser.add(nextT, max)
+}
+
+// countChunkSeriesIterator iterates over an ordered sequence of chunks and treats decreasing
+// values as counter reset.
+// Additionally, it can deal with downsampled counter chunks, which set the last value of a chunk
+// to the original last value. The last value can be detected by checking whether the timestamp
+// did not increase w.r.t to the previous sample
+type countChunkSeriesIterator struct {
+	chks   []chunkenc.Iterator
+	i      int     // current chunk
+	total  int     // total number of processed samples
+	lastT  int64   // timestamp of the last sample
+	lastV  float64 // value of the last sample
+	totalV float64 // total counter state since beginning of series
+}
+
+func (it *countChunkSeriesIterator) LastSample() (int64, float64) {
+	return it.lastT, it.lastV
+}
+
+func (it *countChunkSeriesIterator) Next() bool {
+	if it.i >= len(it.chks) {
+		return false
+	}
+	// Chunk ends without special sample. It was not a downsampled counter series.
+	if ok := it.chks[it.i].Next(); !ok {
+		it.i++
+		return it.Next()
+	}
+	t, v := it.chks[it.i].At()
+	// First sample sets the initial counter state.
+	if it.total == 0 {
+		it.total++
+		it.lastT, it.lastV = t, v
+		it.totalV = v
+		return true
+	}
+	// If the timestamp increased, it is not the special last sample.
+	if t > it.lastT {
+		if v >= it.lastV {
+			it.totalV += v - it.lastV
+		} else {
+			it.totalV += v
+		}
+		it.lastT, it.lastV = t, v
+		it.total++
+		return true
+	}
+	// We hit the last sample that indicates what the true last value was. For the
+	// next chunk we use it to determine whether there was a counter reset between them.
+	it.lastT, it.lastV = t, v
+	it.i++
+
+	return it.Next()
+}
+
+func (it *countChunkSeriesIterator) At() (t int64, v float64) {
+	return it.lastT, it.totalV
+}
+
+func (it *countChunkSeriesIterator) Seek(x int64) bool {
+	for {
+		ok := it.Next()
+		if !ok {
+			return false
+		}
+		if t, _ := it.At(); t >= x {
+			return true
+		}
+	}
+}
+
+func (it *countChunkSeriesIterator) Err() error {
+	if it.i >= len(it.chks) {
+		return nil
+	}
+	return it.chks[it.i].Err()
+}

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -2,7 +2,7 @@ package downsample
 
 import (
 	"context"
-	"fmt"
+	"encoding/binary"
 	"math"
 	"path/filepath"
 	"sort"
@@ -40,6 +40,8 @@ func Downsample(
 	}
 	defer chunkr.Close()
 
+	rng := origMeta.MaxTime - origMeta.MinTime
+
 	// Write downsampled data in a custom memory block where we have fine-grained control
 	// over created chunks.
 	// This is necessary since we need to inject special values at the end of chunks for
@@ -51,56 +53,52 @@ func Downsample(
 		return id, errors.Wrap(err, "get all postings list")
 	}
 	var (
-		all     []sample
-		chunked [][]sample
-		chks    []chunks.Meta
+		aggrChunks []*AggrChunk
+		all        []sample
+		chks       []chunks.Meta
 	)
 	for pall.Next() {
 		var lset labels.Labels
 		chks = chks[:0]
 		all = all[:0]
-		chunked = chunked[:0]
+		aggrChunks = aggrChunks[:0]
 
 		// Get series labels and chunks. Downsampled data is sensitive to chunk boundaries
 		// and we need to preserve them to properly downsample previously downsampled data.
 		if err := indexr.Series(pall.At(), &lset, &chks); err != nil {
 			return id, errors.Wrapf(err, "get series %d", pall.At())
 		}
+		// Raw and already downsampled data need different processing.
+		if origMeta.Thanos.Downsample.Window == 0 {
+			for _, c := range chks {
+				chk, err := chunkr.Chunk(c.Ref)
+				if err != nil {
+					return id, errors.Wrapf(err, "get chunk %d", c.Ref)
+				}
+				if err := expandChunkIterator(chk.Iterator(), &all); err != nil {
+					return id, errors.Wrapf(err, "expand chunk %d", c.Ref)
+				}
+			}
+			newb.addSeries(downsampleRaw(lset, all, window))
+			continue
+		}
 		for _, c := range chks {
 			chk, err := chunkr.Chunk(c.Ref)
 			if err != nil {
 				return id, errors.Wrapf(err, "get chunk %d", c.Ref)
 			}
-			k := len(all)
-			it := chk.Iterator()
-
-			for it.Next() {
-				t, v := it.At()
-				all = append(all, sample{t, v})
-			}
-			if it.Err() != nil {
-				return id, errors.Wrapf(it.Err(), "expand chunk %d", c.Ref)
-			}
-			chunked = append(chunked, all[k:])
+			aggrChunks = append(aggrChunks, chk.(*AggrChunk))
 		}
-		// Raw and already downsampled data need different processing.
-		if origMeta.Thanos.Downsample.Window == 0 {
-			for _, s := range downsampleRaw(lset, all, window) {
-				newb.addSeries(s)
-			}
-			continue
-		}
-		s, err := downsampleAggr(lset, all, chunked, window)
+		res, err := downsampleAggr(aggrChunks, &all, chks[0].MinTime, chks[len(chks)-1].MaxTime, window)
 		if err != nil {
 			return id, errors.Wrap(err, "downsample aggregate block")
 		}
-		newb.addSeries(s)
+		newb.addSeries(&series{lset: lset, chunks: res})
 	}
 	if pall.Err() != nil {
 		return id, errors.Wrap(pall.Err(), "iterate series set")
 	}
-	rng := origMeta.MaxTime - origMeta.MinTime
-	comp, err := tsdb.NewLeveledCompactor(nil, log.NewNopLogger(), []int64{rng}, nil)
+	comp, err := tsdb.NewLeveledCompactor(nil, log.NewNopLogger(), []int64{rng}, aggrPool{})
 	if err != nil {
 		return id, errors.Wrap(err, "create compactor")
 	}
@@ -212,71 +210,333 @@ func (b *memBlock) Close() error {
 	return nil
 }
 
-func downsampleRaw(lset labels.Labels, data []sample, window int64) []*series {
+// aggregator collects commulative stats for a stream of values.
+type aggregator struct {
+	total   int     // total samples processed
+	count   int     // samples in current window
+	sum     float64 // value sum of current window
+	min     float64 // min of current window
+	max     float64 // max of current window
+	counter float64 // total counter state since beginning
+	resets  int     // number of counter resests since beginning
+	last    float64 // last added value
+}
+
+// reset the stats to start a new aggregation window.
+func (a *aggregator) reset() {
+	a.count = 0
+	a.sum = 0
+	a.min = math.MaxFloat64
+	a.max = -math.MaxFloat64
+}
+
+func (a *aggregator) add(v float64) {
+	if a.total > 0 {
+		if v < a.last {
+			// Counter reset, correct the value.
+			a.counter += v
+			a.resets++
+		} else {
+			// Add delta with last value to the counter.
+			a.counter += v - a.last
+		}
+	} else {
+		// First sample sets the counter.
+		a.counter = v
+	}
+	a.last = v
+
+	a.sum += v
+	a.count++
+	a.total++
+
+	if v < a.min {
+		a.min = v
+	}
+	if v > a.max {
+		a.max = v
+	}
+}
+
+// AggrType represents an aggregation type.
+type AggrType uint8
+
+// Valid aggregations.
+const (
+	AggrCount AggrType = iota
+	AggrSum
+	AggrMin
+	AggrMax
+	AggrCounter
+)
+
+func (t AggrType) String() string {
+	switch t {
+	case AggrCount:
+		return "count"
+	case AggrSum:
+		return "sum"
+	case AggrMin:
+		return "min"
+	case AggrMax:
+		return "max"
+	case AggrCounter:
+		return "counter"
+	}
+	return "<unknown>"
+}
+
+// aggrChunkBuilder builds chunks for multiple different aggregates.
+type aggrChunkBuilder struct {
+	mint, maxt int64
+	isCounter  bool
+	added      int
+
+	chunks [5]chunkenc.Chunk
+	apps   [5]chunkenc.Appender
+}
+
+func newAggrChunkBuilder(isCounter bool) *aggrChunkBuilder {
+	b := &aggrChunkBuilder{
+		mint:      math.MaxInt64,
+		maxt:      math.MinInt64,
+		isCounter: isCounter,
+	}
+	if !isCounter {
+		b.chunks[AggrSum] = chunkenc.NewXORChunk()
+		b.chunks[AggrMin] = chunkenc.NewXORChunk()
+		b.chunks[AggrMax] = chunkenc.NewXORChunk()
+	}
+	b.chunks[AggrCount] = chunkenc.NewXORChunk()
+	b.chunks[AggrCounter] = chunkenc.NewXORChunk()
+
+	for i, c := range b.chunks {
+		if c != nil {
+			b.apps[i], _ = c.Appender()
+		}
+	}
+
+	return b
+}
+
+func (b *aggrChunkBuilder) add(t int64, aggr *aggregator) {
+	if t < b.mint {
+		b.mint = t
+	}
+	if t > b.maxt {
+		b.maxt = t
+	}
+	if !b.isCounter {
+		b.apps[AggrSum].Append(t, aggr.sum)
+		b.apps[AggrMin].Append(t, aggr.min)
+		b.apps[AggrMax].Append(t, aggr.max)
+	}
+	b.apps[AggrCount].Append(t, float64(aggr.count))
+	b.apps[AggrCounter].Append(t, aggr.counter)
+
+	b.added++
+}
+
+func (b *aggrChunkBuilder) encode() *AggrChunk {
+	return EncodeAggrChunk(b.chunks)
+}
+
+// currentWindow returns the end timestamp of the window that t falls into.
+func currentWindow(t, w int64) int64 {
+	// The next timestamp is the next number after s.t that's aligned with window.
+	// We substract 1 because block ranges are [from, to) and the last sample would
+	// go out of bounds otherwise.
+	return t - (t % w) + w - 1
+}
+
+// downsampleRaw create a series of aggregation chunks for the given sample data.
+func downsampleRaw(lset labels.Labels, data []sample, window int64) *series {
 	if len(data) == 0 {
 		return nil
 	}
-	n := targetChunkSize(len(data))
-
-	countSeries := newAggrSeries(lset, "count", n)
-	sumSeries := newAggrSeries(lset, "sum", n)
-	minSeries := newAggrSeries(lset, "min", n)
-	maxSeries := newAggrSeries(lset, "max", n)
-	counterSeries := newAggrSeries(lset, "counter", 0)
-
-	res := make([]*series, 0, 5)
-
-	if !isCounter(lset) {
-		downsampleSum(sumSeries, data, window)
-		downsampleMin(minSeries, data, window)
-		downsampleMax(maxSeries, data, window)
-		res = append(res, sumSeries, minSeries, maxSeries)
-	}
-	downsampleCount(countSeries, data, window)
-	downsampleCounter(counterSeries, data, window, true)
-	res = append(res, countSeries, counterSeries)
-
-	for _, s := range res {
-		s.close()
-	}
-	return res
-}
-
-func downsampleAggr(lset labels.Labels, all []sample, chunked [][]sample, window int64) (*series, error) {
-	if len(all) == 0 {
-		return nil, nil
-	}
-	metric := lset.Get("__name__")
-	ser := newSeries(lset, targetChunkSize(len(all))+1)
-
-	if strings.HasSuffix(metric, "$sum") {
-		downsampleSum(ser, all, window)
-	} else if strings.HasSuffix(metric, "$count") {
-		// Downsampling a count aggregate is equivalent to downsampling a sum.
-		downsampleSum(ser, all, window)
-	} else if strings.HasSuffix(metric, "$min") {
-		downsampleMin(ser, all, window)
-	} else if strings.HasSuffix(metric, "$max") {
-		downsampleMax(ser, all, window)
-	} else if strings.HasSuffix(metric, "$counter") {
-		downsampleAggrCounter(ser, all, chunked, window)
-	} else {
-		return nil, errors.Errorf("unknown aggregate metric %q", metric)
-	}
-	ser.close()
-	return ser, nil
-}
-
-func aggrLset(lset labels.Labels, aggr string) labels.Labels {
-	res := make(labels.Labels, len(lset))
-	copy(res, lset)
-
-	for i, l := range res {
-		if l.Name == "__name__" {
-			res[i].Value = fmt.Sprintf("%s$%s", l.Value, aggr)
+	var (
+		mint, maxt = data[0].t, data[len(data)-1].t
+		ns         = int((maxt-mint)/window) + 1
+		nc, _      = targetChunkSize(ns)
+		chks       = make([]chunks.Meta, 0, nc)
+		batchSize  = (len(data) / nc) + 1
+	)
+	for len(data) > 0 {
+		j := batchSize
+		if j > len(data) {
+			j = len(data)
 		}
+		// The batch we took might end in the middle of a downsampling window. We have to additionally
+		// grab all following samples still within our current window.
+		curW := currentWindow(data[j-1].t, window)
+
+		for ; j < len(data) && data[j].t <= curW; j++ {
+		}
+
+		ab := newAggrChunkBuilder(isCounter(lset))
+		batch := data[:j]
+		data = data[j:]
+
+		lastT := downsampleBatch(batch, window, ab.add)
+
+		// Finalize the chunk's counter aggregate with the last true sample.
+		ab.apps[AggrCounter].Append(lastT, batch[len(batch)-1].v)
+
+		chks = append(chks, chunks.Meta{
+			MinTime: ab.mint,
+			MaxTime: ab.maxt,
+			Chunk:   ab.encode(),
+		})
 	}
-	return res
+	return &series{lset: lset, chunks: chks}
+}
+
+// downsampleBatch aggregates the data over the given window and calls add each time
+// the end of a window was reached.
+func downsampleBatch(data []sample, window int64, add func(int64, *aggregator)) int64 {
+	var (
+		aggr  aggregator
+		nextT = int64(-1)
+	)
+	// Fill up one aggregate chunk with up to m samples.
+	for _, s := range data {
+		if s.t > nextT {
+			if nextT != -1 {
+				add(nextT, &aggr)
+			}
+			aggr.reset()
+			nextT = currentWindow(s.t, window)
+		}
+		aggr.add(s.v)
+	}
+	// Add the last sample.
+	add(nextT, &aggr)
+
+	return nextT
+}
+
+// downsampleAggr downsamples a sequence of aggregation chunks to the given resolution window.
+func downsampleAggr(chks []*AggrChunk, buf *[]sample, mint, maxt, window int64) ([]chunks.Meta, error) {
+	// We downsample aggregates only along chunk boundaries. This is required for counters
+	// to be downsampled correctly since a chunks' last counter value is the true last value
+	// of the original series. We need to preserve it even across multiple aggregation iterations.
+	var (
+		ns        = int((maxt-mint)/window) + 1
+		nc, _     = targetChunkSize(ns)
+		res       = make([]chunks.Meta, 0, nc)
+		batchSize = len(chks) / nc
+	)
+
+	for len(chks) > 0 {
+		j := batchSize
+		if j > len(chks) {
+			j = len(chks)
+		}
+		part := chks[:j]
+		chks = chks[j:]
+
+		mint, maxt, c, err := downsampleAggrBatch(part, buf, window)
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, chunks.Meta{
+			MinTime: mint,
+			MaxTime: maxt,
+			Chunk:   c,
+		})
+	}
+	return res, nil
+}
+
+func expandChunkIterator(it chunkenc.Iterator, buf *[]sample) error {
+	for it.Next() {
+		t, v := it.At()
+		*buf = append(*buf, sample{t, v})
+	}
+	return it.Err()
+}
+
+func downsampleAggrBatch(chks []*AggrChunk, buf *[]sample, window int64) (mint, maxt int64, c *AggrChunk, err error) {
+	ab := &aggrChunkBuilder{}
+
+	// do does a generic aggregation for count, sum, min, and max aggregates.
+	// Counters need special treatment.
+	do := func(at AggrType, f func(a *aggregator) float64) error {
+		(*buf) = (*buf)[:0]
+		// Expand all samples for the aggregate type.
+		for _, chk := range chks {
+			c, err := chk.Get(at)
+			if err == ErrAggrNotExist {
+				continue
+			} else if err != nil {
+				return err
+			}
+			if err := expandChunkIterator(c.Iterator(), buf); err != nil {
+				return err
+			}
+		}
+		if len(*buf) == 0 {
+			return nil
+		}
+		ab.chunks[at] = chunkenc.NewXORChunk()
+		ab.apps[at], _ = ab.chunks[at].Appender()
+
+		downsampleBatch(*buf, window, func(t int64, a *aggregator) {
+			ab.apps[at].Append(t, f(a))
+		})
+		return nil
+	}
+	if err := do(AggrCount, func(a *aggregator) float64 {
+		return a.sum
+	}); err != nil {
+		return 0, 0, nil, err
+	}
+	if err = do(AggrSum, func(a *aggregator) float64 {
+		return a.sum
+	}); err != nil {
+		return 0, 0, nil, err
+	}
+	if err := do(AggrMin, func(a *aggregator) float64 {
+		return a.min
+	}); err != nil {
+		return 0, 0, nil, err
+	}
+	if err := do(AggrMax, func(a *aggregator) float64 {
+		return a.max
+	}); err != nil {
+		return 0, 0, nil, err
+	}
+
+	// Handle counters by reading them properly.
+	acs := make([]chunkenc.Iterator, 0, len(chks))
+	for _, chk := range chks {
+		c, err := chk.Get(AggrCounter)
+		if err == ErrAggrNotExist {
+			continue
+		} else if err != nil {
+			return 0, 0, nil, err
+		}
+		acs = append(acs, c.Iterator())
+	}
+	*buf = (*buf)[:0]
+	it := newCounterChunkSeriesIterator(acs...)
+
+	if err := expandChunkIterator(it, buf); err != nil {
+		return 0, 0, nil, err
+	}
+	if len(*buf) == 0 {
+		return ab.mint, ab.maxt, ab.encode(), nil
+	}
+	ab.chunks[AggrCounter] = chunkenc.NewXORChunk()
+	ab.apps[AggrCounter], _ = ab.chunks[AggrCounter].Appender()
+
+	lastT := downsampleBatch(*buf, window, func(t int64, a *aggregator) {
+		ab.apps[AggrCounter].Append(t, a.counter)
+	})
+	ab.apps[AggrCounter].Append(lastT, it.lastV)
+
+	return ab.mint, ab.maxt, ab.encode(), nil
 }
 
 // isCounter guesses whether a series is a counter based on its label set.
@@ -290,11 +550,10 @@ func isCounter(lset labels.Labels) bool {
 // targetChunkSize computes an intended sample count per chunk given a fixed length
 // of samples in the series.
 // It aims to split the series into chunks of length 120 or higher.
-func targetChunkSize(l int) int {
-	c := 1
-	for ; l/c > 250; c++ {
+func targetChunkSize(l int) (c, s int) {
+	for c = 1; l/c > 240; c++ {
 	}
-	return l / c
+	return c, (l / c) + 1
 }
 
 type sample struct {
@@ -302,221 +561,113 @@ type sample struct {
 	v float64
 }
 
-// series is a mutable series that creates XOR chunk with a configurable target amount
-// of samples per chunk.
 type series struct {
 	lset   labels.Labels
 	chunks []chunks.Meta
-
-	l, n       int
-	cur        chunkenc.Chunk
-	app        chunkenc.Appender
-	cmin, cmax int64
 }
 
-// newSeries returns a new series and automatically cuts a new chunk after n samples if
-// n is greater than 0.
-func newSeries(lset labels.Labels, n int) *series {
-	return &series{lset: lset, n: n}
+// AggrChunk is a chunk that is composed of a set of aggregates for the same underlying data.
+// Not all aggregates must be present.
+type AggrChunk struct {
+	b []byte
 }
 
-// newSeries returns a new series and automatically cuts a new chunk after n samples if
-// n is greater than 0.
-// It extends the metric name of the label set by the aggregation modifier.
-func newAggrSeries(lset labels.Labels, aggr string, n int) *series {
-	return &series{lset: aggrLset(lset, aggr), n: n}
-}
+// EncodeAggrChunk encodes a new aggregate chunk from the array of chunks for each aggregate.
+// Each array entry corresponds to the respective AggrType number.
+func EncodeAggrChunk(chks [5]chunkenc.Chunk) *AggrChunk {
+	var mask byte
+	var all []chunkenc.Chunk
 
-func (s *series) add(t int64, v float64) {
-	if s.n > 0 && s.l >= s.n {
-		s.cut()
-	}
-	if s.cur == nil {
-		s.cur = chunkenc.NewXORChunk()
-		s.cmin = t
-		s.app, _ = s.cur.Appender()
-	}
-	s.app.Append(t, v)
-	s.cmax = t
-}
-
-// cut finishes the currently appended to chunk.
-func (s *series) cut() {
-	s.chunks = append(s.chunks, chunks.Meta{
-		MinTime: s.cmin,
-		MaxTime: s.cmax,
-		Chunk:   s.cur,
-	})
-	s.cur = nil
-}
-
-// close finalizes the series.
-func (s *series) close() {
-	if s.cur == nil {
-		return
-	}
-	s.chunks = append(s.chunks, chunks.Meta{
-		MinTime: s.cmin,
-		MaxTime: s.cmax,
-		Chunk:   s.cur,
-	})
-}
-
-// downsampleCounter downsamples the data points into the series with the given window.
-// If split is set to false, it will write all result data into a single chunk in the series.
-// It writes a signal sample to the end of each chunk which preservers the last true sample of
-// the input data.
-// If it is called on already downsampled data, the input data must end at such a signaling
-// sample to recursively guarantee the semantics.
-func downsampleCounter(ser *series, data []sample, window int64, split bool) {
-	var (
-		n       = targetChunkSize(len(data))
-		nextT   = int64(-1)
-		lastT   int64
-		lastV   float64
-		counter float64
-	)
-	for i, s := range data {
-		if s.t > nextT {
-			if nextT != -1 {
-				ser.add(nextT, counter)
-
-				if split && i%n == 0 {
-					// Add signaling sample that indicates what the true last value was
-					// before cutting a new chunk.
-					// For already downsampled series lastV is set to the last value that
-					// series itself added as a signaling sample.
-					ser.add(nextT, lastV)
-					ser.cut()
-				}
-			}
-			nextT = s.t - (s.t % window) + window - 1
-		}
-		if i == 0 {
-			// First sample sets the counter.
-			counter = s.v
-		} else if s.t > lastT {
-			// We ignored samples with no increasing timestamps. This handles signaling samples
-			// in already downsampled counter series.
-			// At breaking points (e.g. chunks) they add a sample with non-increased timestamp
-			// and the true last value, like the one we add ourselves in this function.
-			if s.v < lastV {
-				// Counter reset, correct the value.
-				counter += s.v
-			} else {
-				// Add delta with last value to the counter.
-				counter += s.v - lastV
-			}
-		}
-		lastV = s.v
-		lastT = s.t
-	}
-	ser.add(nextT, counter)
-	// Add signaling sample that indicates what the true last value was.
-	ser.add(nextT, lastV)
-	ser.cut()
-}
-
-// downsampleAggrCounter downsamples a counter series that already is an aggregated counter.
-func downsampleAggrCounter(ser *series, data []sample, chunked [][]sample, window int64) {
-	// For downsampling an already downsampled counter series, we have to ensure that produced
-	// chunks align with boundaries of input chunks.
-	// Otherwise the signal sample indiciating the last true sample value is not picked correctly.
-	n := targetChunkSize(len(data))
-	k := len(chunked)/(len(data)/n) + 1 // batch size
-
-	for len(chunked) > 0 {
-		j := k
-		if j > len(chunked) {
-			j = len(chunked)
-		}
-		length := 0
-		for _, p := range chunked[:j] {
-			length += len(p)
-		}
-		part := data[:length]
-		data = data[length:]
-		chunked = chunked[j:]
-
-		// Downsample the counter series spanning the chunk batch into a single chunk.
-		downsampleCounter(ser, part, window, false)
-	}
-}
-
-// downsampleCount creates a sample count aggregate over a raw series.
-func downsampleCount(ser *series, data []sample, window int64) {
-	nextT := int64(-1)
-	var count int
-
-	for _, s := range data {
-		if s.t > nextT {
-			if nextT != -1 {
-				ser.add(nextT, float64(count))
-			}
-			count = 0
-			nextT = s.t - (s.t % window) + window - 1
-		}
-		count++
-	}
-	ser.add(nextT, float64(count))
-}
-
-// downsampleSum creates a downsampled sum aggregate over a series.
-func downsampleSum(ser *series, data []sample, window int64) {
-	nextT := int64(-1)
-	var sum float64
-
-	for _, s := range data {
-		if s.t > nextT {
-			if nextT != -1 {
-				ser.add(nextT, sum)
-			}
-			sum = 0
-			nextT = s.t - (s.t % window) + window - 1
-		}
-		sum += s.v
-	}
-	ser.add(nextT, sum)
-}
-
-// downsampleMin creates a downsampled min aggregate over a series.
-func downsampleMin(ser *series, data []sample, window int64) {
-	nextT := int64(-1)
-	min := math.MaxFloat64
-
-	for _, s := range data {
-		if s.t > nextT {
-			if nextT != -1 {
-				ser.add(nextT, min)
-			}
-			min = math.MaxFloat64
-			nextT = s.t - (s.t % window) + window - 1
-		}
-		if s.v < min {
-			min = s.v
+	for i, c := range chks {
+		if c != nil {
+			mask |= 1 << (7 - uint(i))
+			all = append(all, c)
 		}
 	}
-	ser.add(nextT, min)
+
+	var b []byte
+	b = append(b, mask)
+	buf := [8]byte{}
+
+	for _, c := range all {
+		l := len(c.Bytes())
+		n := binary.PutUvarint(buf[:], uint64(l))
+		b = append(b, buf[:n]...)
+		b = append(b, byte(c.Encoding()))
+		b = append(b, c.Bytes()...)
+	}
+	return &AggrChunk{b: b}
 }
 
-// downsampleMin creates a downsampled max aggregate over a series.
-func downsampleMax(ser *series, data []sample, window int64) {
-	nextT := int64(-1)
-	max := -math.MaxFloat64
+func (c *AggrChunk) Bytes() []byte {
+	return c.b
+}
 
-	for _, s := range data {
-		if s.t > nextT {
-			if nextT != -1 {
-				ser.add(nextT, max)
-			}
-			max = -math.MaxFloat64
-			nextT = s.t - (s.t % window) + window - 1
-		}
-		if s.v > max {
-			max = s.v
-		}
+func (c *AggrChunk) Appender() (chunkenc.Appender, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *AggrChunk) Iterator() chunkenc.Iterator {
+	return chunkenc.NewNopIterator()
+}
+
+func (c *AggrChunk) NumSamples() int {
+	x, err := c.nth(0)
+	if err != nil {
+		return 0
 	}
-	ser.add(nextT, max)
+	return x.NumSamples()
+}
+
+// ErrAggrNotExist is returned if a requested aggregation is not present in an AggrChunk.
+var ErrAggrNotExist = errors.New("aggregate does not exist")
+
+// ChunkEncAggr is the top level encoding byte for the AggrChunk.
+// It picks the highest number possible to prevent future collisions with upstream encodings.
+const ChunkEncAggr = chunkenc.Encoding(0xff)
+
+func (c *AggrChunk) Encoding() chunkenc.Encoding {
+	return ChunkEncAggr
+}
+
+// nth returns the nth chunk present in the aggregated chunk.
+func (c *AggrChunk) nth(n uint8) (chunkenc.Chunk, error) {
+	b := c.b[1:]
+	var x []byte
+
+	for i := uint8(0); i <= n; i++ {
+		l, n := binary.Uvarint(b)
+		if n < 1 || len(b[n:]) < int(l)+1 {
+			return nil, errors.New("invalid size")
+		}
+		x = b[n : n+int(l)+1]
+		b = b[n+int(l)+1:]
+	}
+	return chunkenc.FromData(chunkenc.Encoding(x[0]), x[1:])
+}
+
+// position returns at which position the chunk for the type is located.
+func (c *AggrChunk) position(t AggrType) (ok bool, p uint8) {
+	mask := uint8(c.b[0])
+
+	if mask&(1<<(7-t)) == 0 {
+		return false, 0
+	}
+	// In the bit mask we count how many chunk types have their bit set before
+	// the type's own position.
+	for i := int(t) - 1; i >= 0; i-- {
+		p += (mask << uint(i)) >> 7
+	}
+	return true, p
+}
+
+// Get returns the sub-chunk for the given aggregate type if it exists.
+func (c *AggrChunk) Get(t AggrType) (chunkenc.Chunk, error) {
+	ok, p := c.position(t)
+	if !ok {
+		return nil, ErrAggrNotExist
+	}
+	return c.nth(p)
 }
 
 // countChunkSeriesIterator iterates over an ordered sequence of chunks and treats decreasing
@@ -531,6 +682,10 @@ type countChunkSeriesIterator struct {
 	lastT  int64   // timestamp of the last sample
 	lastV  float64 // value of the last sample
 	totalV float64 // total counter state since beginning of series
+}
+
+func newCounterChunkSeriesIterator(its ...chunkenc.Iterator) *countChunkSeriesIterator {
+	return &countChunkSeriesIterator{chks: its}
 }
 
 func (it *countChunkSeriesIterator) Next() bool {
@@ -563,7 +718,6 @@ func (it *countChunkSeriesIterator) Next() bool {
 	// We hit the last sample that indicates what the true last value was. For the
 	// next chunk we use it to determine whether there was a counter reset between them.
 	it.lastT, it.lastV = t, v
-	it.i++
 
 	return it.Next()
 }
@@ -589,4 +743,14 @@ func (it *countChunkSeriesIterator) Err() error {
 		return nil
 	}
 	return it.chks[it.i].Err()
+}
+
+type aggrPool struct{}
+
+func (p aggrPool) Get(e chunkenc.Encoding, b []byte) (chunkenc.Chunk, error) {
+	return &AggrChunk{b: b}, nil
+}
+
+func (p aggrPool) Put(c chunkenc.Chunk) error {
+	return nil
 }

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -3,46 +3,73 @@ package downsample
 import (
 	"context"
 	"io/ioutil"
-	"math"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/prometheus/tsdb/chunks"
+
 	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/testutil"
-	"github.com/prometheus/tsdb"
 	"github.com/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/tsdb/index"
 	"github.com/prometheus/tsdb/labels"
 )
 
+func TestAggrChunk(t *testing.T) {
+	var input [5][]sample
+
+	input[AggrCount] = []sample{{100, 30}, {200, 50}, {300, 60}, {400, 67}}
+	input[AggrSum] = []sample{{100, 130}, {200, 1000}, {300, 2000}, {400, 5555}}
+	input[AggrMin] = []sample{{100, 0}, {200, -10}, {300, 1000}, {400, -9.5}}
+	// Maximum is absent.
+	input[AggrCounter] = []sample{{100, 5}, {200, 10}, {300, 10.1}, {400, 15}, {400, 3}}
+
+	var chks [5]chunkenc.Chunk
+
+	for i, smpls := range input {
+		if len(smpls) == 0 {
+			continue
+		}
+		chks[i] = chunkenc.NewXORChunk()
+		a, err := chks[i].Appender()
+		testutil.Ok(t, err)
+
+		for _, s := range smpls {
+			a.Append(s.t, s.v)
+		}
+	}
+
+	var res [5][]sample
+	ac := EncodeAggrChunk(chks)
+
+	for _, at := range []AggrType{AggrCount, AggrSum, AggrMin, AggrMax, AggrCounter} {
+		if c, err := ac.Get(at); err != ErrAggrNotExist {
+			testutil.Ok(t, err)
+			testutil.Ok(t, expandChunkIterator(c.Iterator(), &res[at]))
+		}
+	}
+	testutil.Equals(t, input, res)
+}
+
+type testAggrSeries struct {
+	lset labels.Labels
+	data map[AggrType][]sample
+}
+
 func TestDownsampleRaw(t *testing.T) {
 	input := []*downsampleTestSet{
 		{
-			input: &testSeries{
-				lset: labels.FromStrings("__name__", "a"),
-				data: []sample{
-					{20, 1}, {40, 2}, {60, 3}, {80, 1}, {100, 2}, {120, 5}, {180, 10}, {250, 1},
-				},
+			lset: labels.FromStrings("__name__", "a"),
+			inRaw: []sample{
+				{20, 1}, {40, 2}, {60, 3}, {80, 1}, {100, 2}, {120, 5}, {180, 10}, {250, 1},
 			},
-			output: []*testSeries{
-
-				{
-					lset: labels.FromStrings("__name__", "a$sum"),
-					data: []sample{{99, 7}, {199, 17}, {299, 1}},
-				}, {
-					lset: labels.FromStrings("__name__", "a$count"),
-					data: []sample{{99, 4}, {199, 3}, {299, 1}},
-				}, {
-					lset: labels.FromStrings("__name__", "a$max"),
-					data: []sample{{99, 3}, {199, 10}, {299, 1}},
-				}, {
-					lset: labels.FromStrings("__name__", "a$min"),
-					data: []sample{{99, 1}, {199, 2}, {299, 1}},
-				}, {
-					lset: labels.FromStrings("__name__", "a$counter"),
-					data: []sample{{99, 4}, {199, 13}, {299, 14}, {299, 1}},
-				},
+			output: map[AggrType][]sample{
+				AggrCount:   {{99, 4}, {199, 3}, {299, 1}},
+				AggrSum:     {{99, 7}, {199, 17}, {299, 1}},
+				AggrMin:     {{99, 1}, {199, 2}, {299, 1}},
+				AggrMax:     {{99, 3}, {199, 10}, {299, 1}},
+				AggrCounter: {{99, 4}, {199, 13}, {299, 14}, {299, 1}},
 			},
 		},
 	}
@@ -52,65 +79,32 @@ func TestDownsampleRaw(t *testing.T) {
 func TestDownsampleAggr(t *testing.T) {
 	input := []*downsampleTestSet{
 		{
-			input: &testSeries{
-				lset: labels.FromStrings("__name__", "a$counter"),
-				data: []sample{
+			lset: labels.FromStrings("__name__", "a"),
+			inAggr: map[AggrType][]sample{
+				AggrCount: []sample{
+					{199, 5}, {299, 1}, {399, 10}, {400, 3}, {499, 10}, {699, 0}, {999, 100},
+				},
+				AggrSum: []sample{
+					{199, 5}, {299, 1}, {399, 10}, {400, 3}, {499, 10}, {699, 0}, {999, 100},
+				},
+				AggrMin: []sample{
+					{199, 5}, {299, 1}, {399, 10}, {400, -3}, {499, 10}, {699, 0}, {999, 100},
+				},
+				AggrMax: []sample{
+					{199, 5}, {299, 1}, {399, 10}, {400, -3}, {499, 10}, {699, 0}, {999, 100},
+				},
+				AggrCounter: []sample{
 					{99, 100}, {299, 150}, {499, 210}, {499, 10}, // chunk 1
 					{599, 20}, {799, 50}, {999, 120}, {999, 50}, // chunk 2, no reset
 					{1099, 40}, {1199, 80}, {1299, 110}, // chunk 3, reset
 				},
 			},
-			output: []*testSeries{
-				{
-					lset: labels.FromStrings("__name__", "a$counter"),
-					data: []sample{
-						{499, 210}, {999, 320}, {1499, 430}, {1499, 110},
-					},
-				},
-			},
-		}, {
-			input: &testSeries{
-				lset: labels.FromStrings("__name__", "a$min"),
-				data: []sample{{199, 5}, {299, 1}, {399, 10}, {400, -3}, {499, 10}, {699, 0}, {999, 100}},
-			},
-			output: []*testSeries{
-				{
-					lset: labels.FromStrings("__name__", "a$min"),
-					data: []sample{{499, -3}, {999, 0}},
-				},
-			},
-		}, {
-			input: &testSeries{
-				lset: labels.FromStrings("__name__", "a$max"),
-				data: []sample{{199, 5}, {299, 1}, {399, 10}, {400, -3}, {499, 10}, {699, 0}, {999, 100}},
-			},
-			output: []*testSeries{
-				{
-					lset: labels.FromStrings("__name__", "a$max"),
-					data: []sample{{499, 10}, {999, 100}},
-				},
-			},
-		}, {
-			input: &testSeries{
-				lset: labels.FromStrings("__name__", "a$sum"),
-				data: []sample{{199, 5}, {299, 1}, {399, 10}, {400, 3}, {499, 10}, {699, 0}, {999, 100}},
-			},
-			output: []*testSeries{
-				{
-					lset: labels.FromStrings("__name__", "a$sum"),
-					data: []sample{{499, 29}, {999, 100}},
-				},
-			},
-		}, {
-			input: &testSeries{
-				lset: labels.FromStrings("__name__", "a$count"),
-				data: []sample{{199, 5}, {299, 1}, {399, 10}, {400, 3}, {499, 10}, {699, 0}, {999, 100}},
-			},
-			output: []*testSeries{
-				{
-					lset: labels.FromStrings("__name__", "a$count"),
-					data: []sample{{499, 29}, {999, 100}},
-				},
+			output: map[AggrType][]sample{
+				AggrCount:   []sample{{499, 29}, {999, 100}},
+				AggrSum:     []sample{{499, 29}, {999, 100}},
+				AggrMin:     []sample{{499, -3}, {999, 0}},
+				AggrMax:     []sample{{499, 10}, {999, 100}},
+				AggrCounter: []sample{{499, 210}, {999, 320}, {1499, 430}, {1499, 110}},
 			},
 		},
 	}
@@ -125,9 +119,22 @@ type testSeries struct {
 	data []sample
 }
 
+func encodeTestAggrSeries(v map[AggrType][]sample) (*AggrChunk, int64, int64) {
+	b := newAggrChunkBuilder(false)
+
+	for at, d := range v {
+		for _, s := range d {
+			b.apps[at].Append(s.t, s.v)
+		}
+	}
+	return b.encode(), b.mint, b.maxt
+}
+
 type downsampleTestSet struct {
-	input  *testSeries
-	output []*testSeries
+	lset   labels.Labels
+	inRaw  []sample
+	inAggr map[AggrType][]sample
+	output map[AggrType][]sample
 }
 
 // testDownsample inserts the input into a block and invokes the downsampler with the given window.
@@ -144,59 +151,90 @@ func testDownsample(t *testing.T, data []*downsampleTestSet, meta *block.Meta, w
 	mb := newMemBlock()
 
 	for _, d := range data {
-		ser := newSeries(d.input.lset, 0)
-		for _, s := range d.input.data {
-			ser.add(s.t, s.v)
-			// Cut a new chunk whenever we cross a 500 boundary.
-			if ser.cmax/500 < s.t/500 {
-				ser.cut()
-			}
+		if len(d.inRaw) > 0 && len(d.inAggr) > 0 {
+			t.Fatalf("test must not have raw and aggregate input data at once")
 		}
-		ser.close()
+		ser := &series{lset: d.lset}
+
+		if len(d.inRaw) > 0 {
+			chk := chunkenc.NewXORChunk()
+			app, _ := chk.Appender()
+
+			for _, s := range d.inRaw {
+				app.Append(s.t, s.v)
+			}
+			ser.chunks = append(ser.chunks, chunks.Meta{
+				MinTime: d.inRaw[0].t,
+				MaxTime: d.inRaw[len(d.inRaw)-1].t,
+				Chunk:   chk,
+			})
+		} else {
+			ac, mint, maxt := encodeTestAggrSeries(d.inAggr)
+
+			ser.chunks = append(ser.chunks, chunks.Meta{
+				MinTime: mint,
+				MaxTime: maxt,
+				Chunk:   ac,
+			})
+		}
 		mb.addSeries(ser)
 	}
 
 	id, err := Downsample(context.Background(), meta, mb, dir, window)
 	testutil.Ok(t, err)
 
-	exp := map[uint64]*testSeries{}
-	got := map[uint64]*testSeries{}
+	exp := map[uint64]map[AggrType][]sample{}
+	got := map[uint64]map[AggrType][]sample{}
 
 	for _, d := range data {
-		for _, ser := range d.output {
-			exp[ser.lset.Hash()] = ser
+		exp[d.lset.Hash()] = d.output
+	}
+	indexr, err := index.NewFileReader(filepath.Join(dir, id.String(), "index"))
+	testutil.Ok(t, err)
+	defer indexr.Close()
+
+	chunkr, err := chunks.NewDirReader(filepath.Join(dir, id.String(), "chunks"), aggrPool{})
+	testutil.Ok(t, err)
+	defer chunkr.Close()
+
+	pall, err := indexr.Postings(index.AllPostingsKey())
+	testutil.Ok(t, err)
+
+	for pall.Next() {
+		id := pall.At()
+
+		var lset labels.Labels
+		var chks []chunks.Meta
+		testutil.Ok(t, indexr.Series(id, &lset, &chks))
+
+		m := map[AggrType][]sample{}
+		got[lset.Hash()] = m
+
+		for _, c := range chks {
+			chk, err := chunkr.Chunk(c.Ref)
+			testutil.Ok(t, err)
+
+			for _, at := range []AggrType{AggrCount, AggrSum, AggrMin, AggrMax, AggrCounter} {
+				c, err := chk.(*AggrChunk).Get(at)
+				if err == ErrAggrNotExist {
+					continue
+				}
+				testutil.Ok(t, err)
+
+				buf := m[at]
+				testutil.Ok(t, expandChunkIterator(c.Iterator(), &buf))
+				m[at] = buf
+			}
 		}
 	}
-
-	b, err := tsdb.OpenBlock(filepath.Join(dir, id.String()), nil)
-	testutil.Ok(t, err)
-
-	q, err := tsdb.NewBlockQuerier(b, 0, math.MaxInt64)
-	testutil.Ok(t, err)
-	defer q.Close()
-
-	set, err := q.Select(labels.NewEqualMatcher(index.AllPostingsKey()))
-	testutil.Ok(t, err)
-
-	for set.Next() {
-		ser := &testSeries{lset: set.At().Labels()}
-		got[ser.lset.Hash()] = ser
-
-		it := set.At().Iterator()
-
-		for it.Next() {
-			t, v := it.At()
-			ser.data = append(ser.data, sample{t, v})
-		}
-		testutil.Ok(t, it.Err())
-	}
-	testutil.Ok(t, set.Err())
 
 	testutil.Equals(t, len(exp), len(got))
 
 	for h, ser := range exp {
-		o := got[h]
-		testutil.Equals(t, ser, o)
+		for _, at := range []AggrType{AggrCount, AggrSum, AggrMin, AggrMax, AggrCounter} {
+			t.Logf("series %d, type %s", h, at)
+			testutil.Equals(t, ser[at], got[h][at])
+		}
 	}
 }
 

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -115,7 +115,7 @@ func TestDownsampleAggr(t *testing.T) {
 		},
 	}
 	var meta block.Meta
-	meta.Thanos.DownsamplingWindow = 10
+	meta.Thanos.Downsample.Window = 10
 
 	testDownsample(t, input, &meta, 500)
 }

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -1,0 +1,260 @@
+package downsample
+
+import (
+	"context"
+	"io/ioutil"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/prometheus/tsdb"
+	"github.com/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/tsdb/index"
+	"github.com/prometheus/tsdb/labels"
+)
+
+func TestDownsampleRaw(t *testing.T) {
+	input := []*downsampleTestSet{
+		{
+			input: &testSeries{
+				lset: labels.FromStrings("__name__", "a"),
+				data: []sample{
+					{20, 1}, {40, 2}, {60, 3}, {80, 1}, {100, 2}, {120, 5}, {180, 10}, {250, 1},
+				},
+			},
+			output: []*testSeries{
+
+				{
+					lset: labels.FromStrings("__name__", "a$sum"),
+					data: []sample{{99, 7}, {199, 17}, {299, 1}},
+				}, {
+					lset: labels.FromStrings("__name__", "a$count"),
+					data: []sample{{99, 4}, {199, 3}, {299, 1}},
+				}, {
+					lset: labels.FromStrings("__name__", "a$max"),
+					data: []sample{{99, 3}, {199, 10}, {299, 1}},
+				}, {
+					lset: labels.FromStrings("__name__", "a$min"),
+					data: []sample{{99, 1}, {199, 2}, {299, 1}},
+				}, {
+					lset: labels.FromStrings("__name__", "a$counter"),
+					data: []sample{{99, 4}, {199, 13}, {299, 14}, {299, 1}},
+				},
+			},
+		},
+	}
+	testDownsample(t, input, &block.Meta{}, 100)
+}
+
+func TestDownsampleAggr(t *testing.T) {
+	input := []*downsampleTestSet{
+		{
+			input: &testSeries{
+				lset: labels.FromStrings("__name__", "a$counter"),
+				data: []sample{
+					{99, 100}, {299, 150}, {499, 210}, {499, 10}, // chunk 1
+					{599, 20}, {799, 50}, {999, 120}, {999, 50}, // chunk 2, no reset
+					{1099, 40}, {1199, 80}, {1299, 110}, // chunk 3, reset
+				},
+			},
+			output: []*testSeries{
+				{
+					lset: labels.FromStrings("__name__", "a$counter"),
+					data: []sample{
+						{499, 210}, {999, 320}, {1499, 430}, {1499, 110},
+					},
+				},
+			},
+		}, {
+			input: &testSeries{
+				lset: labels.FromStrings("__name__", "a$min"),
+				data: []sample{{199, 5}, {299, 1}, {399, 10}, {400, -3}, {499, 10}, {699, 0}, {999, 100}},
+			},
+			output: []*testSeries{
+				{
+					lset: labels.FromStrings("__name__", "a$min"),
+					data: []sample{{499, -3}, {999, 0}},
+				},
+			},
+		}, {
+			input: &testSeries{
+				lset: labels.FromStrings("__name__", "a$max"),
+				data: []sample{{199, 5}, {299, 1}, {399, 10}, {400, -3}, {499, 10}, {699, 0}, {999, 100}},
+			},
+			output: []*testSeries{
+				{
+					lset: labels.FromStrings("__name__", "a$max"),
+					data: []sample{{499, 10}, {999, 100}},
+				},
+			},
+		}, {
+			input: &testSeries{
+				lset: labels.FromStrings("__name__", "a$sum"),
+				data: []sample{{199, 5}, {299, 1}, {399, 10}, {400, 3}, {499, 10}, {699, 0}, {999, 100}},
+			},
+			output: []*testSeries{
+				{
+					lset: labels.FromStrings("__name__", "a$sum"),
+					data: []sample{{499, 29}, {999, 100}},
+				},
+			},
+		}, {
+			input: &testSeries{
+				lset: labels.FromStrings("__name__", "a$count"),
+				data: []sample{{199, 5}, {299, 1}, {399, 10}, {400, 3}, {499, 10}, {699, 0}, {999, 100}},
+			},
+			output: []*testSeries{
+				{
+					lset: labels.FromStrings("__name__", "a$count"),
+					data: []sample{{499, 29}, {999, 100}},
+				},
+			},
+		},
+	}
+	var meta block.Meta
+	meta.Thanos.DownsamplingWindow = 10
+
+	testDownsample(t, input, &meta, 500)
+}
+
+type testSeries struct {
+	lset labels.Labels
+	data []sample
+}
+
+type downsampleTestSet struct {
+	input  *testSeries
+	output []*testSeries
+}
+
+// testDownsample inserts the input into a block and invokes the downsampler with the given window.
+// The chunk ranges within the input block are aligned at 500 time units.
+func testDownsample(t *testing.T, data []*downsampleTestSet, meta *block.Meta, window int64) {
+	t.Helper()
+
+	dir, err := ioutil.TempDir("", "downsample-raw")
+	testutil.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	// Ideally we would use tsdb.HeadBlock here for less dependency on our own code. However,
+	// it cannot accept the counter signal sample with the same timestamp as the previous sample.
+	mb := newMemBlock()
+
+	for _, d := range data {
+		ser := newSeries(d.input.lset, 0)
+		for _, s := range d.input.data {
+			ser.add(s.t, s.v)
+			// Cut a new chunk whenever we cross a 500 boundary.
+			if ser.cmax/500 < s.t/500 {
+				ser.cut()
+			}
+		}
+		ser.close()
+		mb.addSeries(ser)
+	}
+
+	id, err := Downsample(context.Background(), meta, mb, dir, window)
+	testutil.Ok(t, err)
+
+	exp := map[uint64]*testSeries{}
+	got := map[uint64]*testSeries{}
+
+	for _, d := range data {
+		for _, ser := range d.output {
+			exp[ser.lset.Hash()] = ser
+		}
+	}
+
+	b, err := tsdb.OpenBlock(filepath.Join(dir, id.String()), nil)
+	testutil.Ok(t, err)
+
+	q, err := tsdb.NewBlockQuerier(b, 0, math.MaxInt64)
+	testutil.Ok(t, err)
+	defer q.Close()
+
+	set, err := q.Select(labels.NewEqualMatcher(index.AllPostingsKey()))
+	testutil.Ok(t, err)
+
+	for set.Next() {
+		ser := &testSeries{lset: set.At().Labels()}
+		got[ser.lset.Hash()] = ser
+
+		it := set.At().Iterator()
+
+		for it.Next() {
+			t, v := it.At()
+			ser.data = append(ser.data, sample{t, v})
+		}
+		testutil.Ok(t, it.Err())
+	}
+	testutil.Ok(t, set.Err())
+
+	testutil.Equals(t, len(exp), len(got))
+
+	for h, ser := range exp {
+		o := got[h]
+		testutil.Equals(t, ser, o)
+	}
+}
+
+func TestCountChunkSeriesIterator(t *testing.T) {
+	chunks := [][]sample{
+		{{100, 10}, {200, 20}, {300, 10}, {400, 20}, {400, 5}},
+		{{500, 10}, {600, 20}, {700, 30}, {800, 40}, {800, 10}}, // no actual reset
+		{{900, 5}, {1000, 10}, {1100, 15}},                      // actual reset
+		{{1200, 20}, {1300, 40}},                                // no special last sample, no reset
+		{{1400, 30}, {1500, 30}, {1600, 50}},                    // no special last sample, reset
+	}
+	exp := []sample{
+		{100, 10}, {200, 20}, {300, 30}, {400, 40}, {500, 45},
+		{600, 55}, {700, 65}, {800, 75}, {900, 80}, {1000, 85},
+		{1100, 90}, {1200, 95}, {1300, 115}, {1400, 145}, {1500, 145}, {1600, 165},
+	}
+
+	var its []chunkenc.Iterator
+	for _, c := range chunks {
+		its = append(its, newSampleIterator(c))
+	}
+
+	x := countChunkSeriesIterator{chks: its}
+
+	var res []sample
+	for x.Next() {
+		t, v := x.At()
+		res = append(res, sample{t, v})
+	}
+	testutil.Ok(t, x.Err())
+	testutil.Equals(t, exp, res)
+}
+
+type sampleIterator struct {
+	l []sample
+	i int
+}
+
+func newSampleIterator(l []sample) *sampleIterator {
+	return &sampleIterator{l: l, i: -1}
+}
+
+func (it *sampleIterator) Err() error {
+	return nil
+}
+
+func (it *sampleIterator) Next() bool {
+	if it.i >= len(it.l)-1 {
+		return false
+	}
+	it.i++
+	return true
+}
+
+func (it *sampleIterator) Seek(int64) bool {
+	panic("unexpected")
+}
+
+func (it *sampleIterator) At() (t int64, v float64) {
+	return it.l[it.i].t, it.l[it.i].v
+}

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -109,7 +109,7 @@ func TestDownsampleAggr(t *testing.T) {
 		},
 	}
 	var meta block.Meta
-	meta.Thanos.Downsample.Window = 10
+	meta.Thanos.Downsample.Resolution = 10
 
 	testDownsample(t, input, &meta, 500)
 }
@@ -137,9 +137,9 @@ type downsampleTestSet struct {
 	output map[AggrType][]sample
 }
 
-// testDownsample inserts the input into a block and invokes the downsampler with the given window.
+// testDownsample inserts the input into a block and invokes the downsampler with the given resolution.
 // The chunk ranges within the input block are aligned at 500 time units.
-func testDownsample(t *testing.T, data []*downsampleTestSet, meta *block.Meta, window int64) {
+func testDownsample(t *testing.T, data []*downsampleTestSet, meta *block.Meta, resolution int64) {
 	t.Helper()
 
 	dir, err := ioutil.TempDir("", "downsample-raw")
@@ -180,7 +180,7 @@ func testDownsample(t *testing.T, data []*downsampleTestSet, meta *block.Meta, w
 		mb.addSeries(ser)
 	}
 
-	id, err := Downsample(context.Background(), meta, mb, dir, window)
+	id, err := Downsample(context.Background(), meta, mb, dir, resolution)
 	testutil.Ok(t, err)
 
 	exp := map[uint64]map[AggrType][]sample{}


### PR DESCRIPTION
This implements, as discussed a special chunk type for aggregations. This prevents blow up of series count and index size on downsampling. It also makes subsequent handling of aggregated data easier, since for some queries we have to match and align different aggregates, e.g. sum and count to compute an average series.

This also addresses comments from the original PR #176 
All other work that was done for downsampling should be rebased onto this.

@Bplotka let me know whether you want to review it as the delta against #176 or whether I should file it against master.