### PR TITLE
Fix s3 upload issue

### DIFF
--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -62,7 +62,7 @@ func TestSyncer_SyncMetas(t *testing.T) {
 	for _, m := range metas[5:] {
 		var buf bytes.Buffer
 		testutil.Ok(t, json.NewEncoder(&buf).Encode(&m))
-		testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), block.MetaFilename), &buf))
+		testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), block.MetaFilename), &buf, int64(buf.Len())))
 	}
 
 	groups, err := sy.Groups()
@@ -139,7 +139,7 @@ func TestSyncer_GarbageCollect(t *testing.T) {
 		fmt.Println("create", m.ULID)
 		var buf bytes.Buffer
 		testutil.Ok(t, json.NewEncoder(&buf).Encode(&m))
-		testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), block.MetaFilename), &buf))
+		testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), block.MetaFilename), &buf, int64(buf.Len())))
 	}
 
 	// Do one initial synchronization with the bucket.

--- a/pkg/objstore/gcs/gcs.go
+++ b/pkg/objstore/gcs/gcs.go
@@ -111,7 +111,7 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 }
 
 // Upload writes the file specified in src to remote GCS location specified as target.
-func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, filesize int64) error {
 	b.opsTotal.WithLabelValues(opObjectInsert).Inc()
 
 	w := b.bkt.Object(name).NewWriter(ctx)

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -191,9 +191,10 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 }
 
 // Upload the contents of the reader as an object into the bucket.
-func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, filesize int64) error {
 	b.opsTotal.WithLabelValues(opObjectInsert).Inc()
-	_, err := b.client.PutObjectWithContext(ctx, b.bucket, name, r, -1, minio.PutObjectOptions{})
+
+	_, err := b.client.PutObjectWithContext(ctx, b.bucket, name, r, filesize, minio.PutObjectOptions{})
 	return errors.Wrap(err, "upload s3 object")
 }
 


### PR DESCRIPTION
Iam testing thanos sidecar using s3 buckets and it fails with error:

```
vel=error ts=2018-05-15T15:06:42.013968661Z caller=shipper.go:152 msg="shipping failed" block=01CDJ51CFFYG9F7TBRDVXP00KP err="upload chunks: upload file /prometheus/data/thanos/upload/01CDJ51CFFYG9F7TBRDVXP00KP/chunks/000001 as 01CDJ51CFFYG9F7TBRDVXP00KP/chunks/000001: upload s3 object: Your proposed upload size ‘-1’ is below the minimum allowed object size ‘0B’ for single PUT operation.
```

Looking at `minio-go` code turns out filesize `-1` is only supported in GCP.

There is an explanation i comment:

 https://github.com/minio/minio-go/blob/c6412e9f72738208830f9d16014896124028c4ce/api-put-object-streaming.go#L340