### PR TITLE
store: Fix storeset to check external label duplicates correctly and allow multiple store nodes.

### DIFF
--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -252,10 +252,12 @@ func (s *StoreSet) Update(ctx context.Context) {
 	}
 
 	// Swap old store set with new one, excluding these with duplicated external labels.
-	s.stores = make(map[string]*storeRef, len(s.stores))
+	s.stores = make(map[string]*storeRef, len(stores))
 	for addr, st := range stores {
-		// Check if it has some ext labels specified. If no, it means that it might be a store node and it is fine to have
-		// access to multiple of store nodes in the querier. If it has some, block duplicates.
+		// Check if it has some ext labels specified.
+		// No external labels means strictly store gateway or ruler and it is fine to have access to multiple instances of them.
+		//
+		// Sidecar will error out if it will be configured with empty external labels.
 		if len(st.Labels()) == 0 || externalLabelStores[externalLabelsFromStore(st)] == 1 {
 			s.stores[addr] = st
 			continue

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"sort"
+
 	"github.com/fortytw2/leaktest"
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/improbable-eng/thanos/pkg/testutil"
@@ -48,13 +50,26 @@ type testStores struct {
 	srvs map[string]*grpc.Server
 }
 
-func newTestStores(numStores int) (*testStores, error) {
+func newTestStores(numStores int, storesExtLabels ...[]storepb.Label) (*testStores, error) {
 	st := &testStores{
 		srvs: map[string]*grpc.Server{},
 	}
 
 	for i := 0; i < numStores; i++ {
-		srv, addr, err := startStore()
+		lsetFn := func(addr string) []storepb.Label {
+			if len(storesExtLabels) != numStores {
+				return []storepb.Label{
+					{
+						Name:  "addr",
+						Value: addr,
+					},
+				}
+			}
+
+			return storesExtLabels[i]
+		}
+
+		srv, addr, err := startStore(lsetFn)
 		if err != nil {
 			// Close so far started servers.
 			st.Close()
@@ -67,21 +82,14 @@ func newTestStores(numStores int) (*testStores, error) {
 	return st, nil
 }
 
-func startStore() (*grpc.Server, string, error) {
+func startStore(lsetFn func(addr string) []storepb.Label) (*grpc.Server, string, error) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, "", err
 	}
 
 	srv := grpc.NewServer()
-	storepb.RegisterStoreServer(srv, &testStore{info: storepb.InfoResponse{
-		Labels: []storepb.Label{
-			{
-				Name:  "addr",
-				Value: listener.Addr().String(),
-			},
-		},
-	}})
+	storepb.RegisterStoreServer(srv, &testStore{info: storepb.InfoResponse{Labels: lsetFn(listener.Addr().String())}})
 	go func() {
 		srv.Serve(listener)
 	}()
@@ -165,7 +173,6 @@ func TestStoreSet_AllAvailable_ThenDown(t *testing.T) {
 	testutil.Equals(t, 1, len(store.labels))
 	testutil.Equals(t, "addr", store.labels[0].Name)
 	testutil.Equals(t, addr, store.labels[0].Value)
-
 }
 
 func TestStoreSet_StaticStores_OneAvailable(t *testing.T) {
@@ -217,4 +224,71 @@ func TestStoreSet_StaticStores_NoneAvailable(t *testing.T) {
 	testutil.Assert(t, len(storeSet.stores) == 0, "none of services should respond just fine, so we expect no client to be ready.")
 
 	// Leak test will ensure that we don't keep client connection around.
+}
+
+func TestStoreSet_AllAvailable_BlockExtLsetDuplicates(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 10*time.Second)()
+
+	storeExtLabels := [][]storepb.Label{
+		{
+			{
+				Name:  "l1",
+				Value: "v1",
+			},
+		},
+		{
+			{
+				Name:  "l1",
+				Value: "v2",
+			},
+		},
+		{
+			{
+				// Duplicate with above.
+				Name:  "l1",
+				Value: "v2",
+			},
+		},
+		// Two store nodes, they don't have ext labels set.
+		nil,
+		nil,
+	}
+	st, err := newTestStores(5, storeExtLabels...)
+	testutil.Ok(t, err)
+	defer st.Close()
+
+	initialStoreAddr := st.StoreAddresses()
+
+	storeSet := NewStoreSet(nil, nil, specsFromAddrFunc(initialStoreAddr), testGRPCOpts)
+	storeSet.gRPCRetryTimeout = 2 * time.Second
+	defer storeSet.Close()
+
+	// Should not matter how many of these we run.
+	storeSet.Update(context.Background())
+	storeSet.Update(context.Background())
+	storeSet.Update(context.Background())
+	storeSet.Update(context.Background())
+
+	testutil.Assert(t, len(storeSet.stores) == 5-2, "all services should respond just fine, but we expect duplicates being blocked.")
+
+	// Sort result to be able to compare.
+
+	var existingStoreLabels [][]storepb.Label
+	for _, store := range storeSet.stores {
+		existingStoreLabels = append(existingStoreLabels, store.Labels())
+	}
+	sort.Slice(existingStoreLabels, func(i, j int) bool {
+		return len(existingStoreLabels[i]) > len(existingStoreLabels[j])
+	})
+
+	var i int
+	for _, lset := range existingStoreLabels {
+		testutil.Equals(t, storeExtLabels[i], lset)
+
+		i++
+		if i == 1 {
+			// Store 1 and 2 should be blocked, so fast forward.
+			i += 2
+		}
+	}
 }

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -39,9 +39,8 @@ groups:
 `
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-	defer cancel()
 
-	unexpectedExit, err := spinup(t, ctx, config{
+	exit, err := spinup(t, ctx, config{
 		workDir:          dir,
 		numQueries:       1,
 		numRules:         2,
@@ -50,8 +49,14 @@ groups:
 	})
 	if err != nil {
 		t.Errorf("spinup failed: %v", err)
+		cancel()
 		return
 	}
+
+	defer func() {
+		cancel()
+		<-exit
+	}()
 
 	expMetrics := []model.Metric{
 		{
@@ -83,7 +88,7 @@ groups:
 	}
 	err = runutil.Retry(5*time.Second, ctx.Done(), func() error {
 		select {
-		case err := <-unexpectedExit:
+		case err := <-exit:
 			t.Errorf("Some process exited unexpectedly: %v", err)
 			return nil
 		default:


### PR DESCRIPTION
Problems:
- we were checking ext labels on old stores not new ones. As a result we were adding and deleting peer all the time for duplicates.
- we were blocking multiple store nodes use case, since they don't have ext labels.

Plus, added test. PTAL @brancz 

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>