### PR TITLE
block: Handle gracefully extra duplicated chunk produced by TSDB issue.

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/alert"
+	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/cluster"
 	"github.com/improbable-eng/thanos/pkg/objstore/client"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
@@ -360,7 +361,7 @@ func runRule(
 			}
 		}()
 
-		s := shipper.New(logger, nil, dataDir, bkt, func() labels.Labels { return lset })
+		s := shipper.New(logger, nil, dataDir, bkt, func() labels.Labels { return lset }, block.RulerSource)
 
 		ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/cluster"
 	"github.com/improbable-eng/thanos/pkg/objstore/client"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
@@ -241,7 +242,7 @@ func runSidecar(
 			}
 		}()
 
-		s := shipper.New(logger, nil, dataDir, bkt, metadata.Labels)
+		s := shipper.New(logger, nil, dataDir, bkt, metadata.Labels, block.SidecarSource)
 		ctx, cancel := context.WithCancel(context.Background())
 
 		g.Add(func() error {

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"sync"
 	"time"
+
+	"io/ioutil"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -170,9 +171,17 @@ func (c *Syncer) syncMetas(ctx context.Context) error {
 		}
 
 		// ULIDs contain a millisecond timestamp. We do not consider blocks that have been created too recently to
-		// avoid races when a block is only partially uploaded. This relates only to level 1 blocks.
-		// NOTE: It is not safe to miss compacted block in sync step. Compactor needs to aware of ALL old blocks.
-		if meta.Compaction.Level == 1 && ulid.Now()-id.Time() < uint64(c.syncDelay/time.Millisecond) {
+		// avoid races when a block is only partially uploaded. This relates to all blocks, excluding:
+		// - repair created blocks
+		// - compactor created blocks
+		// NOTE: It is not safe to miss "old" block (even that it is newly created) in sync step. Compactor needs to aware of ALL old blocks.
+		// TODO(bplotka): https://github.com/improbable-eng/thanos/issues/377
+		if ulid.Now()-id.Time() < uint64(c.syncDelay/time.Millisecond) &&
+			meta.Thanos.Source != block.BucketRepairSource &&
+			meta.Thanos.Source != block.CompactorSource &&
+			meta.Thanos.Source != block.CompactorRepairSource {
+
+			level.Debug(c.logger).Log("msg", "block is too fresh for now", "block", id)
 			return nil
 		}
 
@@ -441,7 +450,7 @@ func (cg *Group) Resolution() int64 {
 // Compact plans and runs a single compaction against the group. The compacted result
 // is uploaded into the bucket the blocks were retrieved from.
 func (cg *Group) Compact(ctx context.Context, dir string, comp tsdb.Compactor) (ulid.ULID, error) {
-	subDir := path.Join(dir, cg.Key())
+	subDir := filepath.Join(dir, cg.Key())
 
 	if err := os.RemoveAll(subDir); err != nil {
 		return ulid.ULID{}, errors.Wrap(err, "clean compaction group dir")
@@ -450,13 +459,34 @@ func (cg *Group) Compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 		return ulid.ULID{}, errors.Wrap(err, "create compaction group dir")
 	}
 
-	id, err := cg.compact(ctx, subDir, comp)
+	compID, err := cg.compact(ctx, subDir, comp)
 	if err != nil {
 		cg.compactionFailures.Inc()
 	}
 	cg.compactions.Inc()
 
-	return id, err
+	return compID, err
+}
+
+// Issue347Error is a type wrapper for errors that should invoke repair process for broken block.
+type Issue347Error struct {
+	err error
+
+	id ulid.ULID
+}
+
+func issue347Error(err error, brokenBlock ulid.ULID) Issue347Error {
+	return Issue347Error{err: err, id: brokenBlock}
+}
+
+func (e Issue347Error) Error() string {
+	return e.err.Error()
+}
+
+// Issue347Error returns true if the base error is a Issue347Error.
+func IsIssue347Error(err error) bool {
+	_, ok := errors.Cause(err).(Issue347Error)
+	return ok
 }
 
 // HaltError is a type wrapper for errors that should halt any further progress on compactions.
@@ -532,6 +562,60 @@ func (cg *Group) areBlocksOverlapping(include *block.Meta, excludeDirs ...string
 	return nil
 }
 
+// RepairIssue347 repairs the https://github.com/prometheus/tsdb/issues/347 issue when having issue347Error.
+func RepairIssue347(ctx context.Context, logger log.Logger, bkt objstore.Bucket, issue347Err error) error {
+	ie, ok := errors.Cause(issue347Err).(Issue347Error)
+	if !ok {
+		return errors.Errorf("Given error is not an issue347 error: %v", issue347Err)
+	}
+
+	level.Info(logger).Log("msg", "Repairing block broken by https://github.com/prometheus/tsdb/issues/347", "id", ie.id, "err", issue347Err)
+
+	tmpdir, err := ioutil.TempDir("", fmt.Sprintf("repair-issue-347-id-%s-", ie.id))
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpdir)
+
+	bdir := filepath.Join(tmpdir, ie.id.String())
+	if err := block.Download(ctx, bkt, ie.id, bdir); err != nil {
+		return retry(errors.Wrapf(err, "download block %s", ie.id))
+	}
+
+	meta, err := block.ReadMetaFile(bdir)
+	if err != nil {
+		return errors.Wrapf(err, "read meta from %s", bdir)
+	}
+
+	resid, err := block.Repair(tmpdir, ie.id, block.CompactorRepairSource, block.IgnoreIssue347OutsideChunk)
+	if err != nil {
+		return errors.Wrapf(err, "repair failed for block %s", ie.id)
+	}
+
+	// Verify repaired id before uploading it.
+	if err := block.VerifyIndex(filepath.Join(tmpdir, resid.String(), block.IndexFilename), meta.MinTime, meta.MaxTime); err != nil {
+		return errors.Wrapf(err, "repaired block is invalid %s", resid)
+	}
+
+	level.Info(logger).Log("msg", "uploading repaired block", "newID", resid)
+	if err = block.Upload(ctx, bkt, filepath.Join(tmpdir, resid.String())); err != nil {
+		return retry(errors.Wrapf(err, "upload of %s failed", resid))
+	}
+
+	level.Info(logger).Log("msg", "deleting broken block", "id", ie.id)
+
+	// Spawn a new context so we always delete a block in full on shutdown.
+	delCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// TODO(bplotka): Issue with this will introduce overlap that will halt compactor. Automate that (fix duplicate overlaps caused by this).
+	if err := block.Delete(delCtx, bkt, ie.id); err != nil {
+		return errors.Wrapf(err, "deleting old block %s failed. You need to delete this block manually", ie.id)
+	}
+
+	return nil
+}
+
 func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (compID ulid.ULID, err error) {
 	cg.mtx.Lock()
 	defer cg.mtx.Unlock()
@@ -592,13 +676,26 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 			return compID, errors.Wrapf(err, "plan dir %s", pdir)
 		}
 
+		if meta.ULID.Compare(id) != 0 {
+			return compID, errors.Errorf("mismatch between meta %s and dir %s", meta.ULID, id)
+		}
+
 		if err := block.Download(ctx, cg.bkt, id, pdir); err != nil {
 			return compID, retry(errors.Wrapf(err, "download block %s", id))
 		}
 
 		// Ensure all input blocks are valid.
-		if err := block.VerifyIndex(filepath.Join(pdir, block.IndexFilename), meta.MinTime, meta.MaxTime); err != nil {
-			return compID, halt(errors.Wrapf(err, "invalid plan block %s", pdir))
+		stats, err := block.GatherIndexIssueStats(filepath.Join(pdir, block.IndexFilename), meta.MinTime, meta.MaxTime)
+		if err != nil {
+			return compID, errors.Wrapf(err, "gather index issues for block %s", pdir)
+		}
+
+		if err := stats.CriticalErr(); err != nil {
+			return compID, halt(errors.Wrapf(err, "invalid plan id %s", pdir))
+		}
+
+		if err := stats.Issue347OutsideChunksErr(); err != nil {
+			return compID, issue347Error(errors.Wrapf(err, "invalid, but reparable block %s", pdir), meta.ULID)
 		}
 	}
 	level.Debug(cg.logger).Log("msg", "downloaded and verified blocks",
@@ -615,9 +712,17 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 
 	bdir := filepath.Join(dir, compID.String())
 
-	newMeta, err := block.Finalize(bdir, cg.labels.Map(), cg.resolution, nil)
+	newMeta, err := block.InjectThanosMeta(bdir, block.ThanosMeta{
+		Labels:     cg.labels.Map(),
+		Downsample: block.ThanosDownsampleMeta{Resolution: cg.resolution},
+		Source:     block.CompactorSource,
+	}, nil)
 	if err != nil {
 		return compID, errors.Wrapf(err, "failed to finalize the block %s", bdir)
+	}
+
+	if err = os.Remove(filepath.Join(bdir, "tombstones")); err != nil {
+		return compID, errors.Wrap(err, "remove tombstones")
 	}
 
 	// Ensure the output block is valid.

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -68,6 +68,7 @@ type Shipper struct {
 	metrics *metrics
 	bucket  objstore.Bucket
 	labels  func() labels.Labels
+	source  block.SourceType
 }
 
 // New creates a new shipper that detects new TSDB blocks in dir and uploads them
@@ -78,6 +79,7 @@ func New(
 	dir string,
 	bucket objstore.Bucket,
 	lbls func() labels.Labels,
+	source block.SourceType,
 ) *Shipper {
 	if logger == nil {
 		logger = log.NewNopLogger()
@@ -91,6 +93,7 @@ func New(
 		bucket:  bucket,
 		labels:  lbls,
 		metrics: newMetrics(r),
+		source:  source,
 	}
 }
 
@@ -215,6 +218,7 @@ func (s *Shipper) sync(ctx context.Context, meta *block.Meta) (err error) {
 	if lset := s.labels(); lset != nil {
 		meta.Thanos.Labels = lset.Map()
 	}
+	meta.Thanos.Source = s.source
 	if err := block.WriteMetaFile(updir, meta); err != nil {
 		return errors.Wrap(err, "write meta file")
 	}

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -30,7 +30,7 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 		defer os.RemoveAll(dir)
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset })
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, block.TestSource)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -60,6 +60,7 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 			}
 			meta.Version = 1
 			meta.ULID = id
+			meta.Thanos.Source = block.TestSource
 
 			metab, err := json.Marshal(&meta)
 			testutil.Ok(t, err)

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -20,7 +20,7 @@ func TestShipperTimestamps(t *testing.T) {
 	testutil.Ok(t, err)
 	defer os.RemoveAll(dir)
 
-	s := New(nil, nil, dir, nil, nil)
+	s := New(nil, nil, dir, nil, nil, block.TestSource)
 
 	// Missing thanos meta file.
 	_, _, err = s.Timestamps()

--- a/pkg/verifier/duplicated_compaction.go
+++ b/pkg/verifier/duplicated_compaction.go
@@ -23,7 +23,11 @@ const DuplicatedCompactionIssueID = "duplicated_compaction"
 // until sync-delay passes.
 // The expected print of this are same overlapped blocks with exactly the same sources, time ranges and stats.
 // If repair is enabled, all but one duplicates are safely deleted.
-func DuplicatedCompactionIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool) error {
+func DuplicatedCompactionIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool) error {
+	if idMatcher != nil {
+		return errors.Errorf("id matching is not supported by issue %s verifier", DuplicatedCompactionIssueID)
+	}
+
 	level.Info(logger).Log("msg", "started verifying issue", "with-repair", repair, "issue", DuplicatedCompactionIssueID)
 
 	overlaps, err := fetchOverlaps(ctx, bkt)

--- a/pkg/verifier/index_issue.go
+++ b/pkg/verifier/index_issue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/objstore"
+	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 )
 
@@ -22,12 +23,16 @@ const IndexIssueID = "index_issue"
 // If the replacement was created successfully it is uploaded to the bucket and the input
 // block is deleted.
 // NOTE: This also verifies all indexes against chunks mismatches and duplicates.
-func IndexIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool) error {
+func IndexIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool) error {
 	level.Info(logger).Log("msg", "started verifying issue", "with-repair", repair, "issue", IndexIssueID)
 
 	err := bkt.Iter(ctx, "", func(name string) error {
 		id, ok := block.IsBlockDir(name)
 		if !ok {
+			return nil
+		}
+
+		if idMatcher != nil && !idMatcher(id) {
 			return nil
 		}
 
@@ -37,8 +42,7 @@ func IndexIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bac
 		}
 		defer os.RemoveAll(tmpdir)
 
-		err = objstore.DownloadFile(ctx, bkt, path.Join(id.String(), block.IndexFilename), filepath.Join(tmpdir, block.IndexFilename))
-		if err != nil {
+		if err = objstore.DownloadFile(ctx, bkt, path.Join(id.String(), block.IndexFilename), filepath.Join(tmpdir, block.IndexFilename)); err != nil {
 			return errors.Wrapf(err, "download index file %s", path.Join(id.String(), block.IndexFilename))
 		}
 
@@ -52,8 +56,7 @@ func IndexIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bac
 			return errors.Wrapf(err, "gather index issues %s", id)
 		}
 
-		err = stats.ErrSummary()
-		if err == nil {
+		if err = stats.AnyErr(); err == nil {
 			return nil
 		}
 
@@ -64,34 +67,40 @@ func IndexIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bac
 			return nil
 		}
 
-		if stats.OutOfOrderSum > stats.ExactSum {
+		if stats.OutOfOrderChunks > stats.DuplicatedChunks {
 			level.Warn(logger).Log("msg", "detected overlaps are not entirely by duplicated chunks. We are able to repair only duplicates", "id", id, "issue", IndexIssueID)
 		}
 
-		if stats.Outsiders > stats.CompleteOutsiders {
-			level.Warn(logger).Log("msg", "detected outsiders are not all 'complete' outsiders. We can safely delete only complete outsiders", "id", id, "issue", IndexIssueID)
+		if stats.OutsideChunks > (stats.CompleteOutsideChunks + stats.Issue347OutsideChunks) {
+			level.Warn(logger).Log("msg", "detected outsiders are not all 'complete' outsiders or outsiders from https://github.com/prometheus/tsdb/issues/347. We can safely delete only these outsiders", "id", id, "issue", IndexIssueID)
 		}
-
-		level.Info(logger).Log("msg", "repairing block", "id", id, "issue", IndexIssueID)
 
 		if meta.Thanos.Downsample.Resolution > 0 {
 			return errors.New("cannot repair downsampled blocks")
 		}
 
-		err = block.Download(ctx, bkt, id, path.Join(tmpdir, id.String()))
-		if err != nil {
+		level.Info(logger).Log("msg", "downloading block for repair", "id", id, "issue", IndexIssueID)
+		if err = block.Download(ctx, bkt, id, path.Join(tmpdir, id.String())); err != nil {
 			return errors.Wrapf(err, "download block %s", id)
 		}
 		level.Info(logger).Log("msg", "downloaded block to be repaired", "id", id, "issue", IndexIssueID)
 
-		resid, err := block.Repair(tmpdir, id)
+		level.Info(logger).Log("msg", "repairing block", "id", id, "issue", IndexIssueID)
+		resid, err := block.Repair(
+			tmpdir,
+			id,
+			block.BucketRepairSource,
+			block.IgnoreCompleteOutsideChunk,
+			block.IgnoreDuplicateOutsideChunk,
+			block.IgnoreIssue347OutsideChunk,
+		)
 		if err != nil {
 			return errors.Wrapf(err, "repair failed for block %s", id)
 		}
+		level.Info(logger).Log("msg", "verifying repaired block", "id", id, "newID", resid, "issue", IndexIssueID)
 
 		// Verify repaired block before uploading it.
-		err = block.VerifyIndex(filepath.Join(tmpdir, resid.String(), block.IndexFilename), meta.MinTime, meta.MaxTime)
-		if err != nil {
+		if err := block.VerifyIndex(filepath.Join(tmpdir, resid.String(), block.IndexFilename), meta.MinTime, meta.MaxTime); err != nil {
 			return errors.Wrapf(err, "repaired block is invalid %s", resid)
 		}
 

--- a/pkg/verifier/overlapped_blocks.go
+++ b/pkg/verifier/overlapped_blocks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/compact"
 	"github.com/improbable-eng/thanos/pkg/objstore"
+	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb"
 )
@@ -16,7 +17,11 @@ const OverlappedBlocksIssueID = "overlapped_blocks"
 
 // OverlappedBlocksIssue checks bucket for blocks with overlapped time ranges.
 // No repair is available for this issue.
-func OverlappedBlocksIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, _ objstore.Bucket, repair bool) error {
+func OverlappedBlocksIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, _ objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool) error {
+	if idMatcher != nil {
+		return errors.Errorf("id matching is not supported by issue %s verifier", DuplicatedCompactionIssueID)
+	}
+
 	level.Info(logger).Log("msg", "started verifying issue", "with-repair", repair, "issue", OverlappedBlocksIssueID)
 
 	overlaps, err := fetchOverlaps(ctx, bkt)

--- a/pkg/verifier/verify.go
+++ b/pkg/verifier/verify.go
@@ -6,12 +6,13 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/objstore"
+	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 )
 
 // Issue is an function that does verification and repair only if repair arg is true.
 // It should log affected blocks using warn level logs. It should be safe for issue to run on healthy bucket.
-type Issue func(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool) error
+type Issue func(ctx context.Context, logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bucket, repair bool, idMatcher func(ulid.ULID) bool) error
 
 // Verifier runs given issues to verify if bucket is healthy.
 type Verifier struct {
@@ -44,7 +45,7 @@ func NewWithRepair(logger log.Logger, bkt objstore.Bucket, backupBkt objstore.Bu
 }
 
 // Verify verifies registered issues.
-func (v *Verifier) Verify(ctx context.Context) error {
+func (v *Verifier) Verify(ctx context.Context, idMatcher func(ulid.ULID) bool) error {
 	level.Warn(v.logger).Log(
 		"msg", "GLOBAL COMPACTOR SHOULD __NOT__ BE RUNNING ON THE SAME BUCKET",
 		"issues", len(v.issues),
@@ -58,7 +59,7 @@ func (v *Verifier) Verify(ctx context.Context) error {
 	// TODO(blotka): Wrap bucket with BucketWithMetrics and print metrics after each issue (e.g how many blocks where touched).
 	// TODO(bplotka): Implement disk "bucket" to allow this verify to work on local disk space as well.
 	for _, issueFn := range v.issues {
-		err := issueFn(ctx, v.logger, v.bkt, v.backupBkt, v.repair)
+		err := issueFn(ctx, v.logger, v.bkt, v.backupBkt, v.repair, idMatcher)
 		if err != nil {
 			return errors.Wrap(err, "verify")
 		}


### PR DESCRIPTION
TSDB issue: https://github.com/prometheus/tsdb/issues/347

How we handle it?
- segregate this issue in special stat entry in verifier.
- auto-fix broken plan block before thanos compaction.
- adding repair job to run offline batch repair for indivdual blocks.

NOTE: At this point we have no power of fixing the bug when someone uses local compaction ):

Fixes https://github.com/improbable-eng/thanos/issues/354

PTAL @BenoitKnecht
Signed-off-by: Bartek Plotka <bwplotka@gmail.com>