### PR TITLE
Make GCS bucket optional where S3 bucket supported

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -34,7 +34,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 		Default("./data").String()
 
 	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks.").
-		PlaceHolder("<bucket>").Required().String()
+		PlaceHolder("<bucket>").String()
 
 	s3Bucket := cmd.Flag("s3.bucket", "S3-Compatible API bucket name for stored blocks.").
 		PlaceHolder("<bucket>").Envar("S3_BUCKET").String()

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -39,7 +39,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 		Default("./data").String()
 
 	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks. If empty sidecar won't store any block inside Google Cloud Storage").
-		PlaceHolder("<bucket>").Required().String()
+		PlaceHolder("<bucket>").String()
 
 	s3Bucket := cmd.Flag("s3.bucket", "S3-Compatible API bucket name for stored blocks.").
 		PlaceHolder("<bucket>").Envar("S3_BUCKET").String()


### PR DESCRIPTION
For commands that support use of an S3 bucket (not all do), make the GCS
bucket flag optional.

Otherwise, Thanos fails to start because `--gcs.bucket` is not set.