### PR TITLE
test: fix Alertmanager flags

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -352,6 +352,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bfd3228e097c9fdafc38387fdb09c8c4de5ec8c7f3155f85b5fce3ef3345368c"
+  inputs-digest = "79377894d44bee626f58fd0358d903633d6686033749705ce27d009fb6c3e4c9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -171,9 +171,9 @@ receivers:
 			return nil, errors.Wrap(err, "creating alertmanager config file failed")
 		}
 		commands = append(commands, exec.Command("alertmanager",
-			"-config.file", dir+"/config.yaml",
-			"-web.listen-address", "127.0.0.1:29093",
-			"-log.level", "debug",
+			"--config.file", dir+"/config.yaml",
+			"--web.listen-address", "127.0.0.1:29093",
+			"--log.level", "debug",
 		))
 	}
 


### PR DESCRIPTION
Upstream changed the flag library. 

PR for visibility. Will merge straight away to fix broken builds on other PRs.