### PR TITLE
Fix missing value in log entry

### DIFF
--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -147,7 +147,7 @@ func main() {
 		level.Error(logger).Log("msg", "running command failed", "err", err)
 		os.Exit(1)
 	}
-	level.Info(logger).Log("exiting")
+	level.Info(logger).Log("msg", "exiting")
 }
 
 func interrupt(cancel <-chan struct{}) error {


### PR DESCRIPTION
The gokit logger expects key-value pairs. Previously, this line would
cause:

    exiting=(MISSING)

...to appear in the logs.

It should now be:

    msg="exiting"

...which is consistent with other log entries from Thanos.