### PR TITLE
main: downsample in compactor, exit on complete

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -434,6 +434,10 @@ func (cg *Group) Compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 		return ulid.ULID{}, errors.Wrap(err, "create compaction dir")
 	}
 
+	if err := os.MkdirAll(dir, 0777); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "create compaction dir")
+	}
+
 	id, err := cg.compact(ctx, dir, comp)
 	if err != nil {
 		cg.compactionFailures.Inc()

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -433,11 +433,6 @@ func (cg *Group) Compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		return ulid.ULID{}, errors.Wrap(err, "create compaction dir")
 	}
-
-	if err := os.MkdirAll(dir, 0777); err != nil {
-		return ulid.ULID{}, errors.Wrap(err, "create compaction dir")
-	}
-
 	id, err := cg.compact(ctx, dir, comp)
 	if err != nil {
 		cg.compactionFailures.Inc()


### PR DESCRIPTION
This adds a downsampling pass after all compaction work has been done.
By default the compactor will exit now after all compactions and
downsamplings completed, which makes deployment as a batch job easy.
The `--wait` flag restores previous behavior where the process keeps
running and waiting for new work.