### PR TITLE
Simplify compactor and respect resolutions

### DIFF
--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -83,7 +83,7 @@ func runBucketCheck(logger log.Logger, bkt objstore.Bucket, repair bool) error {
 	for _, id := range all {
 		level.Info(logger).Log("msg", "verify block", "id", id)
 
-		if err := verifyBlock(ctx, bkt, id); err != nil {
+		if err = verifyBlock(ctx, bkt, id); err != nil {
 			level.Warn(logger).Log("msg", "detected issue", "id", id, "err", err)
 		}
 		if err == nil || !repair {

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -418,7 +418,7 @@ func newGroup(
 
 // Key returns an identifier for the group.
 func (cg *Group) Key() string {
-	return fmt.Sprintf("%s@%d", cg.labels, cg.resolution)
+	return fmt.Sprintf("%d@%s", cg.resolution, cg.labels)
 }
 
 // Add the block with the given meta to the group.

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -1,9 +1,11 @@
 package compact
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -35,50 +37,45 @@ func TestSyncer_SyncMetas(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
-	randr := rand.New(rand.NewSource(0))
+	sy, err := NewSyncer(nil, nil, bkt, 0)
+	testutil.Ok(t, err)
 
-	// Generate 15 blocks. Initially the first 10 are on disk and the last
+	// Generate 15 blocks. Initially the first 10 are synced into memory and only the last
 	// 10 are in the bucket.
-	// After starting the Syncer, the first 10 should be loaded.
 	// After the first synchronization the first 5 should be dropped and the
 	// last 5 be loaded from the bucket.
 	var ids []ulid.ULID
-	var bdirs []string
+	var metas []*block.Meta
 
 	for i := 0; i < 15; i++ {
-		id, err := ulid.New(uint64(i), randr)
+		id, err := ulid.New(uint64(i), nil)
 		testutil.Ok(t, err)
-
-		bdir := filepath.Join(dir, id.String())
-		bdirs = append(bdirs, bdir)
-		ids = append(ids, id)
 
 		var meta block.Meta
 		meta.Version = 1
 		meta.ULID = id
 
-		testutil.Ok(t, os.MkdirAll(bdir, 0777))
-		testutil.Ok(t, block.WriteMetaFile(bdir, &meta))
+		if i < 10 {
+			sy.blocks[id] = &meta
+		}
+		ids = append(ids, id)
+		metas = append(metas, &meta)
 	}
-	for i, id := range ids[5:] {
-		testutil.Ok(t, objstore.UploadDir(ctx, bkt, bdirs[i+5], id.String()))
-	}
-	for _, d := range bdirs[10:] {
-		testutil.Ok(t, os.RemoveAll(d))
+	for _, m := range metas[5:] {
+		var buf bytes.Buffer
+		testutil.Ok(t, json.NewEncoder(&buf).Encode(&m))
+		testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), "meta.json"), &buf))
 	}
 
-	sy, err := NewSyncer(nil, nil, dir, bkt, 0)
+	groups, err := sy.Groups()
 	testutil.Ok(t, err)
-
-	got, err := sy.Groups()[0].IDs()
-	testutil.Ok(t, err)
-	testutil.Equals(t, ids[:10], got)
+	testutil.Equals(t, ids[:10], groups[0].IDs())
 
 	testutil.Ok(t, sy.SyncMetas(ctx))
 
-	got, err = sy.Groups()[0].IDs()
+	groups, err = sy.Groups()
 	testutil.Ok(t, err)
-	testutil.Equals(t, ids[5:], got)
+	testutil.Equals(t, ids[5:], groups[0].IDs())
 }
 
 // TODO(bplotka): Add leaktest when this is done: https://github.com/improbable-eng/thanos/issues/234
@@ -96,73 +93,63 @@ func TestSyncer_GarbageCollect(t *testing.T) {
 
 	// Generate 10 source block metas and construct higher level blocks
 	// that are higher compactions of them.
-	randr := rand.New(rand.NewSource(0))
 	var metas []*block.Meta
 	var ids []ulid.ULID
 
 	for i := 0; i < 10; i++ {
 		var m block.Meta
 
-		id, err := ulid.New(0, randr)
-		testutil.Ok(t, err)
-
 		m.Version = 1
-		m.ULID = id
-		m.Compaction.Sources = []ulid.ULID{id}
+		m.ULID = ulid.MustNew(uint64(i), nil)
+		m.Compaction.Sources = []ulid.ULID{m.ULID}
 		m.Compaction.Level = 1
 
-		ids = append(ids, id)
+		ids = append(ids, m.ULID)
 		metas = append(metas, &m)
 	}
 
-	id1, err := ulid.New(100, randr)
-	testutil.Ok(t, err)
-
 	var m1 block.Meta
 	m1.Version = 1
-	m1.ULID = id1
+	m1.ULID = ulid.MustNew(100, nil)
 	m1.Compaction.Level = 2
 	m1.Compaction.Sources = ids[:4]
-
-	id2, err := ulid.New(200, randr)
-	testutil.Ok(t, err)
+	m1.Thanos.Downsample.Resolution = 0
 
 	var m2 block.Meta
 	m2.Version = 1
-	m2.ULID = id2
+	m2.ULID = ulid.MustNew(200, nil)
 	m2.Compaction.Level = 2
 	m2.Compaction.Sources = ids[4:8] // last two source IDs is not part of a level 2 block.
-
-	id3, err := ulid.New(300, randr)
-	testutil.Ok(t, err)
+	m2.Thanos.Downsample.Resolution = 0
 
 	var m3 block.Meta
 	m3.Version = 1
-	m3.ULID = id3
+	m3.ULID = ulid.MustNew(300, nil)
 	m3.Compaction.Level = 3
 	m3.Compaction.Sources = ids[:9] // last source ID is not part of level 3 block.
+	m3.Thanos.Downsample.Resolution = 0
 
-	metas = append(metas, &m1, &m2, &m3)
+	var m4 block.Meta
+	m4.Version = 14
+	m4.ULID = ulid.MustNew(400, nil)
+	m4.Compaction.Level = 2
+	m4.Compaction.Sources = ids[9:] // covers the last block but is a different resolution. Must not trigger deletion.
+	m4.Thanos.Downsample.Resolution = 1000
 
 	// Create all blocks in the bucket.
-	for _, m := range metas {
-		bdir := filepath.Join(dir, m.ULID.String())
-		testutil.Ok(t, os.MkdirAll(bdir, 0777))
-		testutil.Ok(t, block.WriteMetaFile(bdir, m))
-		testutil.Ok(t, objstore.UploadFile(ctx, bkt,
-			path.Join(bdir, "meta.json"),
-			path.Join(m.ULID.String(), "meta.json")))
+	for _, m := range append(metas, &m1, &m2, &m3, &m4) {
+		fmt.Println("create", m.ULID)
+		var buf bytes.Buffer
+		testutil.Ok(t, json.NewEncoder(&buf).Encode(&m))
+		testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), "meta.json"), &buf))
 	}
 
 	// Do one initial synchronization with the bucket.
-	sy, err := NewSyncer(nil, nil, dir, bkt, 0)
+	sy, err := NewSyncer(nil, nil, bkt, 0)
 	testutil.Ok(t, err)
 	testutil.Ok(t, sy.SyncMetas(ctx))
 
 	testutil.Ok(t, sy.GarbageCollect(ctx))
-
-	// Only the level 3 block and the last source block should be left.
-	exp := []ulid.ULID{metas[9].ULID, metas[12].ULID}
 
 	var rem []ulid.ULID
 	err = bkt.Iter(ctx, "", func(n string) error {
@@ -174,14 +161,20 @@ func TestSyncer_GarbageCollect(t *testing.T) {
 	sort.Slice(rem, func(i, j int) bool {
 		return rem[i].Compare(rem[j]) < 0
 	})
-	testutil.Equals(t, exp, rem)
+	// Only the level 3 block, the last source block in both resolutions should be left.
+	testutil.Equals(t, []ulid.ULID{metas[9].ULID, m3.ULID, m4.ULID}, rem)
 
 	// After another sync the changes should also be reflected in the local groups.
 	testutil.Ok(t, sy.SyncMetas(ctx))
 
-	rem, err = sy.Groups()[0].IDs()
+	// Only the level 3 block, the last source block in both resolutions should be left.
+	groups, err := sy.Groups()
 	testutil.Ok(t, err)
-	testutil.Equals(t, exp, rem)
+
+	testutil.Equals(t, "{}@0", groups[0].Key())
+	testutil.Equals(t, []ulid.ULID{metas[9].ULID, m3.ULID}, groups[0].IDs())
+	testutil.Equals(t, "{}@1000", groups[1].Key())
+	testutil.Equals(t, []ulid.ULID{m4.ULID}, groups[1].IDs())
 }
 
 // TODO(bplotka): Add leaktest when this is done: https://github.com/improbable-eng/thanos/issues/234
@@ -226,13 +219,13 @@ func TestGroup_Compact(t *testing.T) {
 	testutil.Ok(t, objstore.UploadDir(ctx, bkt, filepath.Join(dir, b2.String()), b2.String()))
 	testutil.Ok(t, objstore.UploadDir(ctx, bkt, filepath.Join(dir, b3.String()), b3.String()))
 
-	g, err := newGroup(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, nil)
+	g, err := newGroup(nil, nil, bkt, nil, 0)
 	testutil.Ok(t, err)
 
 	comp, err := tsdb.NewLeveledCompactor(nil, log.NewLogfmtLogger(os.Stderr), []int64{1000, 3000}, nil)
 	testutil.Ok(t, err)
 
-	id, err := g.Compact(ctx, comp)
+	id, err := g.Compact(ctx, dir, comp)
 	testutil.Ok(t, err)
 	testutil.Assert(t, id != ulid.ULID{}, "no compaction took place")
 

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -171,9 +171,9 @@ func TestSyncer_GarbageCollect(t *testing.T) {
 	groups, err := sy.Groups()
 	testutil.Ok(t, err)
 
-	testutil.Equals(t, "{}@0", groups[0].Key())
+	testutil.Equals(t, "0@{}", groups[0].Key())
 	testutil.Equals(t, []ulid.ULID{metas[9].ULID, m3.ULID}, groups[0].IDs())
-	testutil.Equals(t, "{}@1000", groups[1].Key())
+	testutil.Equals(t, "1000@{}", groups[1].Key())
 	testutil.Equals(t, []ulid.ULID{m4.ULID}, groups[1].IDs())
 }
 


### PR DESCRIPTION
This extends the compactor to consider downsample resolutions to the compaction grouping. With this it is safe to run the compactor against a bucket with data of different resolutions.

Furthermore #183 is likely to be cased by semantical races in the compactor. The PR drastically simplifies the logic and gets rid of any disk caching of meta.json files and just rebuilds groupings on demand. It is very unlikely that this has any noticable performance impact.