### PR TITLE
Make flag caps/punctuation consistent, fix some descriptions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -545,6 +545,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "892465cc3874ec2f1b49bf78c3555432ab6afe828d82cd128b639e9906878bc6"
+  inputs-digest = "15d0a5000c42f10d9595edc860a16c0fdce64f864ff1a60adf07daec183a9719"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -52,7 +52,7 @@ func registerBucket(m map[string]setupFunc, app *kingpin.Application, name strin
 		PlaceHolder("<bucket>").String()
 	verifyBackupS3Bucket := cmd.Flag("s3-backup-bucket", "S3 bucket name to backup blocks on repair operations.").
 		PlaceHolder("<bucket>").String()
-	verifyIssues := verify.Flag("issues", fmt.Sprintf("issues to verify (and optionally repair). Possible values: %v", allIssues())).
+	verifyIssues := verify.Flag("issues", fmt.Sprintf("Issues to verify (and optionally repair). Possible values: %v", allIssues())).
 		Short('i').Default(verifier.IndexIssueID, verifier.OverlappedBlocksIssueID).Strings()
 	m[name+" verify"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer) error {
 		bkt, closeFn, err := client.NewBucket(gcsBucket, *s3Config, reg, name)
@@ -104,7 +104,7 @@ func registerBucket(m map[string]setupFunc, app *kingpin.Application, name strin
 	}
 
 	ls := cmd.Command("ls", "list all blocks in the bucket")
-	lsOutput := ls.Flag("output", "format in which to print each block's information; may be 'json' or custom template").
+	lsOutput := ls.Flag("output", "Format in which to print each block's information. May be 'json' or custom template.").
 		Short('o').Default("").String()
 	m[name+" ls"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer) error {
 		bkt, closeFn, err := client.NewBucket(gcsBucket, *s3Config, reg, name)

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -34,13 +34,13 @@ import (
 func registerCompact(m map[string]setupFunc, app *kingpin.Application, name string) {
 	cmd := app.Command(name, "continously compacts blocks in an object store bucket")
 
-	haltOnError := cmd.Flag("debug.halt-on-error", "halt the process if a critical compaction error is detected").
+	haltOnError := cmd.Flag("debug.halt-on-error", "Halt the process if a critical compaction error is detected.").
 		Hidden().Default("true").Bool()
 
-	httpAddr := cmd.Flag("http-address", "listen host:port for HTTP endpoints").
+	httpAddr := cmd.Flag("http-address", "Listen host:port for HTTP endpoints.").
 		Default(defaultHTTPAddr).String()
 
-	dataDir := cmd.Flag("data-dir", "data directory to cache blocks and process compactions").
+	dataDir := cmd.Flag("data-dir", "Data directory in which to cache blocks and process compactions.").
 		Default("./data").String()
 
 	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks.").

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -29,18 +29,18 @@ import (
 )
 
 func registerDownsample(m map[string]setupFunc, app *kingpin.Application, name string) {
-	cmd := app.Command(name, "continously compacts blocks in an object store bucket")
+	cmd := app.Command(name, "continously downsamples blocks in an object store bucket")
 
 	httpAddr := cmd.Flag("http-address", "listen host:port for HTTP endpoints").
 		Default(defaultHTTPAddr).String()
 
-	dataDir := cmd.Flag("data-dir", "data directory to cache blocks and process compactions").
+	dataDir := cmd.Flag("data-dir", "Data directory in which to cache blocks and process downsamplings.").
 		Default("./data").String()
 
 	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks.").
 		PlaceHolder("<bucket>").Required().String()
 
-	syncDelay := cmd.Flag("sync-delay", "minimum age of blocks before they are being processed.").
+	syncDelay := cmd.Flag("sync-delay", "Minimum age of blocks before they are being processed.").
 		Default("2h").Duration()
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer) error {

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -51,9 +51,9 @@ func main() {
 	app.Version(version.Print("thanos"))
 	app.HelpFlag.Short('h')
 
-	debugName := app.Flag("debug.name", "name to prefix to log lines").Hidden().String()
+	debugName := app.Flag("debug.name", "Name to add as prefix to log lines.").Hidden().String()
 
-	logLevel := app.Flag("log.level", "log filtering level").
+	logLevel := app.Flag("log.level", "Log filtering level.").
 		Default("info").Enum("error", "warn", "info", "debug")
 
 	gcloudTraceProject := app.Flag("gcloudtrace.project", "GCP project to send Google Cloud Trace tracings to. If empty, tracing will be disabled.").

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -34,39 +34,39 @@ import (
 func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string) {
 	cmd := app.Command(name, "query node exposing PromQL enabled Query API with data retrieved from multiple store nodes")
 
-	httpAddr := cmd.Flag("http-address", "listen host:port for HTTP endpoints").
+	httpAddr := cmd.Flag("http-address", "Listen host:port for HTTP endpoints.").
 		Default(defaultHTTPAddr).String()
 
-	grpcAddr := cmd.Flag("grpc-address", "listen host:port for gRPC endpoints").
+	grpcAddr := cmd.Flag("grpc-address", "Listen host:port for gRPC endpoints.").
 		Default(defaultGRPCAddr).String()
 
-	queryTimeout := cmd.Flag("query.timeout", "maximum time to process query by query node").
+	queryTimeout := cmd.Flag("query.timeout", "Maximum time to process query by query node.").
 		Default("2m").Duration()
 
-	maxConcurrentQueries := cmd.Flag("query.max-concurrent", "maximum number of queries processed concurrently by query node").
+	maxConcurrentQueries := cmd.Flag("query.max-concurrent", "Maximum number of queries processed concurrently by query node.").
 		Default("20").Int()
 
-	replicaLabel := cmd.Flag("query.replica-label", "label to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter").
+	replicaLabel := cmd.Flag("query.replica-label", "Label to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter.").
 		String()
 
-	peers := cmd.Flag("cluster.peers", "initial peers to join the cluster. It can be either <ip:port>, or <domain:port>").Strings()
+	peers := cmd.Flag("cluster.peers", "Initial peers to join the cluster. It can be either <ip:port>, or <domain:port>.").Strings()
 
-	clusterBindAddr := cmd.Flag("cluster.address", "listen address for cluster").
+	clusterBindAddr := cmd.Flag("cluster.address", "Listen address for cluster.").
 		Default(defaultClusterAddr).String()
 
-	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "explicit address to advertise in cluster").
+	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "Explicit address to advertise in cluster.").
 		String()
 
-	gossipInterval := cmd.Flag("cluster.gossip-interval", "interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
+	gossipInterval := cmd.Flag("cluster.gossip-interval", "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
 		Default(cluster.DefaultGossipInterval.String()).Duration()
 
-	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "interval for gossip state syncs . Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
+	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
 		Default(cluster.DefaultPushPullInterval.String()).Duration()
 
-	selectorLabels := cmd.Flag("selector-label", "query selector labels that will be exposed in info endpoint (repeated)").
+	selectorLabels := cmd.Flag("selector-label", "Query selector labels that will be exposed in info endpoint (repeated).").
 		PlaceHolder("<name>=\"<value>\"").Strings()
 
-	stores := cmd.Flag("store", "addresses of statically configured store API servers (repeatable)").
+	stores := cmd.Flag("store", "Addresses of statically configured store API servers (repeatable).").
 		PlaceHolder("<store>").Strings()
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer) error {

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -51,47 +51,47 @@ import (
 func registerRule(m map[string]setupFunc, app *kingpin.Application, name string) {
 	cmd := app.Command(name, "ruler evaluating Prometheus rules against given Query nodes, exposing Store API and storing old blocks in bucket")
 
-	labelStrs := cmd.Flag("label", "labels applying to all generated metrics (repeated)").
+	labelStrs := cmd.Flag("label", "Labels to be applied to all generated metrics (repeated).").
 		PlaceHolder("<name>=\"<value>\"").Strings()
 
 	dataDir := cmd.Flag("data-dir", "data directory").Default("data/").String()
 
-	ruleFiles := cmd.Flag("rule-file", "rule files that should be used by rule manager. Can be in glob format (repeated)").
+	ruleFiles := cmd.Flag("rule-file", "Rule files that should be used by rule manager. Can be in glob format (repeated).").
 		Default("rules/").Strings()
 
-	httpAddr := cmd.Flag("http-address", "listen host:port for HTTP endpoints").
+	httpAddr := cmd.Flag("http-address", "Listen host:port for HTTP endpoints.").
 		Default(defaultHTTPAddr).String()
 
-	grpcAddr := cmd.Flag("grpc-address", "listen host:port for gRPC endpoints").
+	grpcAddr := cmd.Flag("grpc-address", "Listen host:port for gRPC endpoints.").
 		Default(defaultGRPCAddr).String()
 
-	evalInterval := cmd.Flag("eval-interval", "the default evaluation interval to use").
+	evalInterval := cmd.Flag("eval-interval", "The default evaluation interval to use.").
 		Default("30s").Duration()
-	tsdbBlockDuration := cmd.Flag("tsdb.block-duration", "block duration for TSDB block").
+	tsdbBlockDuration := cmd.Flag("tsdb.block-duration", "Block duration for TSDB block.").
 		Default("2h").Duration()
-	tsdbRetention := cmd.Flag("tsdb.retention", "block retention time on local disk").
+	tsdbRetention := cmd.Flag("tsdb.retention", "Block retention time on local disk.").
 		Default("48h").Duration()
 
 	alertmgrs := cmd.Flag("alertmanagers.url", "Alertmanager URLs to push firing alerts to. The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect Alertmanager IPs through respective DNS lookups. The port defaults to 9093 or the SRV record's value. The URL path is used as a prefix for the regular Alertmanager API path.").
 		Strings()
 
-	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks. If empty ruler won't store any block inside Google Cloud Storage").
+	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks. If empty, ruler won't store any block inside Google Cloud Storage.").
 		PlaceHolder("<bucket>").String()
 
 	s3Config := s3.RegisterS3Params(cmd)
 
-	peers := cmd.Flag("cluster.peers", "initial peers to join the cluster. It can be either <ip:port>, or <domain:port>").Strings()
+	peers := cmd.Flag("cluster.peers", "Initial peers to join the cluster. It can be either <ip:port>, or <domain:port>.").Strings()
 
-	clusterBindAddr := cmd.Flag("cluster.address", "listen address for cluster").
+	clusterBindAddr := cmd.Flag("cluster.address", "Listen address for cluster.").
 		Default(defaultClusterAddr).String()
 
-	gossipInterval := cmd.Flag("cluster.gossip-interval", "interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
+	gossipInterval := cmd.Flag("cluster.gossip-interval", "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
 		Default(cluster.DefaultGossipInterval.String()).Duration()
 
-	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "interval for gossip state syncs . Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
+	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
 		Default(cluster.DefaultPushPullInterval.String()).Duration()
 
-	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "explicit address to advertise in cluster").
+	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "Explicit address to advertise in cluster.").
 		String()
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer) error {

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -36,44 +36,44 @@ import (
 func registerSidecar(m map[string]setupFunc, app *kingpin.Application, name string) {
 	cmd := app.Command(name, "sidecar for Prometheus server")
 
-	grpcAddr := cmd.Flag("grpc-address", "listen address for gRPC endpoints").
+	grpcAddr := cmd.Flag("grpc-address", "Listen address for gRPC endpoints.").
 		Default(defaultGRPCAddr).String()
 
-	httpAddr := cmd.Flag("http-address", "listen address for HTTP endpoints").
+	httpAddr := cmd.Flag("http-address", "Listen address for HTTP endpoints.").
 		Default(defaultHTTPAddr).String()
 
-	promURL := cmd.Flag("prometheus.url", "URL at which to reach Prometheus's API").
+	promURL := cmd.Flag("prometheus.url", "URL at which to reach Prometheus's API.").
 		Default("http://localhost:9090").URL()
 
-	dataDir := cmd.Flag("tsdb.path", "data directory of TSDB").
+	dataDir := cmd.Flag("tsdb.path", "Data directory of TSDB.").
 		Default("./data").String()
 
-	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks. If empty sidecar won't store any block inside Google Cloud Storage").
+	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks. If empty, sidecar won't store any block inside Google Cloud Storage.").
 		PlaceHolder("<bucket>").String()
 
 	s3Config := s3.RegisterS3Params(cmd)
 
-	peers := cmd.Flag("cluster.peers", "initial peers to join the cluster. It can be either <ip:port>, or <domain:port>").Strings()
+	peers := cmd.Flag("cluster.peers", "Initial peers to join the cluster. It can be either <ip:port>, or <domain:port>.").Strings()
 
-	clusterBindAddr := cmd.Flag("cluster.address", "listen address for cluster").
+	clusterBindAddr := cmd.Flag("cluster.address", "Listen address for cluster.").
 		Default(defaultClusterAddr).String()
 
-	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "explicit address to advertise in cluster").
+	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "Explicit address to advertise in cluster.").
 		String()
 
-	gossipInterval := cmd.Flag("cluster.gossip-interval", "interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
+	gossipInterval := cmd.Flag("cluster.gossip-interval", "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
 		Default(cluster.DefaultGossipInterval.String()).Duration()
 
-	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "interval for gossip state syncs . Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
+	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
 		Default(cluster.DefaultPushPullInterval.String()).Duration()
 
-	reloaderCfgFile := cmd.Flag("reloader.config-file", "config file watched by the reloader").
+	reloaderCfgFile := cmd.Flag("reloader.config-file", "Config file watched by the reloader.").
 		Default("").String()
 
-	reloaderCfgSubstFile := cmd.Flag("reloader.config-envsubst-file", "output file for environment variable substituted config file").
+	reloaderCfgSubstFile := cmd.Flag("reloader.config-envsubst-file", "Output file for environment variable substituted config file.").
 		Default("").String()
 
-	reloaderRuleDir := cmd.Flag("reloader.rule-dir", "rule directory for the reloader to refresh").String()
+	reloaderRuleDir := cmd.Flag("reloader.rule-dir", "Rule directory for the reloader to refresh.").String()
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer) error {
 		rl := reloader.New(

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -29,16 +29,16 @@ import (
 func registerStore(m map[string]setupFunc, app *kingpin.Application, name string) {
 	cmd := app.Command(name, "store node giving access to blocks in a GCS bucket")
 
-	grpcAddr := cmd.Flag("grpc-address", "listen address for gRPC endpoints").
+	grpcAddr := cmd.Flag("grpc-address", "Listen address for gRPC endpoints.").
 		Default(defaultGRPCAddr).String()
 
-	httpAddr := cmd.Flag("http-address", "listen address for HTTP endpoints").
+	httpAddr := cmd.Flag("http-address", "Listen address for HTTP endpoints.").
 		Default(defaultHTTPAddr).String()
 
-	dataDir := cmd.Flag("tsdb.path", "data directory of TSDB").
+	dataDir := cmd.Flag("tsdb.path", "Data directory of TSDB.").
 		Default("./data").String()
 
-	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks. If empty sidecar won't store any block inside Google Cloud Storage").
+	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks. If empty sidecar won't store any block inside Google Cloud Storage.").
 		PlaceHolder("<bucket>").String()
 
 	s3Config := s3.RegisterS3Params(cmd)
@@ -49,18 +49,18 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 	chunkPoolSize := cmd.Flag("chunk-pool-size", "Maximum size of concurrently allocatable bytes for chunks.").
 		Default("2GB").Bytes()
 
-	peers := cmd.Flag("cluster.peers", "initial peers to join the cluster. It can be either <ip:port>, or <domain:port>").Strings()
+	peers := cmd.Flag("cluster.peers", "Initial peers to join the cluster. It can be either <ip:port>, or <domain:port>.").Strings()
 
-	clusterBindAddr := cmd.Flag("cluster.address", "listen address for cluster").
+	clusterBindAddr := cmd.Flag("cluster.address", "Listen address for cluster.").
 		Default(defaultClusterAddr).String()
 
-	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "explicit address to advertise in cluster").
+	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "Explicit address to advertise in cluster.").
 		String()
 
-	gossipInterval := cmd.Flag("cluster.gossip-interval", "interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
+	gossipInterval := cmd.Flag("cluster.gossip-interval", "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
 		Default(cluster.DefaultGossipInterval.String()).Duration()
 
-	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "interval for gossip state syncs . Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
+	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
 		Default(cluster.DefaultPushPullInterval.String()).Duration()
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer) error {


### PR DESCRIPTION
Makes all flag descriptions start capitalized and end with period (same
as in Prometheus). Some descriptions descriptions had other
typos/problems.