### PR TITLE
External label uniqueness

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -155,6 +155,10 @@ func runSidecar(
 				return errors.Wrap(err, "initial external labels query")
 			}
 
+			if len(externalLabels.Get()) == 0 {
+				return errors.New("no external labels configured on Prometheus server, uniquely identifying external labels must be configured")
+			}
+
 			// New gossip cluster.
 			err = peer.Join(
 				cluster.PeerState{


### PR DESCRIPTION
This PR makes the sidecar error out directly, when no external labels are configured, following @fabxc's suggestion in #266. In order to be able to alert on non-unique sets of external labels I chose to expose a metric that hashes the external labels and increments the time-series for each occurrence, that way an alert can fire, when there are any time-series that have their value >1.

The only trouble I'm having with the metric approach I took is that I can't immediately see which combination of external label is problematic, registering a metric with the external label pair is sadly not possible as the prometheus metrics registry will reject samples that have varying label sets.

Closes #266

@Bplotka @fabxc 