### PR TITLE
Don't allow S3 secret key to be passed as a flag

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -50,8 +51,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 	cmd.Flag("s3.access-key", "Access key for an S3-Compatible API.").
 		PlaceHolder("<key>").Envar("S3_ACCESS_KEY").StringVar(&s3config.AccessKey)
 
-	cmd.Flag("s3.secret-key", "Secret key for an S3-Compatible API.").
-		PlaceHolder("<key>").Envar("S3_SECRET_KEY").StringVar(&s3config.SecretKey)
+	s3config.SecretKey = os.Getenv("S3_SECRET_KEY")
 
 	cmd.Flag("s3.insecure", "Whether to use an insecure connection with an S3-Compatible API.").
 		Default("false").Envar("S3_INSECURE").BoolVar(&s3config.Insecure)

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -87,8 +87,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 	s3AccessKey := cmd.Flag("s3.access-key", "Access key for an S3-Compatible API.").
 		PlaceHolder("<key>").Envar("S3_ACCESS_KEY").String()
 
-	s3SecretKey := cmd.Flag("s3.secret-key", "Secret key for an S3-Compatible API.").
-		PlaceHolder("<key>").Envar("S3_SECRET_KEY").String()
+	s3SecretKey := os.Getenv("S3_SECRET_KEY")
 
 	s3Insecure := cmd.Flag("s3.insecure", "Whether to use an insecure connection with an S3-Compatible API.").
 		Default("false").Envar("S3_INSECURE").Bool()
@@ -148,7 +147,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			NoLockfile:       true,
 			WALFlushInterval: 30 * time.Second,
 		}
-		return runRule(g, logger, reg, tracer, lset, *alertmgrs, *httpAddr, *grpcAddr, *evalInterval, *dataDir, *ruleFiles, peer, *gcsBucket, *s3Bucket, *s3Endpoint, *s3AccessKey, *s3SecretKey, *s3Insecure, tsdbOpts)
+		return runRule(g, logger, reg, tracer, lset, *alertmgrs, *httpAddr, *grpcAddr, *evalInterval, *dataDir, *ruleFiles, peer, *gcsBucket, *s3Bucket, *s3Endpoint, *s3AccessKey, s3SecretKey, *s3Insecure, tsdbOpts)
 	}
 }
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"sync"
 	"time"
@@ -62,8 +63,7 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application, name stri
 	cmd.Flag("s3.access-key", "Access key for an S3-Compatible API.").
 		PlaceHolder("<key>").Envar("S3_ACCESS_KEY").StringVar(&s3config.AccessKey)
 
-	cmd.Flag("s3.secret-key", "Secret key for an S3-Compatible API.").
-		PlaceHolder("<key>").Envar("S3_SECRET_KEY").StringVar(&s3config.SecretKey)
+	s3config.SecretKey = os.Getenv("S3_SECRET_KEY")
 
 	cmd.Flag("s3.insecure", "Whether to use an insecure connection with an S3-Compatible API.").
 		Default("false").Envar("S3_INSECURE").BoolVar(&s3config.Insecure)

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -50,8 +51,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 	s3AccessKey := cmd.Flag("s3.access-key", "Access key for an S3-Compatible API.").
 		PlaceHolder("<key>").Envar("S3_ACCESS_KEY").String()
 
-	s3SecretKey := cmd.Flag("s3.secret-key", "Secret key for an S3-Compatible API.").
-		PlaceHolder("<key>").Envar("S3_SECRET_KEY").String()
+	s3SecretKey := os.Getenv("S3_SECRET_KEY")
 
 	s3Insecure := cmd.Flag("s3.insecure", "Whether to use an insecure connection with an S3-Compatible API.").
 		Default("false").Envar("S3_INSECURE").Bool()
@@ -107,7 +107,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 			*s3Bucket,
 			*s3Endpoint,
 			*s3AccessKey,
-			*s3SecretKey,
+			s3SecretKey,
 			*s3Insecure,
 			*dataDir,
 			*grpcAddr,


### PR DESCRIPTION
Passing credentials as command-line flags is not good security practice
as the credentials are visible to any other user on the system.

Using environment variables to pass credentials also has its problems,
but in lieu of using a configuration file, don't allow users to pass the
S3 secret key as a command-line flag.