### PR TITLE
docs: Fix link to storage.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@ At its heart Thanos provides a global query view, data backup, and access histor
 
 The following examples configure Thanos to work against a Google Cloud Storage bucket. However, any object storage (S3, HDFS, DigitalOcean Spaces, ...) can be used by using the equivalent flags to connect to the S3 API.
 
-See [this](object_stores.md) for up-to-date list of available object stores for Thanos.
+See [this](storage.md) for up-to-date list of available object stores for Thanos.
 
 ## Requirements
 


### PR DESCRIPTION
PR #328 added object_stores.md in one commit and renamed it to
storage.md in another. But the reference to object_stores.md was not
updated to refer to storage.md. Fix that.