### PR TITLE
store: Add bytes unit suffix to metrics

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -90,11 +90,11 @@ func newBucketStoreMetrics(reg prometheus.Registerer, s *BucketStore) *bucketSto
 	}, []string{"data_type"})
 
 	m.seriesDataSizeTouched = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Name: "thanos_bucket_store_series_data_size_touched",
+		Name: "thanos_bucket_store_series_data_size_touched_bytes",
 		Help: "Size of all items of a data type in a block were touched for a single series request.",
 	}, []string{"data_type"})
 	m.seriesDataSizeFetched = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Name: "thanos_bucket_store_series_data_size_fetched",
+		Name: "thanos_bucket_store_series_data_size_fetched_bytes",
 		Help: "Size of all items of a data type in a block were fetched for a single series request.",
 	}, []string{"data_type"})
 


### PR DESCRIPTION
Include the unit of measure as a suffix to store metrics, following
Prometheus naming best practices:
https://prometheus.io/docs/practices/naming/