### PR TITLE
downsample: fix various issues

### DIFF
--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -125,7 +125,7 @@ type testSeries struct {
 }
 
 func encodeTestAggrSeries(v map[AggrType][]sample) (AggrChunk, int64, int64) {
-	b := newAggrChunkBuilder(false)
+	b := newAggrChunkBuilder()
 
 	for at, d := range v {
 		for _, s := range d {


### PR DESCRIPTION
These changes contain:

* Simplified the aggregate chunk serilization format – it was to complex for little benefit. Now we just  set the sub-chunk length to 0 if we want to signal an aggregate is omitted
* We don't omit chunks anymore for now regardless. Always generate all aggregates
* Ensure mint/maxt are set on aggregate-of-aggregate chunks
* Add AverageChunkIterator to combine sum/count chunks into a stream of averages
* Properly handle the Stale NaN signal samples
* Skip over samples that go back in time