### PR TITLE
Pinned to fresh TSDB and updated deps.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -61,6 +61,12 @@
   revision = "bb3d318650d48840a39aa21a027c6630e198e626"
 
 [[projects]]
+  name = "github.com/fortytw2/leaktest"
+  packages = ["."]
+  revision = "7dad53304f9614c1c365755c1176a8e876fee3e8"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
   revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
@@ -335,7 +341,6 @@
   revision = "646adff2ac79efd246e5404db839c30afbb064d9"
 
 [[projects]]
-  branch = "master"
   name = "github.com/prometheus/tsdb"
   packages = [
     ".",
@@ -345,7 +350,7 @@
     "index",
     "labels"
   ]
-  revision = "88ddcab17c08237974aba78391f5ae199954d9fa"
+  revision = "659ed644294eec6310cef0685b002a3aed8c8f85"
 
 [[projects]]
   branch = "master"
@@ -540,6 +545,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3c77f727c61609b23f526cf268080622e3b3ec6240d6c6eb688cd7f51897e7db"
+  inputs-digest = "ae11ea357135b7d58761d9e7f7703f29a21f870285661b8142e3310eb1d568e3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,26 +1,3 @@
-
-# Gopkg.toml example
-#
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#  name = "github.com/x/y"
-#  version = "2.4.0"
-
-
 [[constraint]]
   name = "cloud.google.com/go"
   version = "0.16.0"
@@ -66,7 +43,7 @@
   name = "github.com/grpc-ecosystem/go-grpc-prometheus"
 
 [[constraint]]
-  branch = "master"
+  revision = "659ed644294eec6310cef0685b002a3aed8c8f85"
   name = "github.com/prometheus/tsdb"
 
 [[constraint]]

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -215,9 +215,19 @@ func TestGroup_Compact(t *testing.T) {
 	}, 100, 1001, 2000)
 	testutil.Ok(t, err)
 
+	// Due to TSDB compaction delay (not compacting fresh block), we need one more block to be pushed to trigger compaction.
+	freshB, err := testutil.CreateBlock(dir, []labels.Labels{
+		{{Name: "a", Value: "2"}},
+		{{Name: "a", Value: "3"}},
+		{{Name: "a", Value: "4"}},
+		{{Name: "a", Value: "5"}},
+	}, 100, 3001, 4000)
+	testutil.Ok(t, err)
+
 	testutil.Ok(t, objstore.UploadDir(ctx, bkt, filepath.Join(dir, b1.String()), b1.String()))
 	testutil.Ok(t, objstore.UploadDir(ctx, bkt, filepath.Join(dir, b2.String()), b2.String()))
 	testutil.Ok(t, objstore.UploadDir(ctx, bkt, filepath.Join(dir, b3.String()), b3.String()))
+	testutil.Ok(t, objstore.UploadDir(ctx, bkt, filepath.Join(dir, freshB.String()), freshB.String()))
 
 	metrics := newSyncerMetrics(nil)
 


### PR DESCRIPTION
I think we should pin to some version. Maybe it's bit manual to adopt to new changes, but at least we will be able to track down what version of TSDB we use in given Thanos revision.

@fabxc PTAL

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>