### PR TITLE
compact: Remove outdated comment

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -149,7 +149,6 @@ func runCompact(
 				}
 				done := true
 				for _, g := range groups {
-					// While we do all compactions sequentially we just compact within the top-level dir.
 					id, err := g.Compact(ctx, compactDir, comp)
 					if err == nil {
 						// If the returned ID has a zero value, the group had no blocks to be compacted.


### PR DESCRIPTION
This comment is no longer accurate as of f30c0d5fb; we no longer compact
in the top-level directory.

/cc @Bplotka 