### PR TITLE
docs: Recommend `go get` with `-d` flag to just download thanos.

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -14,6 +14,7 @@ The following examples configure Thanos to work against a Google Cloud Storage b
 Thanos has no official releases yet. With a working installation of the Go toolchain, Thanos can be downloaded and built by running
 
 ```
+export PATH=${GOPATH}/bin:${PATH} # Make sure go/bin is in your PATH.
 go get -d github.com/improbable-eng/thanos/...
 make
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -14,7 +14,7 @@ The following examples configure Thanos to work against a Google Cloud Storage b
 Thanos has no official releases yet. With a working installation of the Go toolchain, Thanos can be downloaded and built by running
 
 ```
-go get github.com/improbable-eng/thanos/...
+go get -d github.com/improbable-eng/thanos/...
 make
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,10 +11,9 @@ The following examples configure Thanos to work against a Google Cloud Storage b
 
 ## Get Thanos!
 
-Thanos has no official releases yet. With a working installation of the Go toolchain, Thanos can be downloaded and built by running
+Thanos has no official releases yet. With a working installation of the Go toolchain (`GOPATH`, `PATH=${GOPATH}/bin:${PATH}`, etc), Thanos can be downloaded and built by running:
 
 ```
-export PATH=${GOPATH}/bin:${PATH} # Make sure go/bin is in your PATH.
 go get -d github.com/improbable-eng/thanos/...
 make
 ```


### PR DESCRIPTION
 We need `dep ensure` first to make sure we have right dependencies.

This should solve https://github.com/improbable-eng/thanos/issues/203 @V3ckt0r