### PR TITLE
store: Reuse sync block for initial sync block.

### DIFF
--- a/pkg/block/block_test.go
+++ b/pkg/block/block_test.go
@@ -1,0 +1,58 @@
+package block
+
+import (
+	"testing"
+
+	"github.com/oklog/ulid"
+)
+
+// NOTE(bplotka): For block packages we cannot use testutil, because they import block package. Consider moving simple
+// testutil methods to separate package.
+func TestIsBlockDir(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		id    ulid.ULID
+		bdir  bool
+	}{
+		{
+			input: "",
+			bdir:  false,
+		},
+		{
+			input: "something",
+			bdir:  false,
+		},
+		{
+			id:    ulid.MustNew(1, nil),
+			input: ulid.MustNew(1, nil).String(),
+			bdir:  true,
+		},
+		{
+			id:    ulid.MustNew(2, nil),
+			input: "/" + ulid.MustNew(2, nil).String(),
+			bdir:  true,
+		},
+		{
+			id:    ulid.MustNew(3, nil),
+			input: "some/path/" + ulid.MustNew(3, nil).String(),
+			bdir:  true,
+		},
+		{
+			input: ulid.MustNew(4, nil).String() + "/something",
+			bdir:  false,
+		},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			id, ok := IsBlockDir(tc.input)
+			if ok != tc.bdir {
+				t.Errorf("expected block dir != %v", tc.bdir)
+				t.FailNow()
+			}
+
+			if id.Compare(tc.id) != 0 {
+				t.Errorf("expected %s got %s", tc.id, id)
+				t.FailNow()
+			}
+		})
+	}
+}

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -218,7 +218,7 @@ func (s *Shipper) iterBlockMetas(f func(m *block.Meta) error) error {
 		return errors.Wrap(err, "read dir")
 	}
 	for _, n := range names {
-		if _, err := ulid.Parse(n); err != nil {
+		if _, ok := block.IsBlockDir(n); !ok {
 			continue
 		}
 		dir := filepath.Join(s.dir, n)

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -316,6 +316,8 @@ func (s *BucketStore) InitialSync(ctx context.Context) error {
 		// No such block loaded, remove the local dir.
 		return os.RemoveAll(path.Join(s.dir, id.String()))
 	}
+
+	return nil
 }
 
 func (s *BucketStore) numBlocks() int {

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -201,6 +201,7 @@ func NewBucketStore(
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		return nil, errors.Wrap(err, "create dir")
 	}
+
 	fns, err := fileutil.ReadDir(dir)
 	if err != nil {
 		return nil, errors.Wrap(err, "read dir")
@@ -233,6 +234,7 @@ func (s *BucketStore) Close() (err error) {
 }
 
 // SyncBlocks synchronizes the stores state with the Bucket bucket.
+// It will reuse disk space as persistent cache based on s.dir param.
 func (s *BucketStore) SyncBlocks(ctx context.Context) error {
 	var wg sync.WaitGroup
 	blockc := make(chan ulid.ULID)
@@ -274,7 +276,7 @@ func (s *BucketStore) SyncBlocks(ctx context.Context) error {
 	wg.Wait()
 
 	if err != nil {
-		return err
+		return errors.Wrap(err, "iter")
 	}
 	// Drop all blocks that are no longer present in the bucket.
 	for id := range s.blocks {
@@ -287,7 +289,33 @@ func (s *BucketStore) SyncBlocks(ctx context.Context) error {
 		}
 		s.metrics.blockDrops.Inc()
 	}
+
 	return nil
+}
+
+// InitialSync perform blocking sync with extra step at the end to delete locally saved blocks that are no longer
+// present in the bucket. The mismatch of these can only happen between restarts, so we can do that only once per startup.
+func (s *BucketStore) InitialSync(ctx context.Context) error {
+	if err := s.SyncBlocks(ctx); err != nil {
+		return errors.Wrap(err, "sync block")
+	}
+
+	names, err := fileutil.ReadDir(s.dir)
+	if err != nil {
+		return errors.Wrap(err, "read dir")
+	}
+	for _, n := range names {
+		id, ok := block.IsBlockDir(n)
+		if !ok {
+			continue
+		}
+		if b := s.getBlock(id); b != nil {
+			continue
+		}
+
+		// No such block loaded, remove the local dir.
+		return os.RemoveAll(path.Join(s.dir, id.String()))
+	}
 }
 
 func (s *BucketStore) numBlocks() int {
@@ -308,7 +336,9 @@ func (s *BucketStore) addBlock(ctx context.Context, id ulid.ULID) (err error) {
 	defer func() {
 		if err != nil {
 			s.metrics.blockLoadFailures.Inc()
-			os.RemoveAll(dir)
+			if err2 := os.RemoveAll(dir); err2 != nil {
+				level.Warn(s.logger).Log("msg", "failed to remove block we cannot load", "err", err)
+			}
 		}
 	}()
 	s.metrics.blockLoads.Inc()
@@ -316,7 +346,7 @@ func (s *BucketStore) addBlock(ctx context.Context, id ulid.ULID) (err error) {
 	b, err := newBucketBlock(ctx, log.With(s.logger, "block", id),
 		s.bucket, id, dir, s.indexCache, s.chunkPool)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "new bucket block")
 	}
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -343,18 +373,18 @@ func (s *BucketStore) addBlock(ctx context.Context, id ulid.ULID) (err error) {
 func (s *BucketStore) removeBlock(id ulid.ULID) error {
 	s.mtx.Lock()
 	b, ok := s.blocks[id]
-	delete(s.blocks, id)
-
 	if ok {
 		lset := labels.FromMap(b.meta.Thanos.Labels)
 		s.blockSets[lset.Hash()].remove(id)
+		delete(s.blocks, id)
 	}
 	s.mtx.Unlock()
-	s.metrics.blocksLoaded.Dec()
 
 	if !ok {
 		return nil
 	}
+
+	s.metrics.blocksLoaded.Dec()
 	if err := b.Close(); err != nil {
 		return errors.Wrap(err, "close block")
 	}
@@ -951,16 +981,12 @@ func newBucketBlock(
 		indexObj:   path.Join(id.String(), block.IndexFilename),
 		indexCache: indexCache,
 		chunkPool:  chunkPool,
+		dir:        dir,
 	}
-	defer func() {
-		if err != nil {
-			os.RemoveAll(dir)
-		}
-	}()
-	if err = b.loadMeta(ctx, id, dir); err != nil {
+	if err = b.loadMeta(ctx, id); err != nil {
 		return nil, errors.Wrap(err, "load meta")
 	}
-	if err = b.loadIndexCache(ctx, dir); err != nil {
+	if err = b.loadIndexCache(ctx); err != nil {
 		return nil, errors.Wrap(err, "load index cache")
 	}
 	// Get object handles for all chunk files.
@@ -974,21 +1000,21 @@ func newBucketBlock(
 	return b, nil
 }
 
-func (b *bucketBlock) loadMeta(ctx context.Context, id ulid.ULID, dir string) error {
+func (b *bucketBlock) loadMeta(ctx context.Context, id ulid.ULID) error {
 	// If we haven't seen the block before download the meta.json file.
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		if err := os.MkdirAll(dir, 0777); err != nil {
+	if _, err := os.Stat(b.dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(b.dir, 0777); err != nil {
 			return errors.Wrap(err, "create dir")
 		}
 		src := path.Join(id.String(), block.MetaFilename)
 
-		if err := objstore.DownloadFile(ctx, b.bucket, src, dir); err != nil {
+		if err := objstore.DownloadFile(ctx, b.bucket, src, b.dir); err != nil {
 			return errors.Wrap(err, "download meta.json")
 		}
 	} else if err != nil {
 		return err
 	}
-	meta, err := block.ReadMetaFile(dir)
+	meta, err := block.ReadMetaFile(b.dir)
 	if err != nil {
 		return errors.Wrap(err, "read meta.json")
 	}
@@ -996,8 +1022,8 @@ func (b *bucketBlock) loadMeta(ctx context.Context, id ulid.ULID, dir string) er
 	return nil
 }
 
-func (b *bucketBlock) loadIndexCache(ctx context.Context, dir string) (err error) {
-	cachefn := filepath.Join(dir, block.IndexCacheFilename)
+func (b *bucketBlock) loadIndexCache(ctx context.Context) (err error) {
+	cachefn := filepath.Join(b.dir, block.IndexCacheFilename)
 
 	b.indexVersion, b.symbols, b.lvals, b.postings, err = block.ReadIndexCache(cachefn)
 	if err == nil {
@@ -1007,7 +1033,7 @@ func (b *bucketBlock) loadIndexCache(ctx context.Context, dir string) (err error
 		return errors.Wrap(err, "read index cache")
 	}
 	// No cache exists is on disk yet, build it from a the downloaded index and retry.
-	fn := filepath.Join(dir, block.IndexFilename)
+	fn := filepath.Join(b.dir, block.IndexFilename)
 
 	if err := objstore.DownloadFile(ctx, b.bucket, b.indexObj, fn); err != nil {
 		return errors.Wrap(err, "download index file")

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -341,14 +341,21 @@ func (s *BucketStore) addBlock(ctx context.Context, id ulid.ULID) (err error) {
 		if err != nil {
 			s.metrics.blockLoadFailures.Inc()
 			if err2 := os.RemoveAll(dir); err2 != nil {
-				level.Warn(s.logger).Log("msg", "failed to remove block we cannot load", "err", err)
+				level.Warn(s.logger).Log("msg", "failed to remove block we cannot load", "err", err2)
 			}
 		}
 	}()
 	s.metrics.blockLoads.Inc()
 
-	b, err := newBucketBlock(ctx, log.With(s.logger, "block", id),
-		s.bucket, id, dir, s.indexCache, s.chunkPool)
+	b, err := newBucketBlock(
+		ctx,
+		log.With(s.logger, "block", id),
+		s.bucket,
+		id,
+		dir,
+		s.indexCache,
+		s.chunkPool,
+	)
 	if err != nil {
 		return errors.Wrap(err, "new bucket block")
 	}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -314,7 +314,9 @@ func (s *BucketStore) InitialSync(ctx context.Context) error {
 		}
 
 		// No such block loaded, remove the local dir.
-		return os.RemoveAll(path.Join(s.dir, id.String()))
+		if err := os.RemoveAll(path.Join(s.dir, id.String())); err != nil {
+			level.Warn(s.logger).Log("msg", "failed to remove block which is not needed", "err", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This improves the startup time when most files are cached (we load using multiple concurrent workers).

Improves: https://github.com/improbable-eng/thanos/issues/309

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>