### PR TITLE
included docker push on Makefile + added push of successful master builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,11 @@ install:
 
 script:
 - make format test
+- make docker
+
+after_success:
+- if [ "$TRAVIS_BRANCH" == "master" ]; then
+  docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+  fi
+- cd $HOME/gopath/src/github.com/improbable-eng/thanos
+- make docker-push

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,11 @@ assets:
 
 docker: build
 	@echo ">> building docker image"
-	@docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+	@docker build -t improbable/"$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+
+docker-push:
+	@echo ">> pushing image"
+	@docker push improbable/"$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
 
 docs:
 	@go get -u github.com/campoy/embedmd


### PR DESCRIPTION
@Bplotka @fabxc 

Please could you review changes.  Hopefully this will address having to manually update the docker images #227 and help towards the release workflow #214 

We will need to add the $DOCKER_USERNAME" and "$DOCKER_PASSWORD environment variables to the Travis job for this to work. https://docs.travis-ci.com/user/environment-variables/

You can see an example build here https://travis-ci.org/V3ckt0r/thanos/jobs/348643561

cheers