### PR TITLE
Define dependencies for build targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       - checkout
       - setup_remote_docker:
             version: 17.07.0-ce
-      - run: make install-tools
       - run: dep ensure
       - run:
           name: Create Secret if PR is not forked

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       - checkout
       - setup_remote_docker:
             version: 17.07.0-ce
-      - run: dep ensure
       - run:
           name: Create Secret if PR is not forked
           # GCS integration tests are run only for author's PR that have write access, because these tests

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ $(DEP):
 	@echo ">> fetching dep"
 	@go get -u github.com/golang/dep/cmd/dep
 
-test-deps:
+test-deps: deps
 	@go install github.com/improbable-eng/thanos/cmd/thanos
 	@go get -u github.com/prometheus/prometheus/cmd/prometheus
 	@go get -u github.com/prometheus/alertmanager/cmd/alertmanager

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@ PREFIX            ?= $(shell pwd)
 FILES             ?= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 DOCKER_IMAGE_NAME ?= thanos
 DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short HEAD)
+# $GOPATH/bin might not be in $PATH, so we can't assume `which` would give use
+# the path of promu, dep et al. As for selecting the first GOPATH, we assume:
+# - most people only have one GOPATH at a time;
+# - if you don't have one or any of those tools installed, running `go get`
+#   would place them in the first GOPATH.
+# It's possible that any of the tools would be installed in the other GOPATHs,
+# but for simplicity sake we just make sure they exist in the first one, and
+# then keep using those.
 FIRST_GOPATH      ?= $(firstword $(subst :, ,$(shell go env GOPATH)))
 PROMU             ?= $(FIRST_GOPATH)/bin/promu
 GOIMPORTS         ?= $(FIRST_GOPATH)/bin/goimports

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ vendor: Gopkg.toml Gopkg.lock | $(DEP)
 	@echo ">> dep ensure"
 	@$(DEP) ensure
 
-format: $(GOIMPORTS)
+format: $(GOIMPORTS) deps
 	@echo ">> formatting code"
 	@$(GOIMPORTS) -w $(FILES)
 

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ build: deps $(PROMU)
 	@echo ">> building binaries"
 	@$(PROMU) build --prefix $(PREFIX)
 
-install-tools: $(PROMU) $(GOIMPORTS) $(DEP)
-
 $(GOIMPORTS):
 	@echo ">> fetching goimports"
 	@go get -u golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
This patch introduces target dependencies so that requirements are met for each of the build targets. In practical terms this means there is no need to explicitly run `make install-tools` or `make deps` as these targets will be run whevener it is needed. Also, as `make` tracks modification dates for the real targets, it will not re-run dependent targets if there were no changes - meaning, these changes should not impact day-to-day development of thanos.