### PR TITLE
query: Made storeset more reliable and make it log on changes.

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -253,7 +253,7 @@ func (s *gossipSpec) Addr() string {
 }
 
 // Metadata method for gossip store tries get current peer state.
-func (s *gossipSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labels []storepb.Label, mint int64, maxt int64, err error) {
+func (s *gossipSpec) Metadata(_ context.Context, _ storepb.StoreClient) (labels []storepb.Label, mint int64, maxt int64, err error) {
 	state, ok := s.peer.PeerState(s.id)
 	if !ok {
 		return nil, 0, 0, errors.Errorf("peer %s is no longer in gossip cluster", s.id)

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -143,7 +143,7 @@ func runQuery(
 ) error {
 	var staticSpecs []query.StoreSpec
 	for _, addr := range storeAddrs {
-		staticSpecs = append(staticSpecs, query.NewStaticStoreSpec(addr))
+		staticSpecs = append(staticSpecs, query.NewGRPCStoreSpec(addr))
 	}
 	var (
 		stores = query.NewStoreSet(
@@ -252,9 +252,8 @@ func (s *gossipSpec) Addr() string {
 	return s.addr
 }
 
-// Metadata method for gossip store tries get current peer state. If nothing is found, it means that gossip assumed
-// this host is unhealthy in the meantime.
-func (s *gossipSpec) Metadata(_ context.Context, _ storepb.StoreClient) (labels []storepb.Label, mint int64, maxt int64, err error) {
+// Metadata method for gossip store tries get current peer state.
+func (s *gossipSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labels []storepb.Label, mint int64, maxt int64, err error) {
 	state, ok := s.peer.PeerState(s.id)
 	if !ok {
 		return nil, 0, 0, errors.Errorf("peer %s is no longer in gossip cluster", s.id)

--- a/pkg/query/storeset_test.go
+++ b/pkg/query/storeset_test.go
@@ -125,7 +125,7 @@ func (s *testStores) CloseOne(addr string) {
 func specsFromAddrFunc(addrs []string) func() []StoreSpec {
 	return func() (specs []StoreSpec) {
 		for _, addr := range addrs {
-			specs = append(specs, NewStaticStoreSpec(addr))
+			specs = append(specs, NewGRPCStoreSpec(addr))
 		}
 		return specs
 	}
@@ -143,7 +143,7 @@ func TestStoreSet_AllAvailable_ThenDown(t *testing.T) {
 	// Testing if duplicates can cause weird results.
 	initialStoreAddr = append(initialStoreAddr, initialStoreAddr[0])
 	storeSet := NewStoreSet(nil, nil, specsFromAddrFunc(initialStoreAddr), testGRPCOpts)
-	storeSet.gRPCRetryTimeout = 2 * time.Second
+	storeSet.gRPCInfoCallTimeout = 2 * time.Second
 	defer storeSet.Close()
 
 	// Should not matter how many of these we run.
@@ -186,7 +186,7 @@ func TestStoreSet_StaticStores_OneAvailable(t *testing.T) {
 	st.CloseOne(initialStoreAddr[0])
 
 	storeSet := NewStoreSet(nil, nil, specsFromAddrFunc(initialStoreAddr), testGRPCOpts)
-	storeSet.gRPCRetryTimeout = 2 * time.Second
+	storeSet.gRPCInfoCallTimeout = 2 * time.Second
 	defer storeSet.Close()
 
 	// Should not matter how many of these we run.
@@ -216,7 +216,7 @@ func TestStoreSet_StaticStores_NoneAvailable(t *testing.T) {
 	st.CloseOne(initialStoreAddr[1])
 
 	storeSet := NewStoreSet(nil, nil, specsFromAddrFunc(initialStoreAddr), testGRPCOpts)
-	storeSet.gRPCRetryTimeout = 2 * time.Second
+	storeSet.gRPCInfoCallTimeout = 2 * time.Second
 
 	// Should not matter how many of these we run.
 	storeSet.Update(context.Background())
@@ -260,7 +260,7 @@ func TestStoreSet_AllAvailable_BlockExtLsetDuplicates(t *testing.T) {
 	initialStoreAddr := st.StoreAddresses()
 
 	storeSet := NewStoreSet(nil, nil, specsFromAddrFunc(initialStoreAddr), testGRPCOpts)
-	storeSet.gRPCRetryTimeout = 2 * time.Second
+	storeSet.gRPCInfoCallTimeout = 2 * time.Second
 	defer storeSet.Close()
 
 	// Should not matter how many of these we run.


### PR DESCRIPTION
Changes:
- gRPC dial is non-blocking, so we need to make intial Info call to make sure connection is ok for gossip.
- duplicates were wrongly handled
- log on every storeset change for better debugability

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>