### PR TITLE
quickstart.sh: Enable web lifecycle URLs

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -69,6 +69,7 @@ EOF
     --config.file         data/prom${i}/prometheus.yml \
     --storage.tsdb.path   data/prom${i} \
     --log.level           warn \
+    --web.enable-lifecycle \
     --web.listen-address  0.0.0.0:909${i} &
 
   sleep 0.25


### PR DESCRIPTION
Without this flag, requests to `/-/reload` on the Prometheus instances
return a HTTP 403, which shows in the logs when running `quickstart.sh`:

    level=error name=sidecar-1 ts=2018-03-06T23:00:20.548170907Z caller=reloader.go:71 component=reloader msg="triggering reload failed" err="received non-200 response: 403 Forbidden"
    level=error name=sidecar-2 ts=2018-03-06T23:00:20.814485689Z caller=reloader.go:71 component=reloader msg="triggering reload failed" err="received non-200 response: 403 Forbidden"
    level=error name=sidecar-3 ts=2018-03-06T23:00:21.06514265Z caller=reloader.go:71 component=reloader msg="triggering reload failed" err="received non-200 response: 403 Forbidden"