### PR TITLE
Replace gcs/s3 bucket init code with factory

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -91,7 +91,13 @@ func runCompact(
 	if err != nil {
 		return err
 	}
-	defer closeFn()
+
+	// Ensure we close up everything properly.
+	defer func() {
+		if err != nil {
+			closeFn()
+		}
+	}()
 
 	sy, err := compact.NewSyncer(logger, reg, bkt, syncDelay)
 	if err != nil {
@@ -175,6 +181,8 @@ func runCompact(
 		}
 
 		g.Add(func() error {
+			defer closeFn()
+
 			if !wait {
 				return f()
 			}

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -2,20 +2,16 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"path"
-	"runtime"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/compact"
 	"github.com/improbable-eng/thanos/pkg/compact/downsample"
-	"github.com/improbable-eng/thanos/pkg/objstore"
-	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
+	"github.com/improbable-eng/thanos/pkg/objstore/client"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
 	"github.com/improbable-eng/thanos/pkg/query/ui"
 	"github.com/improbable-eng/thanos/pkg/runutil"
@@ -25,9 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/route"
-	"github.com/prometheus/common/version"
 	"github.com/prometheus/tsdb"
-	"google.golang.org/api/option"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -81,11 +75,6 @@ func runCompact(
 	wait bool,
 	component string,
 ) error {
-	var (
-		bkt    objstore.Bucket
-		bucket string
-	)
-
 	halted := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_compactor_halted",
 		Help: "Set to 1 if the compactor halted due to an unexpected error",
@@ -98,27 +87,11 @@ func runCompact(
 
 	reg.MustRegister(halted)
 
-	if gcsBucket != "" {
-		gcsOptions := option.WithUserAgent(fmt.Sprintf("thanos-%s/%s (%s)", component, version.Version, runtime.Version()))
-		gcsClient, err := storage.NewClient(context.Background(), gcsOptions)
-		if err != nil {
-			return errors.Wrap(err, "create GCS client")
-		}
-		bkt = gcs.NewBucket(gcsBucket, gcsClient.Bucket(gcsBucket), reg)
-		bucket = gcsBucket
-	} else if s3Config.Validate() == nil {
-		b, err := s3.NewBucket(s3Config, reg, component)
-		if err != nil {
-			return errors.Wrap(err, "create s3 client")
-		}
-
-		bkt = b
-		bucket = s3Config.Bucket
-	} else {
-		return errors.New("no valid GCS or S3 configuration supplied")
+	bkt, closeFn, err := client.NewBucket(&gcsBucket, *s3Config, reg, component)
+	if err != nil {
+		return err
 	}
-
-	bkt = objstore.BucketWithMetrics(bucket, bkt, reg)
+	defer closeFn()
 
 	sy, err := compact.NewSyncer(logger, reg, bkt, syncDelay)
 	if err != nil {

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -67,7 +67,7 @@ func runDownsample(
 		return err
 	}
 
-	// Ensure we close up everything properly
+	// Ensure we close up everything properly.
 	defer func() {
 		if err != nil {
 			closeFn()

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -67,6 +67,13 @@ func runDownsample(
 		return err
 	}
 
+	// Ensure we close up everything properly
+	defer func() {
+		if err != nil {
+			closeFn()
+		}
+	}()
+
 	// Start cycle of syncing blocks from the bucket and garbage collecting the bucket.
 	{
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -392,6 +392,13 @@ func runRule(
 	}
 
 	if uploads {
+		// Ensure we close up everything properly.
+		defer func() {
+			if err != nil {
+				closeFn()
+			}
+		}()
+
 		s := shipper.New(logger, nil, dataDir, bkt, func() labels.Labels { return lset })
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -19,13 +19,12 @@ import (
 	"syscall"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/alert"
 	"github.com/improbable-eng/thanos/pkg/cluster"
 	"github.com/improbable-eng/thanos/pkg/objstore"
-	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
+	"github.com/improbable-eng/thanos/pkg/objstore/client"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/shipper"
@@ -380,8 +379,7 @@ func runRule(
 	}
 
 	var (
-		bkt    objstore.Bucket
-		bucket string
+		bkt objstore.Bucket
 		// closeFn gets called when the sync loop ends to close clients, clean up, etc
 		closeFn = func() error { return nil }
 		uploads = true
@@ -389,30 +387,17 @@ func runRule(
 
 	// The background shipper continuously scans the data directory and uploads
 	// new blocks to Google Cloud Storage or an S3-compatible storage service.
-	if gcsBucket != "" {
-		gcsClient, err := storage.NewClient(context.Background())
+	if gcsBucket != "" || s3Config.Validate() == nil {
+		bkt, closeFn, err = client.NewBucket(&gcsBucket, *s3Config, reg, component)
 		if err != nil {
-			return errors.Wrap(err, "create GCS client")
+			return err
 		}
-
-		bkt = gcs.NewBucket(gcsBucket, gcsClient.Bucket(gcsBucket), reg)
-		closeFn = gcsClient.Close
-		bucket = gcsBucket
-	} else if s3Config.Validate() == nil {
-		bkt, err = s3.NewBucket(s3Config, reg, component)
-		if err != nil {
-			return errors.Wrap(err, "create s3 client")
-		}
-
-		bucket = s3Config.Bucket
 	} else {
 		level.Info(logger).Log("msg", "No GCS or S3 bucket configured, uploads will be disabled")
 		uploads = false
 	}
 
 	if uploads {
-		bkt = objstore.BucketWithMetrics(bucket, bkt, reg)
-
 		s := shipper.New(logger, nil, dataDir, bkt, func() labels.Labels { return lset })
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -384,8 +384,10 @@ func runRule(
 	bkt, closeFn, err := client.NewBucket(&gcsBucket, *s3Config, reg, component)
 	if err != nil && err != client.ErrNotFound {
 		return err
-	} else {
-		level.Info(logger).Log("msg", "No GCS or S3 bucket configured, uploads will be disabled")
+	}
+
+	if err == client.ErrNotFound {
+		level.Info(logger).Log("msg", "No GCS or S3 bucket was configured, uploads will be disabled")
 		uploads = false
 	}
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -259,9 +259,11 @@ func runSidecar(
 	bkt, closeFn, err := client.NewBucket(&gcsBucket, *s3Config, reg, component)
 	if err != nil && err != client.ErrNotFound {
 		return err
-	} else {
+	}
+
+	if err == client.ErrNotFound {
+		level.Info(logger).Log("msg", "No GCS or S3 bucket was configured, uploads will be disabled")
 		uploads = false
-		level.Info(logger).Log("msg", "No GCS or S3 bucket were configured, uploads will be disabled")
 	}
 
 	if uploads {

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -267,6 +267,12 @@ func runSidecar(
 	}
 
 	if uploads {
+		// Ensure we close up everything properly.
+		defer func() {
+			if err != nil {
+				closeFn()
+			}
+		}()
 
 		s := shipper.New(logger, nil, dataDir, bkt, externalLabels.Get)
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -105,6 +105,13 @@ func runStore(
 			return err
 		}
 
+		// Ensure we close up everything properly
+		defer func() {
+			if err != nil {
+				closeFn()
+			}
+		}()
+
 		bs, err := store.NewBucketStore(
 			logger,
 			reg,

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -105,7 +105,7 @@ func runStore(
 			return err
 		}
 
-		// Ensure we close up everything properly
+		// Ensure we close up everything properly.
 		defer func() {
 			if err != nil {
 				closeFn()

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -18,7 +18,6 @@ import (
 var ErrNotFound = errors.New("no valid GCS or S3 configuration supplied")
 
 // NewBucket initializes and returns new object storage clients.
-// TODO(bplotka): Use that in every command.
 func NewBucket(gcsBucket *string, s3Config s3.Config, reg *prometheus.Registry, component string) (objstore.Bucket, func() error, error) {
 	if *gcsBucket != "" {
 		gcsOptions := option.WithUserAgent(fmt.Sprintf("thanos-%s/%s (%s)", component, version.Version, runtime.Version()))
@@ -26,7 +25,9 @@ func NewBucket(gcsBucket *string, s3Config s3.Config, reg *prometheus.Registry, 
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "create GCS client")
 		}
-		return gcs.NewBucket(*gcsBucket, gcsClient.Bucket(*gcsBucket), reg), gcsClient.Close, nil
+		b := gcs.NewBucket(*gcsBucket, gcsClient.Bucket(*gcsBucket), reg)
+		bkt := objstore.BucketWithMetrics(*gcsBucket, b, reg)
+		return bkt, gcsClient.Close, nil
 	}
 
 	if s3Config.Validate() == nil {
@@ -34,7 +35,8 @@ func NewBucket(gcsBucket *string, s3Config s3.Config, reg *prometheus.Registry, 
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "create s3 client")
 		}
-		return b, func() error { return nil }, nil
+		bkt := objstore.BucketWithMetrics(s3Config.Bucket, b, reg)
+		return bkt, func() error { return nil }, nil
 	}
 
 	return nil, nil, ErrNotFound

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -25,9 +25,7 @@ func NewBucket(gcsBucket *string, s3Config s3.Config, reg *prometheus.Registry, 
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "create GCS client")
 		}
-		b := gcs.NewBucket(*gcsBucket, gcsClient.Bucket(*gcsBucket), reg)
-		bkt := objstore.BucketWithMetrics(*gcsBucket, b, reg)
-		return bkt, gcsClient.Close, nil
+		return objstore.BucketWithMetrics(*gcsBucket, gcs.NewBucket(*gcsBucket, gcsClient.Bucket(*gcsBucket), reg), reg), gcsClient.Close, nil
 	}
 
 	if s3Config.Validate() == nil {
@@ -35,8 +33,7 @@ func NewBucket(gcsBucket *string, s3Config s3.Config, reg *prometheus.Registry, 
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "create s3 client")
 		}
-		bkt := objstore.BucketWithMetrics(s3Config.Bucket, b, reg)
-		return bkt, func() error { return nil }, nil
+		return objstore.BucketWithMetrics(s3Config.Bucket, b, reg), func() error { return nil }, nil
 	}
 
 	return nil, nil, ErrNotFound


### PR DESCRIPTION
Replaces copy and pasted object store initialization with an already existing factory function.
Also makes sure that metrics are created whenever the object store instance is required.

Signed-off-by: Łukasz Jernaś <deejay1@srem.org>