### PR TITLE
sidecar: Fixed critical bug for datapoints not being accessible on query.

### DIFF
--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -160,6 +160,8 @@ func (s *Shipper) Sync(ctx context.Context) {
 		if _, ok := hasUploaded[m.ULID]; !ok {
 			if err := s.sync(ctx, m); err != nil {
 				level.Error(s.logger).Log("msg", "shipping failed", "block", m.ULID, "err", err)
+				// No error returned, just log line. This is because we want other blocks to be uploaded even
+				// though this one failed. It will be retried on second Sync iteration.
 				return nil
 			}
 		}

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestShipper_UploadBlocks_e2e(t *testing.T) {
 	objtesting.ForeachStore(t, func(t testing.TB, bkt objstore.Bucket) {
-		dir, err := ioutil.TempDir("", "shipper-test")
+		dir, err := ioutil.TempDir("", "shipper-e2e-test")
 		testutil.Ok(t, err)
 		defer os.RemoveAll(dir)
 

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -1,0 +1,78 @@
+package shipper
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"math"
+
+	"path"
+
+	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/oklog/ulid"
+	"github.com/prometheus/tsdb"
+)
+
+func TestShipperTimestamps(t *testing.T) {
+	dir, err := ioutil.TempDir("", "shipper-test")
+	testutil.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	s := New(nil, nil, dir, nil, nil)
+
+	// Missing thanos meta file.
+	_, _, err = s.Timestamps()
+	testutil.NotOk(t, err)
+
+	meta := &Meta{Version: 1}
+	testutil.Ok(t, WriteMetaFile(dir, meta))
+
+	// Nothing uploaded, nothing in the filesystem. We assume that
+	// we are still waiting for TSDB to dump first TSDB block.
+	mint, maxt, err := s.Timestamps()
+	testutil.Ok(t, err)
+	testutil.Equals(t, int64(0), mint)
+	testutil.Equals(t, int64(math.MinInt64), maxt)
+
+	id1 := ulid.MustNew(1, nil)
+	testutil.Ok(t, os.Mkdir(path.Join(dir, id1.String()), os.ModePerm))
+	testutil.Ok(t, block.WriteMetaFile(path.Join(dir, id1.String()), &block.Meta{
+		Version: 1,
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    id1,
+			MaxTime: 2000,
+			MinTime: 1000,
+		},
+	}))
+	mint, maxt, err = s.Timestamps()
+	testutil.Ok(t, err)
+	testutil.Equals(t, int64(1000), mint)
+	testutil.Equals(t, int64(math.MinInt64), maxt)
+
+	id2 := ulid.MustNew(2, nil)
+	testutil.Ok(t, os.Mkdir(path.Join(dir, id2.String()), os.ModePerm))
+	testutil.Ok(t, block.WriteMetaFile(path.Join(dir, id2.String()), &block.Meta{
+		Version: 1,
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    id2,
+			MaxTime: 4000,
+			MinTime: 2000,
+		},
+	}))
+	mint, maxt, err = s.Timestamps()
+	testutil.Ok(t, err)
+	testutil.Equals(t, int64(1000), mint)
+	testutil.Equals(t, int64(math.MinInt64), maxt)
+
+	meta = &Meta{
+		Version:  1,
+		Uploaded: []ulid.ULID{id1},
+	}
+	testutil.Ok(t, WriteMetaFile(dir, meta))
+	mint, maxt, err = s.Timestamps()
+	testutil.Ok(t, err)
+	testutil.Equals(t, int64(1000), mint)
+	testutil.Equals(t, int64(2000), maxt)
+}

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -38,10 +38,10 @@ func TestPrometheusStore_Series_e2e(t *testing.T) {
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
 	testutil.Ok(t, err)
 
-	proxy, err := NewPrometheusStore(nil, nil, nil, u,
+	proxy, err := NewPrometheusStore(nil, nil, u,
 		func() labels.Labels {
 			return labels.FromStrings("region", "eu-west")
-		})
+		}, nil)
 	testutil.Ok(t, err)
 
 	// Query all three samples except for the first one. Since we round up queried data
@@ -110,7 +110,7 @@ func TestPrometheusStore_LabelValues_e2e(t *testing.T) {
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
 	testutil.Ok(t, err)
 
-	proxy, err := NewPrometheusStore(nil, nil, nil, u, nil)
+	proxy, err := NewPrometheusStore(nil, nil, u, nil, nil)
 	testutil.Ok(t, err)
 
 	resp, err := proxy.LabelValues(ctx, &storepb.LabelValuesRequest{
@@ -144,10 +144,10 @@ func TestPrometheusStore_Series_MatchExternalLabel_e2e(t *testing.T) {
 	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
 	testutil.Ok(t, err)
 
-	proxy, err := NewPrometheusStore(nil, nil, nil, u,
+	proxy, err := NewPrometheusStore(nil, nil, u,
 		func() labels.Labels {
 			return labels.FromStrings("region", "eu-west")
-		})
+		}, nil)
 	testutil.Ok(t, err)
 	srv := newStoreSeriesServer(ctx)
 
@@ -182,4 +182,27 @@ func TestPrometheusStore_Series_MatchExternalLabel_e2e(t *testing.T) {
 
 	// No series.
 	testutil.Equals(t, 0, len(srv.SeriesSet))
+}
+
+func TestPrometheusStore_Info(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 10*time.Second)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	proxy, err := NewPrometheusStore(nil, nil, nil,
+		func() labels.Labels {
+			return labels.FromStrings("region", "eu-west")
+		},
+		func() (int64, int64) {
+			return 123, 456
+		})
+	testutil.Ok(t, err)
+
+	resp, err := proxy.Info(ctx, &storepb.InfoRequest{})
+	testutil.Ok(t, err)
+
+	testutil.Equals(t, []storepb.Label{{Name: "region", Value: "eu-west"}}, resp.Labels)
+	testutil.Equals(t, int64(123), resp.MinTime)
+	testutil.Equals(t, int64(456), resp.MaxTime)
 }

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -121,6 +121,12 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 
 		seriesSet = append(seriesSet, startStreamSeriesSet(sc, respCh, 10))
 	}
+	if len(seriesSet) == 0 {
+		err := errors.New("No store matched for this query")
+		level.Warn(s.logger).Log("err", err)
+		respCh <- storepb.NewWarnSeriesResponse(err)
+		return nil
+	}
 
 	g.Go(func() error {
 		defer close(respCh)


### PR DESCRIPTION
Fixes https://github.com/improbable-eng/thanos/issues/353

TL;DR: Because of bug inside shipper we were propagating wrong blocks time range that is accessible by sidecar. Query was then assuming that there is no need to ask this sidecar for data. This was only if there is NO TSDB block in the filesystem (first 2h)

PTAL @adamhosier 

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>