### PR TITLE
compact: Use sync-delay only for fresh blocks. Refactored halt, retry logic.

### DIFF
--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -300,3 +300,34 @@ func TestGroup_Compact(t *testing.T) {
 	})
 	testutil.Ok(t, err)
 }
+
+func TestHaltError(t *testing.T) {
+	err := errors.New("test")
+	testutil.Assert(t, !IsHaltError(err), "halt error")
+
+	err = halt(errors.New("test"))
+	testutil.Assert(t, IsHaltError(err), "not a halt error")
+
+	err = errors.Wrap(halt(errors.New("test")), "something")
+	testutil.Assert(t, IsHaltError(err), "not a halt error")
+
+	err = errors.Wrap(errors.Wrap(halt(errors.New("test")), "something"), "something2")
+	testutil.Assert(t, IsHaltError(err), "not a halt error")
+}
+
+func TestRetryError(t *testing.T) {
+	err := errors.New("test")
+	testutil.Assert(t, !IsRetryError(err), "retry error")
+
+	err = retry(errors.New("test"))
+	testutil.Assert(t, IsRetryError(err), "not a retry error")
+
+	err = errors.Wrap(retry(errors.New("test")), "something")
+	testutil.Assert(t, IsRetryError(err), "not a retry error")
+
+	err = errors.Wrap(errors.Wrap(retry(errors.New("test")), "something"), "something2")
+	testutil.Assert(t, IsRetryError(err), "not a retry error")
+
+	err = errors.Wrap(retry(errors.Wrap(halt(errors.New("test")), "something")), "something2")
+	testutil.Assert(t, IsHaltError(err), "not a halt error. Retry should not hide halt error")
+}

--- a/pkg/objstore/objstore.go
+++ b/pkg/objstore/objstore.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Bucket provides read and write access to an object storage bucket.
+// NOTE: We assume strong consistency for write-read flow.
 type Bucket interface {
 	BucketReader
 

--- a/pkg/runutil/runutil.go
+++ b/pkg/runutil/runutil.go
@@ -40,7 +40,7 @@ func RetryWithLog(logger log.Logger, interval time.Duration, stopc <-chan struct
 		if err = f(); err == nil {
 			return nil
 		} else {
-			level.Error(logger).Log("msg", "function failed. Retrying", "err", err)
+			level.Error(logger).Log("msg", "function failed. Retrying in next tick", "err", err)
 		}
 		select {
 		case <-stopc:


### PR DESCRIPTION
Currently, we have a similar issue as with prom 2.2.0 compaction.

< Critical fix >

For newly uploaded compacted blocks we need to assume strong consistency for object storage.
If not, we need to address it somehow with file locks or something like that. Basically, compaction is not safe to be planned without whole overview. (except fresh blocks - these can be safely excluded)

GCS has strong write-read consistency: https://cloud.google.com/storage/docs/consistency
S3 has weird consistency, but seems to be write-read for newly created objects:  https://codeburst.io/quick-explanation-of-the-s3-consistency-model-6c9f325e3f82

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>