### PR TITLE
Support binding to any IPv6 interface

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -33,9 +33,9 @@ import (
 )
 
 const (
-	defaultClusterAddr = "0.0.0.0:10900"
-	defaultGRPCAddr    = "0.0.0.0:10901"
-	defaultHTTPAddr    = "0.0.0.0:10902"
+	defaultClusterAddr = ":10900"
+	defaultGRPCAddr    = ":10901"
+	defaultHTTPAddr    = ":10902"
 )
 
 type setupFunc func(*run.Group, log.Logger, *prometheus.Registry, opentracing.Tracer) error

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -32,7 +32,7 @@ Flags:
                              If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
                              How often we send traces (1/<sample-factor>).
-      --http-address="0.0.0.0:10902"  
+      --http-address=":10902"  
                              listen host:port for HTTP endpoints
       --data-dir="./data"    data directory to cache blocks and process
                              compactions

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -8,7 +8,7 @@ This can either be a repeated list of peer addresses or a DNS name, which it wil
 
 ```
 $ thanos query \
-    --http-address     "0.0.0.0:9090" \
+    --http-address     ":9090" \
     --cluster.peers    "thanos-cluster.example.org" \
 ```
 
@@ -19,7 +19,7 @@ Two or more series that have that are only distinguished by the given replica la
 
 ```
 $ thanos query \
-    --http-address     "0.0.0.0:9090" \
+    --http-address     ":9090" \
     --replica-label    "replica" \
     --cluster.peers    "thanos-cluster.example.org" \
 ```
@@ -45,7 +45,7 @@ Flags:
                                  to. If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
                                  How often we send traces (1/<sample-factor>).
-      --http-address="0.0.0.0:10902"  
+      --http-address=":10902"  
                                  listen host:port for HTTP endpoints
       --query.timeout=2m         maximum time to process query by query node
       --query.max-concurrent=20  maximum number of queries processed
@@ -58,7 +58,7 @@ Flags:
       --cluster.peers=CLUSTER.PEERS ...  
                                  initial peers to join the cluster. It can be
                                  either <ip:port>, or <domain:port>
-      --cluster.address="0.0.0.0:10900"  
+      --cluster.address=":10900"  
                                  listen address for cluster
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
                                  explicit address to advertise in cluster

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -47,9 +47,9 @@ Flags:
       --data-dir="data/"        data directory
       --rule-file=rules/ ...    rule files that should be used by rule manager.
                                 Can be in glob format (repeated)
-      --http-address="0.0.0.0:10902"  
+      --http-address=":10902"  
                                 listen host:port for HTTP endpoints
-      --grpc-address="0.0.0.0:10901"  
+      --grpc-address=":10901"  
                                 listen host:port for gRPC endpoints
       --eval-interval=30s       the default evaluation interval to use
       --tsdb.block-duration=2h  block duration for TSDB block
@@ -67,7 +67,7 @@ Flags:
       --cluster.peers=CLUSTER.PEERS ...  
                                 initial peers to join the cluster. It can be
                                 either <ip:port>, or <domain:port>
-      --cluster.address="0.0.0.0:10900"  
+      --cluster.address=":10900"  
                                 listen address for cluster
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
                                 explicit address to advertise in cluster

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -39,9 +39,9 @@ Flags:
                              If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
                              How often we send traces (1/<sample-factor>).
-      --grpc-address="0.0.0.0:10901"  
+      --grpc-address=":10901"  
                              listen address for gRPC endpoints
-      --http-address="0.0.0.0:10902"  
+      --http-address=":10902"  
                              listen address for HTTP endpoints
       --prometheus.url=http://localhost:9090  
                              URL at which to reach Prometheus's API
@@ -52,7 +52,7 @@ Flags:
       --cluster.peers=CLUSTER.PEERS ...  
                              initial peers to join the cluster. It can be either
                              <ip:port>, or <domain:port>
-      --cluster.address="0.0.0.0:10900"  
+      --cluster.address=":10900"  
                              listen address for cluster
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
                              explicit address to advertise in cluster

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -31,9 +31,9 @@ Flags:
                                 to. If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
                                 How often we send traces (1/<sample-factor>).
-      --grpc-address="0.0.0.0:10901"  
+      --grpc-address=":10901"  
                                 listen address for gRPC endpoints
-      --http-address="0.0.0.0:10902"  
+      --http-address=":10902"  
                                 listen address for HTTP endpoints
       --tsdb.path="./data"      data directory of TSDB
       --gcs.bucket=<bucket>     Google Cloud Storage bucket name for stored
@@ -45,7 +45,7 @@ Flags:
       --cluster.peers=CLUSTER.PEERS ...  
                                 initial peers to join the cluster. It can be
                                 either <ip:port>, or <domain:port>
-      --cluster.address="0.0.0.0:10900"  
+      --cluster.address=":10900"  
                                 listen address for clutser
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
                                 explicit address to advertise in cluster

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -93,7 +93,7 @@ It implements Prometheus's official HTTP API and can thus seamlessly be used wit
 
 ```
 thanos query \
-    --http-address "0.0.0.0:19092" \         # Endpoint for the UI
+    --http-address ":19092" \         # Endpoint for the UI
     --cluster.peers all.thanos.internal.org  # Discovery of initial cluster peers
 ```
 
@@ -103,7 +103,7 @@ Providing the label name to the query component will enable the deduplication.
 
 ```
 thanos query \
-    --http-address "0.0.0.0:19092" \
+    --http-address ":19092" \
     --cluster.peers all.thanos.internal.org \
     --replica-label replica
 ```

--- a/pkg/cluster/advertise.go
+++ b/pkg/cluster/advertise.go
@@ -7,17 +7,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-// calculateAdvertiseAddress attempts to clone logic from deep within memberlist
+// calculateAdvertiseIP attempts to clone logic from deep within memberlist
 // (NetTransport.FinalAdvertiseAddr) in order to surface its conclusions to the
 // application, so we can provide more actionable error messages if the user has
 // inadvertantly misconfigured their cluster.
 //
 // https://github.com/hashicorp/memberlist/blob/022f081/net_transport.go#L126
-func calculateAdvertiseAddress(bindAddr, advertiseAddr string) (net.IP, error) {
-	if advertiseAddr != "" {
-		ip := net.ParseIP(advertiseAddr)
+func calculateAdvertiseIP(bindIP, advertiseIP string) (net.IP, error) {
+	if advertiseIP != "" {
+		ip := net.ParseIP(advertiseIP)
 		if ip == nil {
-			return nil, errors.Errorf("failed to parse advertise addr '%s'", advertiseAddr)
+			return nil, errors.Errorf("failed to parse advertise IP '%s'", advertiseIP)
 		}
 		if ip4 := ip.To4(); ip4 != nil {
 			ip = ip4
@@ -25,13 +25,13 @@ func calculateAdvertiseAddress(bindAddr, advertiseAddr string) (net.IP, error) {
 		return ip, nil
 	}
 
-	if bindAddr == "0.0.0.0" {
+	if bindIP == "0.0.0.0" {
 		privateIP, err := sockaddr.GetPrivateIP()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get private IP")
 		}
 		if privateIP == "" {
-			return nil, errors.Wrap(err, "no private IP found, explicit advertise addr not provided")
+			return nil, errors.Wrap(err, "no private IP found, explicit advertise IP not provided")
 		}
 		ip := net.ParseIP(privateIP)
 		if ip == nil {
@@ -40,9 +40,9 @@ func calculateAdvertiseAddress(bindAddr, advertiseAddr string) (net.IP, error) {
 		return ip, nil
 	}
 
-	ip := net.ParseIP(bindAddr)
+	ip := net.ParseIP(bindIP)
 	if ip == nil {
-		return nil, errors.Errorf("failed to parse bind addr '%s'", bindAddr)
+		return nil, errors.Errorf("failed to parse bind IP '%s'", bindIP)
 	}
 	return ip, nil
 }

--- a/pkg/cluster/advertise.go
+++ b/pkg/cluster/advertise.go
@@ -25,7 +25,7 @@ func calculateAdvertiseIP(bindIP, advertiseIP string) (net.IP, error) {
 		return ip, nil
 	}
 
-	if bindIP == "0.0.0.0" {
+	if bindIP == "0.0.0.0" || bindIP == "::" || bindIP == "" {
 		privateIP, err := sockaddr.GetPrivateIP()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get private IP")

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -123,13 +123,13 @@ func Join(
 		level.Warn(l).Log("err", "provide --cluster.advertise-address as a routable IP address or hostname")
 	}
 
-	// If the API listens on 0.0.0.0, deduce it to the advertise IP.
+	// If the API listens on any interface, deduce it to the advertise IP.
 	if initialState.APIAddr != "" {
 		apiHost, apiPort, err := net.SplitHostPort(initialState.APIAddr)
 		if err != nil {
 			return nil, errors.Wrap(err, "invalid API address")
 		}
-		if apiHost == "0.0.0.0" {
+		if apiHost == "0.0.0.0" || apiHost == "::" || apiHost == "" {
 			initialState.APIAddr = net.JoinHostPort(ip.String(), apiPort)
 		}
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -114,11 +114,11 @@ func Join(
 	level.Debug(l).Log("msg", "resolved peers to following addresses", "peers", strings.Join(resolvedPeers, ","))
 
 	// Initial validation of user-specified advertise address.
-	addr, err := calculateAdvertiseAddress(bindHost, advertiseHost)
+	ip, err := calculateAdvertiseIP(bindHost, advertiseHost)
 	if err != nil {
 		level.Warn(l).Log("err", "couldn't deduce an advertise address: "+err.Error())
-	} else if hasNonlocal(resolvedPeers) && isUnroutable(addr.String()) {
-		level.Warn(l).Log("err", "this node advertises itself on an unroutable address", "addr", addr.String())
+	} else if hasNonlocal(resolvedPeers) && isUnroutable(ip.String()) {
+		level.Warn(l).Log("err", "this node advertises itself on an unroutable address", "addr", ip.String())
 		level.Warn(l).Log("err", "this node will be unreachable in the cluster")
 		level.Warn(l).Log("err", "provide --cluster.advertise-address as a routable IP address or hostname")
 	}
@@ -130,7 +130,7 @@ func Join(
 			return nil, errors.Wrap(err, "invalid API address")
 		}
 		if apiHost == "0.0.0.0" {
-			initialState.APIAddr = net.JoinHostPort(addr.String(), apiPort)
+			initialState.APIAddr = net.JoinHostPort(ip.String(), apiPort)
 		}
 	}
 

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -69,7 +69,7 @@ EOF
     --config.file         data/prom${i}/prometheus.yml \
     --storage.tsdb.path   data/prom${i} \
     --log.level           warn \
-    --web.listen-address  0.0.0.0:909${i} &
+    --web.listen-address  :909${i} &
 
   sleep 0.25
 done
@@ -81,12 +81,12 @@ for i in `seq 1 3`
 do
   thanos sidecar \
     --debug.name                sidecar-${i} \
-    --grpc-address              0.0.0.0:1909${i} \
-    --http-address              0.0.0.0:1919${i} \
+    --grpc-address              :1909${i} \
+    --http-address              :1919${i} \
     --prometheus.url            http://localhost:909${i} \
     --tsdb.path                 data/prom${i} \
     --gcs.bucket                "${GCS_BUCKET}" \
-    --cluster.address           0.0.0.0:1939${i} \
+    --cluster.address           :1939${i} \
     --cluster.advertise-address 127.0.0.1:1939${i} \
     --cluster.peers             127.0.0.1:19391 &
 
@@ -100,11 +100,11 @@ then
   thanos store \
     --debug.name                store \
     --log.level debug \
-    --grpc-address              0.0.0.0:19691 \
-    --http-address              0.0.0.0:19791 \
+    --grpc-address              :19691 \
+    --http-address              :19791 \
     --tsdb.path                 data/store \
     --gcs.bucket                "${GCS_BUCKET}" \
-    --cluster.address           0.0.0.0:19891 \
+    --cluster.address           :19891 \
     --cluster.advertise-address 127.0.0.1:19891 \
     --cluster.peers             127.0.0.1:19391 &
 fi
@@ -116,9 +116,9 @@ for i in `seq 1 2`
 do
   thanos query \
     --debug.name                query-${i} \
-    --grpc-address              0.0.0.0:1999${i} \
-    --http-address              0.0.0.0:1949${i} \
-    --cluster.address           0.0.0.0:1959${i} \
+    --grpc-address              :1999${i} \
+    --http-address              :1949${i} \
+    --cluster.address           :1959${i} \
     --cluster.advertise-address 127.0.0.1:1959${i} \
     --cluster.peers             127.0.0.1:19391 &
 done


### PR DESCRIPTION
Allow Thanos to bind to any interface on both IPv4 and IPv6, for example
by specifying `:7777` as the cluster address rather than `0.0.0.0:7777`.

A lot of the defaults and documentation rely on the IPv4 `0.0.0.0`.
Specifically, the cluster advertise IP address would only be calculated
correctly if `0.0.0.0` were used instead of an empty host name.

This follows idiomatic Go:
https://golang.org/pkg/net/#Dial

> For TCP, UDP and IP networks, if the host is empty or a literal
> unspecified IP address, as in ":80", "0.0.0.0:80" or "[::]:80" for TCP
> and UDP, "", "0.0.0.0" or "::" for IP, the local system is assumed.