### PR TITLE
updated hash for prometheus@queryparams

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -257,7 +257,7 @@
   branch = "queryparams"
   name = "github.com/prometheus/prometheus"
   packages = ["pkg/labels","pkg/rulefmt","pkg/textparse","pkg/timestamp","pkg/value","promql","rules","storage","storage/tsdb","template","util/stats","util/strutil","util/testutil"]
-  revision = "126770e81fa24752b30cbcde54cb96d95b243ea5"
+  revision = "0c998d511934e8ab89c5baac0f50ea8833797533"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Raising this to fix build issue with `dep ensure` failing in CI build:

```
 dep ensure
grouped write of manifest, lock and vendor: error while writing out vendor tree: failed to write dep tree: failed to export github.com/prometheus/prometheus: fatal: failed to unpack tree object 126770e81fa24752b30cbcde54cb96d95b243ea5
: exit status 128
```