### PR TITLE
Set custom user agent for S3 store client

### DIFF
--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -55,14 +55,14 @@ func registerBucket(m map[string]setupFunc, app *kingpin.Application, name strin
 	verifyIssues := verify.Flag("issues", fmt.Sprintf("issues to verify (and optionally repair). Possible values: %v", allIssues())).
 		Short('i').Default(verifier.IndexIssueID, verifier.OverlappedBlocksIssueID).Strings()
 	m[name+" verify"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer) error {
-		bkt, closeFn, err := client.NewBucket(gcsBucket, *s3Config, reg)
+		bkt, closeFn, err := client.NewBucket(gcsBucket, *s3Config, reg, name)
 		if err != nil {
 			return err
 		}
 
 		backupS3Config := *s3Config
 		backupS3Config.Bucket = *verifyBackupS3Bucket
-		backupBkt, backupCloseFn, err := client.NewBucket(verifyBackupGCSBucket, backupS3Config, reg)
+		backupBkt, backupCloseFn, err := client.NewBucket(verifyBackupGCSBucket, backupS3Config, reg, name)
 		if err == client.ErrNotFound {
 			if *verifyRepair {
 				return errors.Wrap(err, "repair is specified, so backup client is required")
@@ -103,7 +103,7 @@ func registerBucket(m map[string]setupFunc, app *kingpin.Application, name strin
 	lsOutput := ls.Flag("output", "format in which to print each block's information; may be 'json' or custom template").
 		Short('o').Default("").String()
 	m[name+" ls"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer) error {
-		bkt, closeFn, err := client.NewBucket(gcsBucket, *s3Config, reg)
+		bkt, closeFn, err := client.NewBucket(gcsBucket, *s3Config, reg, name)
 		if err != nil {
 			return err
 		}

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -58,6 +58,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 			*syncDelay,
 			*haltOnError,
 			*wait,
+			name,
 		)
 	}
 }
@@ -73,6 +74,7 @@ func runCompact(
 	syncDelay time.Duration,
 	haltOnError bool,
 	wait bool,
+	component string,
 ) error {
 	var (
 		bkt    objstore.Bucket

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"path"
+	"runtime"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -22,12 +24,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/route"
-	"github.com/prometheus/tsdb"
-	"gopkg.in/alecthomas/kingpin.v2"
-	"google.golang.org/api/option"
-	"fmt"
-	"runtime"
 	"github.com/prometheus/common/version"
+	"github.com/prometheus/tsdb"
+	"google.golang.org/api/option"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func registerCompact(m map[string]setupFunc, app *kingpin.Application, name string) {

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -111,7 +111,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			NoLockfile:       true,
 			WALFlushInterval: 30 * time.Second,
 		}
-		return runRule(g, logger, reg, tracer, lset, *alertmgrs, *httpAddr, *grpcAddr, *evalInterval, *dataDir, *ruleFiles, peer, *gcsBucket, s3Config, tsdbOpts)
+		return runRule(g, logger, reg, tracer, lset, *alertmgrs, *httpAddr, *grpcAddr, *evalInterval, *dataDir, *ruleFiles, peer, *gcsBucket, s3Config, tsdbOpts, name)
 	}
 }
 
@@ -133,6 +133,7 @@ func runRule(
 	gcsBucket string,
 	s3Config *s3.Config,
 	tsdbOpts *tsdb.Options,
+	component string,
 ) error {
 	db, err := tsdb.Open(dataDir, log.With(logger, "component", "tsdb"), reg, tsdbOpts)
 	if err != nil {
@@ -398,7 +399,7 @@ func runRule(
 		closeFn = gcsClient.Close
 		bucket = gcsBucket
 	} else if s3Config.Validate() == nil {
-		bkt, err = s3.NewBucket(s3Config, reg)
+		bkt, err = s3.NewBucket(s3Config, reg, component)
 		if err != nil {
 			return errors.Wrap(err, "create s3 client")
 		}

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -100,6 +100,7 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application, name stri
 			s3Config,
 			peer,
 			rl,
+			name,
 		)
 	}
 }
@@ -117,6 +118,7 @@ func runSidecar(
 	s3Config *s3.Config,
 	peer *cluster.Peer,
 	reloader *reloader.Reloader,
+	component string,
 ) error {
 	var externalLabels = &extLabelSet{promURL: promURL}
 
@@ -269,7 +271,7 @@ func runSidecar(
 		bucket = gcsBucket
 	} else if s3Config.Validate() == nil {
 		var err error
-		bkt, err = s3.NewBucket(s3Config, reg)
+		bkt, err = s3.NewBucket(s3Config, reg, component)
 		if err != nil {
 			return errors.Wrap(err, "create s3 client")
 		}

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -51,7 +51,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 
 	peers := cmd.Flag("cluster.peers", "initial peers to join the cluster. It can be either <ip:port>, or <domain:port>").Strings()
 
-	clusterBindAddr := cmd.Flag("cluster.address", "listen address for clutser").
+	clusterBindAddr := cmd.Flag("cluster.address", "listen address for cluster").
 		Default(defaultClusterAddr).String()
 
 	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "explicit address to advertise in cluster").

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -80,6 +80,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 			peer,
 			uint64(*indexCacheSize),
 			uint64(*chunkPoolSize),
+			name,
 		)
 	}
 }
@@ -98,6 +99,7 @@ func runStore(
 	peer *cluster.Peer,
 	indexCacheSizeBytes uint64,
 	chunkPoolSizeBytes uint64,
+	component string,
 ) error {
 	{
 		var (
@@ -117,7 +119,7 @@ func runStore(
 			closeFn = gcsClient.Close
 			bucket = gcsBucket
 		} else if s3Config.Validate() == nil {
-			b, err := s3.NewBucket(s3Config, reg)
+			b, err := s3.NewBucket(s3Config, reg, component)
 			if err != nil {
 				return errors.Wrap(err, "create s3 client")
 			}

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -46,7 +46,7 @@ Flags:
                                 initial peers to join the cluster. It can be
                                 either <ip:port>, or <domain:port>
       --cluster.address="0.0.0.0:10900"  
-                                listen address for clutser
+                                listen address for cluster
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
                                 explicit address to advertise in cluster
 

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 
 	"cloud.google.com/go/storage"
 	"github.com/improbable-eng/thanos/pkg/objstore"
@@ -9,15 +11,18 @@ import (
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/version"
+	"google.golang.org/api/option"
 )
 
 var ErrNotFound = errors.New("no valid GCS or S3 configuration supplied")
 
 // NewBucket initializes and returns new object storage clients.
 // TODO(bplotka): Use that in every command.
-func NewBucket(gcsBucket *string, s3Config s3.Config, reg *prometheus.Registry) (objstore.Bucket, func() error, error) {
+func NewBucket(gcsBucket *string, s3Config s3.Config, reg *prometheus.Registry, component string) (objstore.Bucket, func() error, error) {
 	if *gcsBucket != "" {
-		gcsClient, err := storage.NewClient(context.Background())
+		gcsOptions := option.WithUserAgent(fmt.Sprintf("thanos-%s/%s (%s)", component, version.Version, runtime.Version()))
+		gcsClient, err := storage.NewClient(context.Background(), gcsOptions)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "create GCS client")
 		}
@@ -25,7 +30,7 @@ func NewBucket(gcsBucket *string, s3Config s3.Config, reg *prometheus.Registry) 
 	}
 
 	if s3Config.Validate() == nil {
-		b, err := s3.NewBucket(&s3Config, reg)
+		b, err := s3.NewBucket(&s3Config, reg, component)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "create s3 client")
 		}

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -80,7 +80,7 @@ func (conf *Config) Validate() error {
 }
 
 // NewBucket returns a new Bucket using the provided s3 config values.
-func NewBucket(conf *Config, reg prometheus.Registerer) (*Bucket, error) {
+func NewBucket(conf *Config, reg prometheus.Registerer, component string) (*Bucket, error) {
 	var f func(string, string, string, bool) (*minio.Client, error)
 	if conf.SignatureV2 {
 		f = minio.NewV2
@@ -89,7 +89,7 @@ func NewBucket(conf *Config, reg prometheus.Registerer) (*Bucket, error) {
 	}
 
 	client, err := f(conf.Endpoint, conf.AccessKey, conf.SecretKey, !conf.Insecure)
-	client.SetAppInfo("Thanos", fmt.Sprintf("%s (%s)", version.Version, runtime.Version()))
+	client.SetAppInfo(fmt.Sprintf("thanos-%s", component), fmt.Sprintf("%s (%s)", version.Version, runtime.Version()))
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize s3 client")
 	}

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -3,13 +3,16 @@ package s3
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/minio/minio-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/version"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -86,6 +89,7 @@ func NewBucket(conf *Config, reg prometheus.Registerer) (*Bucket, error) {
 	}
 
 	client, err := f(conf.Endpoint, conf.AccessKey, conf.SecretKey, !conf.Insecure)
+	client.SetAppInfo("Thanos", fmt.Sprintf("%s (%s)", version.Version, runtime.Version()))
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize s3 client")
 	}

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -1,0 +1,51 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestUserAgent(t *testing.T) {
+
+	serverResponse := `<?xml version="1.0" encoding="UTF-8"?>
+<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`
+
+	var receivedUserAgent = ""
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUserAgent = r.Header.Get("User-Agent")
+		w.Header().Add("Last-Modified", "Sun, 15 Apr 2018 20:26:05 GMT")
+		fmt.Fprintln(w, serverResponse)
+	}))
+
+	s3URL, _ := url.ParseRequestURI(api.URL)
+
+	defer api.Close()
+
+	var s3Config Config
+
+	s3Config.Bucket = "testing"
+	s3Config.Endpoint = s3URL.Host
+	s3Config.Insecure = true
+
+	bucket, err := NewBucket(&s3Config, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	bucketExists, err := bucket.Exists(ctx, "test_obj")
+
+	if err != nil {
+		t.Fatal(err)
+		cancel()
+	}
+	if !bucketExists {
+		t.Error("Test bucket doesn't exist")
+	}
+	if !strings.Contains(receivedUserAgent, "Thanos") {
+		t.Error("Didn't receive proper user agent string from client")
+	}
+
+}

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -8,16 +8,19 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/improbable-eng/thanos/pkg/testutil"
 )
 
 func TestUserAgent(t *testing.T) {
 
-	serverResponse := `<?xml version="1.0" encoding="UTF-8"?>
+	const serverResponse = `<?xml version="1.0" encoding="UTF-8"?>
 <LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`
 
-	var receivedUserAgent = ""
+	var receivedUserAgent string
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedUserAgent = r.Header.Get("User-Agent")
+		// Header required by minio-go, otherwise it fails with "Last-Modified time format is invalid"
 		w.Header().Add("Last-Modified", "Sun, 15 Apr 2018 20:26:05 GMT")
 		fmt.Fprintln(w, serverResponse)
 	}))
@@ -26,26 +29,17 @@ func TestUserAgent(t *testing.T) {
 
 	defer api.Close()
 
-	var s3Config Config
-
-	s3Config.Bucket = "testing"
-	s3Config.Endpoint = s3URL.Host
-	s3Config.Insecure = true
-
-	bucket, err := NewBucket(&s3Config, nil)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	bucketExists, err := bucket.Exists(ctx, "test_obj")
-
-	if err != nil {
-		t.Fatal(err)
-		cancel()
-	}
-	if !bucketExists {
-		t.Error("Test bucket doesn't exist")
-	}
-	if !strings.Contains(receivedUserAgent, "Thanos") {
-		t.Error("Didn't receive proper user agent string from client")
+	s3Config := Config{
+		Bucket:   "testing",
+		Endpoint: s3URL.Host,
+		Insecure: true,
 	}
 
+	bucket, err := NewBucket(&s3Config, nil, "test-component")
+	testutil.Ok(t, err)
+
+	bucketExists, err := bucket.Exists(context.Background(), "test_obj")
+	testutil.Ok(t, err)
+	testutil.Assert(t, bucketExists, "Couldn't get test bucket")
+	testutil.Assert(t, strings.Contains(receivedUserAgent, "thanos-test-component"), "Didn't receive proper user agent string from client")
 }


### PR DESCRIPTION
Fixes #291 

This uses the builtin SetAppInfo from Minio to create "Minio (darwin; amd64) minio-go/4.0.9 Thanos/<version> (go1.10.1)" user agent string for requests.