### PR TITLE
Update minio client and add support for s3 SSE encryption

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -231,13 +231,12 @@
     ".",
     "pkg/credentials",
     "pkg/encrypt",
-    "pkg/policy",
     "pkg/s3signer",
     "pkg/s3utils",
     "pkg/set"
   ]
-  revision = "14f1d472d115bac5ca4804094aa87484a72ced61"
-  version = "4.0.6"
+  revision = "c6108c47ba5d86548404ebf9e51c5ca18769fe79"
+  version = "6.0.1"
 
 [[projects]]
   branch = "master"
@@ -374,6 +373,8 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = [
+    "argon2",
+    "blake2b",
     "ed25519",
     "ed25519/internal/edwards25519",
     "ssh/terminal"
@@ -545,6 +546,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "15d0a5000c42f10d9595edc860a16c0fdce64f864ff1a60adf07daec183a9719"
+  inputs-digest = "eaeee5a92d2a762dc5e29b9096799f331d4e511094693ce518d617d90c5745d8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,4 +72,4 @@
 
 [[constraint]]
   name = "github.com/minio/minio-go"
-  version = "4.0.4"
+  version = "6.0.1"


### PR DESCRIPTION
Enable support for SSE.

I've tested out this bit using my docker image, and it looks good:

```
level=info ts=2018-05-16T04:50:16.144065497Z caller=shipper.go:185 msg="upload new block" id=01CDJJRTXS20130C0QEMQ7T8GS
level=info ts=2018-05-16T04:50:26.61080944Z caller=shipper.go:185 msg="upload new block" id=01CDJSMJ5TFJXF82F7FVZXPM6H
level=info ts=2018-05-16T04:50:37.515684352Z caller=shipper.go:185 msg="upload new block" id=01CDK0G9DS7H7VXNK7BMBY1AZC
```
```
thanos bucket ls
```
```
01CDJJRTW9PDJAYKAZNWK8YG2J
01CDJJRTXS20130C0QEMQ7T8GS
01CDJSMJ490SKQPH9X5JGSE1HW
01CDJSMJ5TFJXF82F7FVZXPM6H
01CDK0G9CBNXT8C0VQ85RCPY4D
01CDK0G9DS7H7VXNK7BMBY1AZC
01CDK7C0M9BJCFDKFYFHBHQN8N
01CDK7C0NTP4EGK2YQDHMDGKGM
01CDKE7QW9AFP0T78WMQ28G73B
01CDKE7QXSXYCCCVXF27VNZKWN
level=info ts=2018-05-16T04:58:28.491598815Z caller=main.go:150 msg=exiting
```