### PR TITLE
Enable deduplication by default in querier

### DIFF
--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -202,7 +202,7 @@ func (api *API) query(r *http.Request) (interface{}, []error, *apiError) {
 	var (
 		warnmtx             sync.Mutex
 		warnings            []error
-		enableDeduplication bool
+		enableDeduplication bool = true
 	)
 	partialErrReporter := func(err error) {
 		warnmtx.Lock()
@@ -210,7 +210,6 @@ func (api *API) query(r *http.Request) (interface{}, []error, *apiError) {
 		warnmtx.Unlock()
 	}
 
-	enableDeduplication = true
 	// Allow disabling deduplication on demand.
 	if dedup := r.FormValue("dedup"); dedup != "" {
 		var err error
@@ -295,7 +294,7 @@ func (api *API) queryRange(r *http.Request) (interface{}, []error, *apiError) {
 	var (
 		warnmtx             sync.Mutex
 		warnings            []error
-		enableDeduplication bool
+		enableDeduplication bool = true
 	)
 	partialErrReporter := func(err error) {
 		warnmtx.Lock()
@@ -303,7 +302,6 @@ func (api *API) queryRange(r *http.Request) (interface{}, []error, *apiError) {
 		warnmtx.Unlock()
 	}
 
-	enableDeduplication = true
 	// Allow disabling deduplication on demand.
 	if dedup := r.FormValue("dedup"); dedup != "" {
 		var err error
@@ -420,7 +418,7 @@ func (api *API) series(r *http.Request) (interface{}, []error, *apiError) {
 	var (
 		warnmtx             sync.Mutex
 		warnings            []error
-		enableDeduplication bool
+		enableDeduplication bool = true
 	)
 	partialErrReporter := func(err error) {
 		warnmtx.Lock()
@@ -428,7 +426,6 @@ func (api *API) series(r *http.Request) (interface{}, []error, *apiError) {
 		warnmtx.Unlock()
 	}
 
-	enableDeduplication = true
 	// Allow disabling deduplication on demand.
 	if dedup := r.FormValue("dedup"); dedup != "" {
 		var err error

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -210,6 +210,7 @@ func (api *API) query(r *http.Request) (interface{}, []error, *apiError) {
 		warnmtx.Unlock()
 	}
 
+	enableDeduplication = true
 	// Allow disabling deduplication on demand.
 	if dedup := r.FormValue("dedup"); dedup != "" {
 		var err error
@@ -302,6 +303,7 @@ func (api *API) queryRange(r *http.Request) (interface{}, []error, *apiError) {
 		warnmtx.Unlock()
 	}
 
+	enableDeduplication = true
 	// Allow disabling deduplication on demand.
 	if dedup := r.FormValue("dedup"); dedup != "" {
 		var err error
@@ -426,6 +428,7 @@ func (api *API) series(r *http.Request) (interface{}, []error, *apiError) {
 		warnmtx.Unlock()
 	}
 
+	enableDeduplication = true
 	// Allow disabling deduplication on demand.
 	if dedup := r.FormValue("dedup"); dedup != "" {
 		var err error


### PR DESCRIPTION
Documentation and even code comments suggest the deduplication feature is enabled by default, which is actually not the case. This change makes using Thanos querier as a standard Grafana datasource work as expected.