### PR TITLE
reloader: Use `os.Stat` instead of `os.Lstat`

### DIFF
--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -148,7 +148,15 @@ func (r *Reloader) apply(ctx context.Context) error {
 				return err
 			}
 
-			if f.IsDir() {
+			// filepath.Walk uses Lstat to retriev os.FileInfo. Lstat does not
+			// follow symlinks. Make sure to follow a symlink before checking
+			// if it is a directory.
+			targetFile, err := os.Stat(path)
+			if err != nil {
+				return err
+			}
+
+			if targetFile.IsDir() {
 				return nil
 			}
 


### PR DESCRIPTION
The Thanos reloader ignores any directories inside the rules directory.
If the reloader looks at a symlink to a directory, it is not interpreted as
a directory, but as a symlink and thereby not ignored.

Instead of using `os.Lstat`, use `os.Stat` to follow symlinks before
checking if it is a directory.

//CC @fabxc 