### PR TITLE
#270 add docs for the bucket component and its sub commands

### DIFF
--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -1,0 +1,168 @@
+# Bucket
+
+The bucket component of Thanos is a set of commands to inspect data in object storage buckets.
+It is normally run as a stand alone command to aid with troubleshooting. 
+
+Example:
+
+```
+$ thanos bucket verify -r --gcs.bucket example-bucket
+```
+
+Bucket can be extended to add more subcommands that will be helpful when working with object storage buckets
+by adding a new command within `/cmd/thanos/bucket.go`
+
+
+## Deployment
+## Flags
+
+[embedmd]:# (flags/bucket.txt $)
+```$
+usage: thanos bucket [<flags>] <command> [<args> ...]
+
+inspect metric data in an object storage bucket
+
+Flags:
+  -h, --help                   Show context-sensitive help (also try --help-long
+                               and --help-man).
+      --version                Show application version.
+      --log.level=info         Log filtering level.
+      --gcloudtrace.project=GCLOUDTRACE.PROJECT  
+                               GCP project to send Google Cloud Trace tracings
+                               to. If empty, tracing will be disabled.
+      --gcloudtrace.sample-factor=1  
+                               How often we send traces (1/<sample-factor>). If
+                               0 no trace will be sent periodically, unless
+                               forced by baggage item. See
+                               `pkg/tracing/tracing.go` for details.
+      --gcs-bucket=<bucket>    Google Cloud Storage bucket name for stored
+                               blocks.
+      --s3.bucket=<bucket>     S3-Compatible API bucket name for stored blocks.
+      --s3.endpoint=<api-url>  S3-Compatible API endpoint for stored blocks.
+      --s3.access-key=<key>    Access key for an S3-Compatible API.
+      --s3.insecure            Whether to use an insecure connection with an
+                               S3-Compatible API.
+      --s3.signature-version2  Whether to use S3 Signature Version 2; otherwise
+                               Signature Version 4 will be used.
+      --s3.encrypt-sse         Whether to use Server Side Encryption
+      --gcs-backup-bucket=<bucket>  
+                               Google Cloud Storage bucket name to backup blocks
+                               on repair operations.
+      --s3-backup-bucket=<bucket>  
+                               S3 bucket name to backup blocks on repair
+                               operations.
+
+Subcommands:
+  bucket verify [<flags>]
+    verify all blocks in the bucket against specified issues
+
+  bucket ls [<flags>]
+    list all blocks in the bucket
+
+
+```
+
+### Verify
+
+`bucket verify` is used to verify and optionally repair blocks within the specified bucket.
+
+Example:
+
+```
+$ thanos bucket verify -r --gcs.bucket example-bucket
+``` 
+
+[embedmd]:# (flags/bucket_verify.txt)
+```txt
+usage: thanos bucket verify [<flags>]
+
+verify all blocks in the bucket against specified issues
+
+Flags:
+  -h, --help                   Show context-sensitive help (also try --help-long
+                               and --help-man).
+      --version                Show application version.
+      --log.level=info         Log filtering level.
+      --gcloudtrace.project=GCLOUDTRACE.PROJECT  
+                               GCP project to send Google Cloud Trace tracings
+                               to. If empty, tracing will be disabled.
+      --gcloudtrace.sample-factor=1  
+                               How often we send traces (1/<sample-factor>). If
+                               0 no trace will be sent periodically, unless
+                               forced by baggage item. See
+                               `pkg/tracing/tracing.go` for details.
+      --gcs-bucket=<bucket>    Google Cloud Storage bucket name for stored
+                               blocks.
+      --s3.bucket=<bucket>     S3-Compatible API bucket name for stored blocks.
+      --s3.endpoint=<api-url>  S3-Compatible API endpoint for stored blocks.
+      --s3.access-key=<key>    Access key for an S3-Compatible API.
+      --s3.insecure            Whether to use an insecure connection with an
+                               S3-Compatible API.
+      --s3.signature-version2  Whether to use S3 Signature Version 2; otherwise
+                               Signature Version 4 will be used.
+      --s3.encrypt-sse         Whether to use Server Side Encryption
+      --gcs-backup-bucket=<bucket>  
+                               Google Cloud Storage bucket name to backup blocks
+                               on repair operations.
+      --s3-backup-bucket=<bucket>  
+                               S3 bucket name to backup blocks on repair
+                               operations.
+  -r, --repair                 attempt to repair blocks for which issues were
+                               detected
+  -i, --issues=index_issue... ...  
+                               Issues to verify (and optionally repair).
+                               Possible values: [index_issue overlapped_blocks
+                               duplicated_compaction]
+
+```
+
+### ls
+
+`bucket ls` is used to list all blocks in the specified bucket.
+
+Example:
+
+```
+$ thanos bucket ls -o="json" --gcs.bucket example-bucket
+``` 
+
+[embedmd]:# (flags/bucket_ls.txt)
+```txt
+usage: thanos bucket ls [<flags>]
+
+lqist all blocks in the bucket
+
+Flags:
+  -h, --help                   Show context-sensitive help (also try --help-long
+                               and --help-man).
+      --version                Show application version.
+      --log.level=info         Log filtering level.
+      --gcloudtrace.project=GCLOUDTRACE.PROJECT  
+                               GCP project to send Google Cloud Trace tracings
+                               to. If empty, tracing will be disabled.
+      --gcloudtrace.sample-factor=1  
+                               How often we send traces (1/<sample-factor>). If
+                               0 no trace will be sent periodically, unless
+                               forced by baggage item. See
+                               `pkg/tracing/tracing.go` for details.
+      --gcs-bucket=<bucket>    Google Cloud Storage bucket name for stored
+                               blocks.
+      --s3.bucket=<bucket>     S3-Compatible API bucket name for stored blocks.
+      --s3.endpoint=<api-url>  S3-Compatible API endpoint for stored blocks.
+      --s3.access-key=<key>    Access key for an S3-Compatible API.
+      --s3.insecure            Whether to use an insecure connection with an
+                               S3-Compatible API.
+      --s3.signature-version2  Whether to use S3 Signature Version 2; otherwise
+                               Signature Version 4 will be used.
+      --s3.encrypt-sse         Whether to use Server Side Encryption
+      --gcs-backup-bucket=<bucket>  
+                               Google Cloud Storage bucket name to backup blocks
+                               on repair operations.
+      --s3-backup-bucket=<bucket>  
+                               S3 bucket name to backup blocks on repair
+                               operations.
+  -o, --output=""              Format in which to print each block's
+                               information. May be 'json' or custom template.
+
+```
+

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -6,7 +6,7 @@ It is normally run as a stand alone command to aid with troubleshooting.
 Example:
 
 ```
-$ thanos bucket verify -r --gcs.bucket example-bucket
+$ thanos bucket verify --gcs.bucket example-bucket
 ```
 
 Bucket can be extended to add more subcommands that will be helpful when working with object storage buckets
@@ -69,7 +69,7 @@ Subcommands:
 Example:
 
 ```
-$ thanos bucket verify -r --gcs.bucket example-bucket
+$ thanos bucket verify --gcs.bucket example-bucket
 ``` 
 
 [embedmd]:# (flags/bucket_verify.txt)
@@ -123,7 +123,7 @@ Flags:
 Example:
 
 ```
-$ thanos bucket ls -o="json" --gcs.bucket example-bucket
+$ thanos bucket ls -o json --gcs.bucket example-bucket
 ``` 
 
 [embedmd]:# (flags/bucket_ls.txt)

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -18,26 +18,40 @@ On-disk data is safe to delete between restarts and should be the first attempt 
 
 [embedmd]:# (flags/compact.txt $)
 ```$
-usage: thanos compact --gcs.bucket=<bucket> [<flags>]
+usage: thanos compact [<flags>]
 
 continously compacts blocks in an object store bucket
 
 Flags:
-  -h, --help                 Show context-sensitive help (also try --help-long
-                             and --help-man).
-      --version              Show application version.
-      --log.level=info       log filtering level
+  -h, --help                   Show context-sensitive help (also try --help-long
+                               and --help-man).
+      --version                Show application version.
+      --log.level=info         Log filtering level.
       --gcloudtrace.project=GCLOUDTRACE.PROJECT  
-                             GCP project to send Google Cloud Trace tracings to.
-                             If empty, tracing will be disabled.
+                               GCP project to send Google Cloud Trace tracings
+                               to. If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
-                             How often we send traces (1/<sample-factor>).
+                               How often we send traces (1/<sample-factor>). If
+                               0 no trace will be sent periodically, unless
+                               forced by baggage item. See
+                               `pkg/tracing/tracing.go` for details.
       --http-address="0.0.0.0:10902"  
-                             listen host:port for HTTP endpoints
-      --data-dir="./data"    data directory to cache blocks and process
-                             compactions
-      --gcs.bucket=<bucket>  Google Cloud Storage bucket name for stored blocks.
-      --sync-delay=2h        minimum age of blocks before they are being
-                             processed.
+                               Listen host:port for HTTP endpoints.
+      --data-dir="./data"      Data directory in which to cache blocks and
+                               process compactions.
+      --gcs.bucket=<bucket>    Google Cloud Storage bucket name for stored
+                               blocks.
+      --s3.bucket=<bucket>     S3-Compatible API bucket name for stored blocks.
+      --s3.endpoint=<api-url>  S3-Compatible API endpoint for stored blocks.
+      --s3.access-key=<key>    Access key for an S3-Compatible API.
+      --s3.insecure            Whether to use an insecure connection with an
+                               S3-Compatible API.
+      --s3.signature-version2  Whether to use S3 Signature Version 2; otherwise
+                               Signature Version 4 will be used.
+      --s3.encrypt-sse         Whether to use Server Side Encryption
+      --sync-delay=30m         Minimum age of fresh (non-compacted) blocks
+                               before they are being processed.
+  -w, --wait                   Do not exit after all compactions have been
+                               processed and wait for new work.
 
 ```

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -39,28 +39,48 @@ Flags:
   -h, --help                     Show context-sensitive help (also try
                                  --help-long and --help-man).
       --version                  Show application version.
-      --log.level=info           log filtering level
+      --log.level=info           Log filtering level.
       --gcloudtrace.project=GCLOUDTRACE.PROJECT  
                                  GCP project to send Google Cloud Trace tracings
                                  to. If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
                                  How often we send traces (1/<sample-factor>).
+                                 If 0 no trace will be sent periodically, unless
+                                 forced by baggage item. See
+                                 `pkg/tracing/tracing.go` for details.
       --http-address="0.0.0.0:10902"  
-                                 listen host:port for HTTP endpoints
-      --query.timeout=2m         maximum time to process query by query node
-      --query.max-concurrent=20  maximum number of queries processed
-                                 concurrently by query node
+                                 Listen host:port for HTTP endpoints.
+      --grpc-address="0.0.0.0:10901"  
+                                 Listen host:port for gRPC endpoints.
+      --query.timeout=2m         Maximum time to process query by query node.
+      --query.max-concurrent=20  Maximum number of queries processed
+                                 concurrently by query node.
       --query.replica-label=QUERY.REPLICA-LABEL  
-                                 label to treat as a replica indicator along
+                                 Label to treat as a replica indicator along
                                  which data is deduplicated. Still you will be
                                  able to query without deduplication using
-                                 'dedup=false' parameter
+                                 'dedup=false' parameter.
       --cluster.peers=CLUSTER.PEERS ...  
-                                 initial peers to join the cluster. It can be
-                                 either <ip:port>, or <domain:port>
+                                 Initial peers to join the cluster. It can be
+                                 either <ip:port>, or <domain:port>.
       --cluster.address="0.0.0.0:10900"  
-                                 listen address for cluster
+                                 Listen address for cluster.
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
-                                 explicit address to advertise in cluster
+                                 Explicit address to advertise in cluster.
+      --cluster.gossip-interval=5s  
+                                 Interval between sending gossip messages. By
+                                 lowering this value (more frequent) gossip
+                                 messages are propagated across the cluster more
+                                 quickly at the expense of increased bandwidth.
+      --cluster.pushpull-interval=5s  
+                                 Interval for gossip state syncs. Setting this
+                                 interval lower (more frequent) will increase
+                                 convergence speeds across larger clusters at
+                                 the expense of increased bandwidth usage.
+      --selector-label=<name>="<value>" ...  
+                                 Query selector labels that will be exposed in
+                                 info endpoint (repeated).
+      --store=<store> ...        Addresses of statically configured store API
+                                 servers (repeatable).
 
 ```

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -28,32 +28,35 @@ Rules are processed with deduplicated data according to the replica label config
 ```$
 usage: thanos rule [<flags>]
 
-query node exposing PromQL enabled Query API with data retrieved from multiple
-store nodes
+ruler evaluating Prometheus rules against given Query nodes, exposing Store API
+and storing old blocks in bucket
 
 Flags:
   -h, --help                    Show context-sensitive help (also try
                                 --help-long and --help-man).
       --version                 Show application version.
-      --log.level=info          log filtering level
+      --log.level=info          Log filtering level.
       --gcloudtrace.project=GCLOUDTRACE.PROJECT  
                                 GCP project to send Google Cloud Trace tracings
                                 to. If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
-                                How often we send traces (1/<sample-factor>).
+                                How often we send traces (1/<sample-factor>). If
+                                0 no trace will be sent periodically, unless
+                                forced by baggage item. See
+                                `pkg/tracing/tracing.go` for details.
       --label=<name>="<value>" ...  
-                                labels applying to all generated metrics
-                                (repeated)
+                                Labels to be applied to all generated metrics
+                                (repeated).
       --data-dir="data/"        data directory
-      --rule-file=rules/ ...    rule files that should be used by rule manager.
-                                Can be in glob format (repeated)
+      --rule-file=rules/ ...    Rule files that should be used by rule manager.
+                                Can be in glob format (repeated).
       --http-address="0.0.0.0:10902"  
-                                listen host:port for HTTP endpoints
+                                Listen host:port for HTTP endpoints.
       --grpc-address="0.0.0.0:10901"  
-                                listen host:port for gRPC endpoints
-      --eval-interval=30s       the default evaluation interval to use
-      --tsdb.block-duration=2h  block duration for TSDB block
-      --tsdb.retention=48h      block retention time on local disk
+                                Listen host:port for gRPC endpoints.
+      --eval-interval=30s       The default evaluation interval to use.
+      --tsdb.block-duration=2h  Block duration for TSDB block.
+      --tsdb.retention=48h      Block retention time on local disk.
       --alertmanagers.url=ALERTMANAGERS.URL ...  
                                 Alertmanager URLs to push firing alerts to. The
                                 scheme may be prefixed with 'dns+' or 'dnssrv+'
@@ -62,14 +65,32 @@ Flags:
                                 SRV record's value. The URL path is used as a
                                 prefix for the regular Alertmanager API path.
       --gcs.bucket=<bucket>     Google Cloud Storage bucket name for stored
-                                blocks. If empty ruler won't store any block
-                                inside Google Cloud Storage
+                                blocks. If empty, ruler won't store any block
+                                inside Google Cloud Storage.
+      --s3.bucket=<bucket>      S3-Compatible API bucket name for stored blocks.
+      --s3.endpoint=<api-url>   S3-Compatible API endpoint for stored blocks.
+      --s3.access-key=<key>     Access key for an S3-Compatible API.
+      --s3.insecure             Whether to use an insecure connection with an
+                                S3-Compatible API.
+      --s3.signature-version2   Whether to use S3 Signature Version 2; otherwise
+                                Signature Version 4 will be used.
+      --s3.encrypt-sse          Whether to use Server Side Encryption
       --cluster.peers=CLUSTER.PEERS ...  
-                                initial peers to join the cluster. It can be
-                                either <ip:port>, or <domain:port>
+                                Initial peers to join the cluster. It can be
+                                either <ip:port>, or <domain:port>.
       --cluster.address="0.0.0.0:10900"  
-                                listen address for cluster
+                                Listen address for cluster.
+      --cluster.gossip-interval=5s  
+                                Interval between sending gossip messages. By
+                                lowering this value (more frequent) gossip
+                                messages are propagated across the cluster more
+                                quickly at the expense of increased bandwidth.
+      --cluster.pushpull-interval=5s  
+                                Interval for gossip state syncs. Setting this
+                                interval lower (more frequent) will increase
+                                convergence speeds across larger clusters at the
+                                expense of increased bandwidth usage.
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
-                                explicit address to advertise in cluster
+                                Explicit address to advertise in cluster.
 
 ```

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -25,50 +25,66 @@ $ thanos query \
 
 [embedmd]:# (flags/sidecar.txt $)
 ```$
-
 usage: thanos sidecar [<flags>]
 
 sidecar for Prometheus server
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
       --version                  Show application version.
-      --log.level=info           log filtering level
-      --gcloudtrace.project=GCLOUDTRACE.PROJECT
-                                 GCP project to send Google Cloud Trace tracings to. If empty, tracing will be disabled.
-      --gcloudtrace.sample-factor=1
-                                 How often we send traces (1/<sample-factor>). If 0 no trace will be sent periodically, unless forced by baggage item. See
+      --log.level=info           Log filtering level.
+      --gcloudtrace.project=GCLOUDTRACE.PROJECT  
+                                 GCP project to send Google Cloud Trace tracings
+                                 to. If empty, tracing will be disabled.
+      --gcloudtrace.sample-factor=1  
+                                 How often we send traces (1/<sample-factor>).
+                                 If 0 no trace will be sent periodically, unless
+                                 forced by baggage item. See
                                  `pkg/tracing/tracing.go` for details.
-      --grpc-address="0.0.0.0:10901"
-                                 listen address for gRPC endpoints
-      --http-address="0.0.0.0:10902"
-                                 listen address for HTTP endpoints
-      --prometheus.url=http://localhost:9090
-                                 URL at which to reach Prometheus's API
-      --tsdb.path="./data"       data directory of TSDB
-      --gcs.bucket=<bucket>      Google Cloud Storage bucket name for stored blocks. If empty sidecar won't store any block inside Google Cloud Storage
-      --s3.bucket=<bucket>       S3-Compatible API bucket name for stored blocks.
+      --grpc-address="0.0.0.0:10901"  
+                                 Listen address for gRPC endpoints.
+      --http-address="0.0.0.0:10902"  
+                                 Listen address for HTTP endpoints.
+      --prometheus.url=http://localhost:9090  
+                                 URL at which to reach Prometheus's API.
+      --tsdb.path="./data"       Data directory of TSDB.
+      --gcs.bucket=<bucket>      Google Cloud Storage bucket name for stored
+                                 blocks. If empty, sidecar won't store any block
+                                 inside Google Cloud Storage.
+      --s3.bucket=<bucket>       S3-Compatible API bucket name for stored
+                                 blocks.
       --s3.endpoint=<api-url>    S3-Compatible API endpoint for stored blocks.
       --s3.access-key=<key>      Access key for an S3-Compatible API.
-      --s3.insecure              Whether to use an insecure connection with an S3-Compatible API.
-      --s3.signature-version2    Whether to use S3 Signature Version 2; otherwise Signature Version 4 will be used.
-      --cluster.peers=CLUSTER.PEERS ...
-                                 initial peers to join the cluster. It can be either <ip:port>, or <domain:port>
-      --cluster.address="0.0.0.0:10900"
-                                 listen address for cluster
-      --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS
-                                 explicit address to advertise in cluster
-      --cluster.gossip-interval=5s
-                                 interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly
-                                 at the expense of increased bandwidth.
-      --cluster.pushpull-interval=5s
-                                 interval for gossip state syncs . Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the
-                                 expense of increased bandwidth usage.
-      --reloader.config-file=""  config file watched by the reloader
-      --reloader.config-envsubst-file=""
-                                 output file for environment variable substituted config file
-      --reloader.rule-dir=RELOADER.RULE-DIR
-                                 rule directory for the reloader to refresh
+      --s3.insecure              Whether to use an insecure connection with an
+                                 S3-Compatible API.
+      --s3.signature-version2    Whether to use S3 Signature Version 2;
+                                 otherwise Signature Version 4 will be used.
+      --s3.encrypt-sse           Whether to use Server Side Encryption
+      --cluster.peers=CLUSTER.PEERS ...  
+                                 Initial peers to join the cluster. It can be
+                                 either <ip:port>, or <domain:port>.
+      --cluster.address="0.0.0.0:10900"  
+                                 Listen address for cluster.
+      --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
+                                 Explicit address to advertise in cluster.
+      --cluster.gossip-interval=5s  
+                                 Interval between sending gossip messages. By
+                                 lowering this value (more frequent) gossip
+                                 messages are propagated across the cluster more
+                                 quickly at the expense of increased bandwidth.
+      --cluster.pushpull-interval=5s  
+                                 Interval for gossip state syncs. Setting this
+                                 interval lower (more frequent) will increase
+                                 convergence speeds across larger clusters at
+                                 the expense of increased bandwidth usage.
+      --reloader.config-file=""  Config file watched by the reloader.
+      --reloader.config-envsubst-file=""  
+                                 Output file for environment variable
+                                 substituted config file.
+      --reloader.rule-dir=RELOADER.RULE-DIR  
+                                 Rule directory for the reloader to refresh.
+
 ```
 
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -17,7 +17,7 @@ In general about 1MB of local disk space is required per TSDB block stored in th
 
 [embedmd]:# (flags/store.txt $)
 ```$
-usage: thanos store --gcs.bucket=<bucket> [<flags>]
+usage: thanos store [<flags>]
 
 store node giving access to blocks in a GCS bucket
 
@@ -25,29 +25,50 @@ Flags:
   -h, --help                    Show context-sensitive help (also try
                                 --help-long and --help-man).
       --version                 Show application version.
-      --log.level=info          log filtering level
+      --log.level=info          Log filtering level.
       --gcloudtrace.project=GCLOUDTRACE.PROJECT  
                                 GCP project to send Google Cloud Trace tracings
                                 to. If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
-                                How often we send traces (1/<sample-factor>).
+                                How often we send traces (1/<sample-factor>). If
+                                0 no trace will be sent periodically, unless
+                                forced by baggage item. See
+                                `pkg/tracing/tracing.go` for details.
       --grpc-address="0.0.0.0:10901"  
-                                listen address for gRPC endpoints
+                                Listen address for gRPC endpoints.
       --http-address="0.0.0.0:10902"  
-                                listen address for HTTP endpoints
-      --tsdb.path="./data"      data directory of TSDB
+                                Listen address for HTTP endpoints.
+      --tsdb.path="./data"      Data directory of TSDB.
       --gcs.bucket=<bucket>     Google Cloud Storage bucket name for stored
                                 blocks. If empty sidecar won't store any block
-                                inside Google Cloud Storage
+                                inside Google Cloud Storage.
+      --s3.bucket=<bucket>      S3-Compatible API bucket name for stored blocks.
+      --s3.endpoint=<api-url>   S3-Compatible API endpoint for stored blocks.
+      --s3.access-key=<key>     Access key for an S3-Compatible API.
+      --s3.insecure             Whether to use an insecure connection with an
+                                S3-Compatible API.
+      --s3.signature-version2   Whether to use S3 Signature Version 2; otherwise
+                                Signature Version 4 will be used.
+      --s3.encrypt-sse          Whether to use Server Side Encryption
       --index-cache-size=250MB  Maximum size of items held in the index cache.
-      --chunk-pool-size=2GB     Maximum size of concurrently allocatble bytes
+      --chunk-pool-size=2GB     Maximum size of concurrently allocatable bytes
                                 for chunks.
       --cluster.peers=CLUSTER.PEERS ...  
-                                initial peers to join the cluster. It can be
-                                either <ip:port>, or <domain:port>
+                                Initial peers to join the cluster. It can be
+                                either <ip:port>, or <domain:port>.
       --cluster.address="0.0.0.0:10900"  
-                                listen address for cluster
+                                Listen address for cluster.
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
-                                explicit address to advertise in cluster
+                                Explicit address to advertise in cluster.
+      --cluster.gossip-interval=5s  
+                                Interval between sending gossip messages. By
+                                lowering this value (more frequent) gossip
+                                messages are propagated across the cluster more
+                                quickly at the expense of increased bandwidth.
+      --cluster.pushpull-interval=5s  
+                                Interval for gossip state syncs. Setting this
+                                interval lower (more frequent) will increase
+                                convergence speeds across larger clusters at the
+                                expense of increased bandwidth usage.
 
 ```

--- a/scripts/genflagdocs.sh
+++ b/scripts/genflagdocs.sh
@@ -10,10 +10,15 @@ if ! [[ "$0" =~ "scripts/genflagdocs.sh" ]]; then
 fi
 
 
-commands=("compact" "query" "rule" "sidecar" "store") 
+commands=("compact" "query" "rule" "sidecar" "store" "bucket")
 
 for x in "${commands[@]}"; do
     ./thanos "${x}" --help &> "docs/components/flags/${x}.txt"
+done
+
+bucketCommands=("verify" "ls")
+for x in "${bucketCommands[@]}"; do
+    ./thanos bucket "${x}" --help &> "docs/components/flags/bucket_${x}.txt"
 done
 
 # Change dir so embedmd understand the local references made in our markdown doc.


### PR DESCRIPTION
Adding basic documentation for `bucket.go` in `/docs/components/bucket.md`.