### PR TITLE
Add web.enable-lifecycle to k8s samples

### DIFF
--- a/kube/manifests/prometheus-gcs.yaml
+++ b/kube/manifests/prometheus-gcs.yaml
@@ -27,6 +27,7 @@ spec:
         - "--storage.tsdb.path=/var/prometheus"
         - "--storage.tsdb.min-block-duration=2h"
         - "--storage.tsdb.max-block-duration=2h"
+        - "--web.enable-lifecycle"
         ports:
         - name: http
           containerPort: 9090

--- a/kube/manifests/prometheus.yaml
+++ b/kube/manifests/prometheus.yaml
@@ -27,6 +27,7 @@ spec:
         - "--storage.tsdb.path=/var/prometheus"
         - "--storage.tsdb.min-block-duration=2h"
         - "--storage.tsdb.max-block-duration=2h"
+        - "--web.enable-lifecycle"
         ports:
         - name: http
           containerPort: 9090


### PR DESCRIPTION
..To avoid having the thanos sidecar throw a `level=error ts=2018-04-08T13:07:32.559863231Z caller=reloader.go:72 component=reloader msg="triggering reload failed" err="received non-200 response: 403 Forbidden"`