### PR TITLE
store: Remove mention of hashing in comment

### DIFF
--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -84,9 +84,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 	}
 }
 
-// runStore starts a daemon that connects to a cluster of other store nodes through gossip.
-// It also connects to a Google Cloud Storage bucket and serves data queries to a subset of its contents.
-// The served subset is determined through HRW hashing against the block's ULIDs and the known peers.
+// runStore starts a daemon that serves queries to cluster peers using data from an object store.
 func runStore(
 	g *run.Group,
 	logger log.Logger,


### PR DESCRIPTION
This comment is inaccurate; the store instance is currently run as a
single instance and does no coordination between peers to determine
which subset of data from the object store it should be responsible for
serving.

A single store instance is responsible for all of the data in a single
object store bucket.