### PR TITLE
compact: Move downsampling and compact to sub dirs to avoid removal of potentially mounted dir.

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"os"
 	"path"
 	"time"
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -132,8 +132,8 @@ func runCompact(
 
 		f := func() error {
 			var (
-				compactDir      = path.Join(dataDir, "compact-work-dir")
-				downsamplingDir = path.Join(dataDir, "downsampling-work-dir")
+				compactDir      = path.Join(dataDir, "compact")
+				downsamplingDir = path.Join(dataDir, "downsample")
 			)
 
 			// Loop over bucket and compact until there's no work left.
@@ -150,10 +150,6 @@ func runCompact(
 				}
 				done := true
 				for _, g := range groups {
-					if err := os.RemoveAll(compactDir); err != nil {
-						return errors.Wrap(err, "clean working directory before compact")
-					}
-
 					// While we do all compactions sequentially we just compact within the top-level dir.
 					id, err := g.Compact(ctx, compactDir, comp)
 					if err == nil {

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -441,9 +441,13 @@ func (cg *Group) Resolution() int64 {
 // Compact plans and runs a single compaction against the group. The compacted result
 // is uploaded into the bucket the blocks were retrieved from.
 func (cg *Group) Compact(ctx context.Context, dir string, comp tsdb.Compactor) (ulid.ULID, error) {
+	if err := os.RemoveAll(dir); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "clean compaction dir")
+	}
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		return ulid.ULID{}, errors.Wrap(err, "create compaction dir")
 	}
+
 	id, err := cg.compact(ctx, dir, comp)
 	if err != nil {
 		cg.compactionFailures.Inc()

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -4,23 +4,22 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"sync"
 	"time"
 
-	"github.com/improbable-eng/thanos/pkg/compact/downsample"
-
-	"github.com/improbable-eng/thanos/pkg/block"
-	"github.com/improbable-eng/thanos/pkg/objstore"
-	"github.com/prometheus/tsdb/labels"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/compact/downsample"
+	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/tsdb"
+	"github.com/prometheus/tsdb/labels"
 )
 
 // Syncer syncronizes block metas from a bucket into a local directory.
@@ -441,14 +440,16 @@ func (cg *Group) Resolution() int64 {
 // Compact plans and runs a single compaction against the group. The compacted result
 // is uploaded into the bucket the blocks were retrieved from.
 func (cg *Group) Compact(ctx context.Context, dir string, comp tsdb.Compactor) (ulid.ULID, error) {
-	if err := os.RemoveAll(dir); err != nil {
-		return ulid.ULID{}, errors.Wrap(err, "clean compaction dir")
+	subDir := path.Join(dir, cg.Key())
+
+	if err := os.RemoveAll(subDir); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "clean compaction group dir")
 	}
-	if err := os.MkdirAll(dir, 0777); err != nil {
-		return ulid.ULID{}, errors.Wrap(err, "create compaction dir")
+	if err := os.MkdirAll(subDir, 0777); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "create compaction group dir")
 	}
 
-	id, err := cg.compact(ctx, dir, comp)
+	id, err := cg.compact(ctx, subDir, comp)
 	if err != nil {
 		cg.compactionFailures.Inc()
 	}
@@ -512,6 +513,11 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 		if err != nil {
 			return compID, errors.Wrapf(err, "read meta from %s", pdir)
 		}
+
+		if cg.Key() != GroupKey(*meta) {
+			return compID, halt(errors.Wrapf(err, "compact planned compaction for mixed groups. group: %s, planned block's group: %s", cg.Key(), GroupKey(*meta)))
+		}
+
 		for _, s := range meta.Compaction.Sources {
 			if _, ok := uniqueSources[s]; ok {
 				return compID, halt(errors.Errorf("overlapping sources detected for plan %v", plan))


### PR DESCRIPTION
I think this one is critical fix @fabxc

Before it, my removal of group dirs in local dir was simply not working (and err ignored), so I think I had all these compact overlaps because my compact planning was including ALL blocks (no matter what group O.o)

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>