### PR TITLE
make: Turned default pushed image tag to branch-date-commit to avoid just "master" or "latest" images.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX            ?= $(shell pwd)
 FILES             ?= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 DOCKER_IMAGE_NAME ?= thanos
-DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(shell date +%Y-%m-%d)-$(shell git rev-parse HEAD)
+DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --short HEAD))-$(shell date +%Y-%m-%d)-$(shell git rev-parse HEAD)
 
 all: install-tools deps format build
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX            ?= $(shell pwd)
 FILES             ?= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 DOCKER_IMAGE_NAME ?= thanos
-DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
+DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(shell date +%Y-%m-%d)-$(shell git rev-parse HEAD)
 
 all: install-tools deps format build
 


### PR DESCRIPTION
I will manually remove `latest` and `master` tags from now on.

Basically it was really risky. In case of bug we were not able to properly tell what exactly commit is deployed. Also having "AlwaysPull` k8s policy and `master` leads to having rolled out different versions of thanos which is not safe.

Related to https://github.com/improbable-eng/thanos/issues/325 when we cannot tell what exactly commit it was running.
Signed-off-by: Bartek Plotka <bwplotka@gmail.com>