### PR TITLE
query: Moved away from querier params passed by context.

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -125,8 +125,8 @@ func runQuery(
 	var (
 		stores    = newStoreSet(logger, reg, tracer, peer, storeAddrs)
 		proxy     = store.NewProxyStore(logger, stores.Get, selectorLset)
-		queryable = query.NewQueryable(logger, proxy, replicaLabel)
 		engine    = promql.NewEngine(logger, reg, maxConcurrentQueries, queryTimeout)
+		queryableCreator = query.NewQueryableCreator(logger, proxy, replicaLabel)
 	)
 	// Periodically update the store set with the addresses we see in our cluster.
 	{
@@ -158,7 +158,7 @@ func runQuery(
 		router := route.New()
 		ui.New(logger, nil).Register(router)
 
-		api := v1.NewAPI(reg, engine, queryable)
+		api := v1.NewAPI(reg, engine, queryableCreator)
 		api.Register(router.WithPrefix("/api/v1"), tracer, logger)
 
 		mux := http.NewServeMux()

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -123,9 +123,9 @@ func runQuery(
 	storeAddrs []string,
 ) error {
 	var (
-		stores    = newStoreSet(logger, reg, tracer, peer, storeAddrs)
-		proxy     = store.NewProxyStore(logger, stores.Get, selectorLset)
-		engine    = promql.NewEngine(logger, reg, maxConcurrentQueries, queryTimeout)
+		stores           = newStoreSet(logger, reg, tracer, peer, storeAddrs)
+		proxy            = store.NewProxyStore(logger, stores.Get, selectorLset)
+		engine           = promql.NewEngine(logger, reg, maxConcurrentQueries, queryTimeout)
 		queryableCreator = query.NewQueryableCreator(logger, proxy, replicaLabel)
 	)
 	// Periodically update the store set with the addresses we see in our cluster.

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -348,8 +348,8 @@ func (api *API) labelValues(r *http.Request) (interface{}, []error, *apiError) {
 	}
 
 	var (
-		warnmtx             sync.Mutex
-		warnings            []error
+		warnmtx  sync.Mutex
+		warnings []error
 	)
 	partialErrReporter := func(err error) {
 		warnmtx.Lock()

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -96,8 +96,8 @@ type apiFunc func(r *http.Request) (interface{}, []error, *apiError)
 // API can register a set of endpoints in a router and handle
 // them using the provided storage and query engine.
 type API struct {
-	queryable   storage.Queryable
-	queryEngine *promql.Engine
+	queryableCreate query.QueryableCreator
+	queryEngine     *promql.Engine
 
 	instantQueryDuration prometheus.Histogram
 	rangeQueryDuration   prometheus.Histogram
@@ -109,7 +109,7 @@ type API struct {
 func NewAPI(
 	reg *prometheus.Registry,
 	qe *promql.Engine,
-	q storage.Queryable,
+	c query.QueryableCreator,
 ) *API {
 	instantQueryDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "thanos_query_api_instant_query_duration_seconds",
@@ -132,7 +132,7 @@ func NewAPI(
 	)
 	return &API{
 		queryEngine:          qe,
-		queryable:            q,
+		queryableCreate:      c,
 		instantQueryDuration: instantQueryDuration,
 		rangeQueryDuration:   rangeQueryDuration,
 		now:                  time.Now,
@@ -199,39 +199,37 @@ func (api *API) query(r *http.Request) (interface{}, []error, *apiError) {
 		defer cancel()
 	}
 
-	var opts []query.Option
-	// Allow disabling deduplication on demand.
-	if dedup := r.FormValue("dedup"); dedup != "" {
-		enableDeduplication, err := strconv.ParseBool(dedup)
-		if err != nil {
-			return nil, nil, &apiError{errorBadData, errors.Wrap(err, "'dedup' parameter")}
-		}
-		if enableDeduplication {
-			opts = append(opts, query.WithDeduplication())
-		}
-	}
 	var (
-		warnmtx  sync.Mutex
-		warnings []error
+		warnmtx             sync.Mutex
+		warnings            []error
+		enableDeduplication bool
 	)
-	opts = append(opts, query.WithPartialErrReporter(func(err error) {
+	partialErrReporter := func(err error) {
 		warnmtx.Lock()
 		warnings = append(warnings, err)
 		warnmtx.Unlock()
-	}))
+	}
+
+	// Allow disabling deduplication on demand.
+	if dedup := r.FormValue("dedup"); dedup != "" {
+		var err error
+		enableDeduplication, err = strconv.ParseBool(dedup)
+		if err != nil {
+			return nil, nil, &apiError{errorBadData, errors.Wrap(err, "'dedup' parameter")}
+		}
+	}
 
 	// We are starting promQL tracing span here, because we have no control over promQL code.
 	span, ctx := tracing.StartSpan(r.Context(), "promql_instant_query")
 	defer span.Finish()
 
 	begin := api.now()
-	qry, err := api.queryEngine.NewInstantQuery(api.queryable, r.FormValue("query"), ts)
+	qry, err := api.queryEngine.NewInstantQuery(api.queryableCreate(enableDeduplication, partialErrReporter), r.FormValue("query"), ts)
 	if err != nil {
 		return nil, nil, &apiError{errorBadData, err}
 	}
 
-	// TODO(Bplotka): Add proper query.PartialErrorReporter to opts when UI is ready.
-	res := qry.Exec(query.ContextWithOpts(ctx, opts...))
+	res := qry.Exec(ctx)
 	if res.Err != nil {
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:
@@ -293,39 +291,37 @@ func (api *API) queryRange(r *http.Request) (interface{}, []error, *apiError) {
 		defer cancel()
 	}
 
-	var opts []query.Option
-	// Allow disabling deduplication on demand.
-	if dedup := r.FormValue("dedup"); dedup != "" {
-		enableDeduplication, err := strconv.ParseBool(dedup)
-		if err != nil {
-			return nil, nil, &apiError{errorBadData, errors.Wrap(err, "'dedup' parameter")}
-		}
-		if enableDeduplication {
-			opts = append(opts, query.WithDeduplication())
-		}
-	}
 	var (
-		warnmtx  sync.Mutex
-		warnings []error
+		warnmtx             sync.Mutex
+		warnings            []error
+		enableDeduplication bool
 	)
-	opts = append(opts, query.WithPartialErrReporter(func(err error) {
+	partialErrReporter := func(err error) {
 		warnmtx.Lock()
 		warnings = append(warnings, err)
 		warnmtx.Unlock()
-	}))
+	}
+
+	// Allow disabling deduplication on demand.
+	if dedup := r.FormValue("dedup"); dedup != "" {
+		var err error
+		enableDeduplication, err = strconv.ParseBool(dedup)
+		if err != nil {
+			return nil, nil, &apiError{errorBadData, errors.Wrap(err, "'dedup' parameter")}
+		}
+	}
 
 	// We are starting promQL tracing span here, because we have no control over promQL code.
 	span, ctx := tracing.StartSpan(r.Context(), "promql_range_query")
 	defer span.Finish()
 
 	begin := api.now()
-	qry, err := api.queryEngine.NewRangeQuery(api.queryable, r.FormValue("query"), start, end, step)
+	qry, err := api.queryEngine.NewRangeQuery(api.queryableCreate(enableDeduplication, partialErrReporter), r.FormValue("query"), start, end, step)
 	if err != nil {
 		return nil, nil, &apiError{errorBadData, err}
 	}
 
-	// TODO(Bplotka): Add proper query.PartialErrorReporter to opts when UI is ready.
-	res := qry.Exec(query.ContextWithOpts(ctx, opts...))
+	res := qry.Exec(ctx)
 	if res.Err != nil {
 		switch res.Err.(type) {
 		case promql.ErrQueryCanceled:
@@ -350,17 +346,18 @@ func (api *API) labelValues(r *http.Request) (interface{}, []error, *apiError) {
 	if !model.LabelNameRE.MatchString(name) {
 		return nil, nil, &apiError{errorBadData, fmt.Errorf("invalid label name: %q", name)}
 	}
+
 	var (
-		warnmtx  sync.Mutex
-		warnings []error
+		warnmtx             sync.Mutex
+		warnings            []error
 	)
-	ctx = query.ContextWithOpts(ctx, query.WithPartialErrReporter(func(err error) {
+	partialErrReporter := func(err error) {
 		warnmtx.Lock()
 		warnings = append(warnings, err)
 		warnmtx.Unlock()
-	}))
+	}
 
-	q, err := api.queryable.Querier(ctx, math.MinInt64, math.MaxInt64)
+	q, err := api.queryableCreate(true, partialErrReporter).Querier(ctx, math.MinInt64, math.MaxInt64)
 	if err != nil {
 		return nil, nil, &apiError{errorExec, err}
 	}
@@ -418,30 +415,27 @@ func (api *API) series(r *http.Request) (interface{}, []error, *apiError) {
 		matcherSets = append(matcherSets, matchers)
 	}
 
-	var opts []query.Option
-	// Allow disabling deduplication on demand.
-	if dedup := r.FormValue("dedup"); dedup != "" {
-		enableDeduplication, err := strconv.ParseBool(r.FormValue("dedup"))
-		if err != nil {
-			return nil, nil, &apiError{errorBadData, errors.Wrap(err, "'dedup' parameter")}
-		}
-		if enableDeduplication {
-			opts = append(opts, query.WithDeduplication())
-		}
-	}
 	var (
-		warnmtx  sync.Mutex
-		warnings []error
+		warnmtx             sync.Mutex
+		warnings            []error
+		enableDeduplication bool
 	)
-	opts = append(opts, query.WithPartialErrReporter(func(err error) {
+	partialErrReporter := func(err error) {
 		warnmtx.Lock()
 		warnings = append(warnings, err)
 		warnmtx.Unlock()
-	}))
-	ctx := query.ContextWithOpts(r.Context(), opts...)
+	}
 
-	// TODO(Bplotka): Add proper query.PartialErrorReporter to opts when UI is ready.
-	q, err := api.queryable.Querier(ctx, timestamp.FromTime(start), timestamp.FromTime(end))
+	// Allow disabling deduplication on demand.
+	if dedup := r.FormValue("dedup"); dedup != "" {
+		var err error
+		enableDeduplication, err = strconv.ParseBool(dedup)
+		if err != nil {
+			return nil, nil, &apiError{errorBadData, errors.Wrap(err, "'dedup' parameter")}
+		}
+	}
+
+	q, err := api.queryableCreate(enableDeduplication, partialErrReporter).Querier(r.Context(), timestamp.FromTime(start), timestamp.FromTime(end))
 	if err != nil {
 		return nil, nil, &apiError{errorExec, err}
 	}

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -28,7 +28,7 @@ func TestQuerier_Series(t *testing.T) {
 
 	// Querier clamps the range to [1,300], which should drop some samples of the result above.
 	// The store API allows endpoints to send more data then initially requested.
-	q := newQuerier(context.Background(), nil, 1, 300, "", testProxy)
+	q := newQuerier(context.Background(), nil, 1, 300, "", testProxy, false, nil)
 	defer q.Close()
 
 	res, err := q.Select(&storage.SelectParams{})


### PR DESCRIPTION
This is stil weird since Queryable should be a base not per request, but this is better than context hack we had.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>