### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-- 1.9.x
+- 1.10.x
 - master
 
 go_import_path: github.com/improbable-eng/thanos


### PR DESCRIPTION
CI is failing because something got merged Prometheus upstream that's using Go 1.10 features.