### PR TITLE
compact: Add a 1-hour compaction level

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -119,7 +119,7 @@ func runCompact(
 		comp, err := tsdb.NewLeveledCompactor(reg, logger, []int64{
 			int64(2 * time.Hour / time.Millisecond),
 			int64(8 * time.Hour / time.Millisecond),
-			int64(2 * 24 * time.Hour / time.Millisecond),  // dwo days
+			int64(2 * 24 * time.Hour / time.Millisecond),  // 2 days
 			int64(14 * 24 * time.Hour / time.Millisecond), // 2 weeks
 		}, nil)
 		if err != nil {

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -117,6 +117,7 @@ func runCompact(
 		// Instantiate the compactor with different time slices. Timestamps in TSDB
 		// are in milliseconds.
 		comp, err := tsdb.NewLeveledCompactor(reg, logger, []int64{
+			int64(1 * time.Hour / time.Millisecond),
 			int64(2 * time.Hour / time.Millisecond),
 			int64(8 * time.Hour / time.Millisecond),
 			int64(2 * 24 * time.Hour / time.Millisecond),  // 2 days


### PR DESCRIPTION
Add a 1-hour compaction level for blocks using a block size smaller than
the 2-hour default used by Prometheus. For block sizes using the default
(or larger) block size, this compaction level will be ignored.

Relates to #263.