### PR TITLE
Add cluster.peers refresh

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -34,6 +34,8 @@ func regCommonServerFlags(cmd *kingpin.CmdClause) (*string, *string, func(log.Lo
 	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
 		Default(cluster.DefaultPushPullInterval.String()).Duration()
 
+	refreshInterval := cmd.Flag("cluster.refresh-interval", "Interval for membership to refresh cluster.peers state, 0 disables refresh.").Default(cluster.DefaultRefreshInterval.String()).Duration()
+
 	return grpcBindAddr,
 		httpBindAddr,
 		func(logger log.Logger, reg *prometheus.Registry, waitIfEmpty bool, httpAdvertiseAddr string, queryAPIEnabled bool) (*cluster.Peer, error) {
@@ -66,7 +68,7 @@ func regCommonServerFlags(cmd *kingpin.CmdClause) (*string, *string, func(log.Lo
 				level.Info(logger).Log("msg", "QueryAPI address that will be propagated through gossip", "address", advQueryAPIAddress)
 			}
 
-			return cluster.New(logger, reg, *clusterBindAddr, *clusterAdvertiseAddr, advStoreAPIAddress, advQueryAPIAddress, *peers, waitIfEmpty, *gossipInterval, *pushPullInterval)
+			return cluster.New(logger, reg, *clusterBindAddr, *clusterAdvertiseAddr, advStoreAPIAddress, advQueryAPIAddress, *peers, waitIfEmpty, *gossipInterval, *pushPullInterval, *refreshInterval)
 		}
 }
 

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -247,6 +247,7 @@ func runQuery(
 			l.Close()
 		})
 	}
+
 	level.Info(logger).Log("msg", "starting query node")
 	return nil
 }


### PR DESCRIPTION
## Changes

Adds a job which runs periodically and refreshes peer.state (requeries DNS server to get peer ip addresses)

The issue is that if at startup DNS has no records, "islands" of 1 thanos members form and DNS never gets refreshed.

An example case where it happens is when you run thanos in Kubernetes with `liveness` probes configured and restart all thanos pods at once. So on startup no IP's will be added to DNS  due to `livenessProbe` not yet being ready and once  `membership.Join()` happens it will never refresh dns.

## Verification

This is log showing that refresh actually works `before=2 after=4`, which added thanos store gateway and cluster formed. In this case I explicitly set refresh to happen after 5mins to check that actually gossip doesn't heal itself and only after refresh happened it did.

```
level=info ts=2018-06-21T13:10:11.071198311Z caller=query.go:243 component=query msg="Listening for StoreAPI gRPC" address=0.0.0.0:10901
level=debug ts=2018-06-21T13:10:11.073078374Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH7EWVH2R31D7GYC6D1VM4Y addr=10.2.1.30:10900
level=debug ts=2018-06-21T13:10:11.087558248Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH715BMW9QB4H0GSZ51D6EA addr=10.2.2.26:10900
level=debug ts=2018-06-21T13:10:11.087692504Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH7C6135494HE709G5S2ZS8 addr=10.2.6.59:10900
level=debug ts=2018-06-21T13:10:11.087728965Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH7EFGG7WP4MB5QXDGSD35H addr=10.2.1.29:10900
level=debug ts=2018-06-21T13:10:11.087767742Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH7BYMCDXTKM552H0WVH2YN addr=10.2.6.58:10900
level=debug ts=2018-06-21T13:10:11.087828991Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH71H60AMEMHJG1CFGF9RGF addr=10.2.2.27:10900
level=debug ts=2018-06-21T13:10:11.087857058Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH714RX1Z06QVCZF9R2ZEKT addr=10.2.1.27:10900
level=debug ts=2018-06-21T13:10:11.096549794Z caller=cluster.go:194 component=cluster msg="joined cluster" peerType=query
level=debug ts=2018-06-21T13:10:11.932515848Z caller=delegate.go:88 component=cluster received=NotifyLeave node=01CGH7C6135494HE709G5S2ZS8 addr=10.2.6.59:10900
level=debug ts=2018-06-21T13:10:11.932747085Z caller=delegate.go:88 component=cluster received=NotifyLeave node=01CGH7EFGG7WP4MB5QXDGSD35H addr=10.2.1.29:10900
level=debug ts=2018-06-21T13:10:11.932794649Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH7EXA0FJYDYFPP1F60AQNV addr=10.2.2.29:10900
level=debug ts=2018-06-21T13:10:11.932863761Z caller=delegate.go:88 component=cluster received=NotifyLeave node=01CGH714RX1Z06QVCZF9R2ZEKT addr=10.2.1.27:10900
level=debug ts=2018-06-21T13:10:11.932891322Z caller=delegate.go:88 component=cluster received=NotifyLeave node=01CGH7BYMCDXTKM552H0WVH2YN addr=10.2.6.58:10900
level=debug ts=2018-06-21T13:10:11.932923465Z caller=delegate.go:88 component=cluster received=NotifyLeave node=01CGH71H60AMEMHJG1CFGF9RGF addr=10.2.2.27:10900
level=debug ts=2018-06-21T13:10:12.074395071Z caller=delegate.go:88 component=cluster received=NotifyLeave node=01CGH715BMW9QB4H0GSZ51D6EA addr=10.2.2.26:10900
level=debug ts=2018-06-21T13:15:11.128426912Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH7H1VPWW2NVXWY9PBYGZPX addr=10.2.2.31:10900
level=debug ts=2018-06-21T13:15:11.129666993Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH7EZFRWTC4TG2NQBWVVHY1 addr=10.2.6.61:10900
level=debug ts=2018-06-21T13:15:11.129704941Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH7J1WFWKBV7PQ7NBEHAR8D addr=10.2.2.32:10900
level=debug ts=2018-06-21T13:15:11.132168008Z caller=delegate.go:82 component=cluster received=NotifyJoin node=01CGH7FAH9JGANEMS9DW6TTN91 addr=10.2.1.32:10900
level=debug ts=2018-06-21T13:15:11.132245256Z caller=cluster.go:249 component=cluster msg="refreshed cluster" before=2 after=4
level=info ts=2018-06-21T13:15:16.068759342Z caller=storeset.go:223 component=storeset msg="adding new store to query storeset" address=10.2.1.32:10901
level=info ts=2018-06-21T13:15:16.0687967Z caller=storeset.go:223 component=storeset msg="adding new store to query storeset" address=10.2.2.32:10901
level=info ts=2018-06-21T13:15:16.068810515Z caller=storeset.go:223 component=storeset msg="adding new store to query storeset" address=10.2.2.31:10901
level=info ts=2018-06-21T13:15:16.068820291Z caller=storeset.go:223 component=storeset msg="adding new store to query storeset" address=10.2.6.61:10901
````