### PR TITLE
block: Simplify check for sorted labels

### DIFF
--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -186,12 +186,8 @@ func VerifyIndex(fn string) error {
 		if lastLset != nil && labels.Compare(lastLset, lset) >= 0 {
 			return errors.Errorf("series %v out of order; previous %v", lset, lastLset)
 		}
-		l0 := lset[0]
-		for _, l := range lset[1:] {
-			if l.Name <= l0.Name {
-				return errors.Errorf("out-of-order label set %s for series %d", lset, id)
-			}
-			l0 = l
+		if !sort.IsSorted(lset) {
+			return errors.Errorf("out-of-order label set %s for series %d", lset, id)
 		}
 		if len(chks) == 0 {
 			return errors.Errorf("empty chunks for series %d", id)


### PR DESCRIPTION
`lset` satisfies sort.Interface, so we can use `sort.IsSorted()` to
verify if the labels are sorted.

Note that with this change, we no longer return an error for duplicate
label names (which should probably be distinguished with a different
error message, if it's something we care about).