### PR TITLE
rule: supply GeneratorURL in alerts

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -40,6 +40,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage/tsdb"
+	"github.com/prometheus/prometheus/util/strutil"
 	"github.com/prometheus/tsdb/labels"
 	"google.golang.org/grpc"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -72,6 +73,8 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks. If empty, ruler won't store any block inside Google Cloud Storage.").
 		PlaceHolder("<bucket>").String()
 
+	externalQueryURL := cmd.Flag("external.query.url", "The external Thanos Query URL").PlaceHolder("<external-query-url>").String()
+
 	s3Config := s3.RegisterS3Params(cmd)
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
@@ -83,6 +86,10 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 		if err != nil {
 			return errors.Wrap(err, "new cluster peer")
 		}
+		externalQueryURL, err := url.Parse(*externalQueryURL)
+		if err != nil {
+			return errors.Wrap(err, "parse external query url")
+		}
 
 		tsdbOpts := &tsdb.Options{
 			MinBlockDuration: model.Duration(*tsdbBlockDuration),
@@ -91,7 +98,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			NoLockfile:       true,
 			WALFlushInterval: 30 * time.Second,
 		}
-		return runRule(g, logger, reg, tracer, lset, *alertmgrs, *grpcBindAddr, *httpBindAddr, *evalInterval, *dataDir, *ruleFiles, peer, *gcsBucket, s3Config, tsdbOpts, name)
+		return runRule(g, logger, reg, tracer, lset, *alertmgrs, *grpcBindAddr, *httpBindAddr, *evalInterval, *dataDir, *ruleFiles, peer, *gcsBucket, s3Config, tsdbOpts, name, externalQueryURL)
 	}
 }
 
@@ -114,6 +121,7 @@ func runRule(
 	s3Config *s3.Config,
 	tsdbOpts *tsdb.Options,
 	component string,
+	externalQueryURL *url.URL,
 ) error {
 	db, err := tsdb.Open(dataDir, log.With(logger, "component", "tsdb"), reg, tsdbOpts)
 	if err != nil {
@@ -169,9 +177,10 @@ func runRule(
 					continue
 				}
 				a := &alert.Alert{
-					StartsAt:    alrt.FiredAt,
-					Labels:      alrt.Labels,
-					Annotations: alrt.Annotations,
+					StartsAt:     alrt.FiredAt,
+					Labels:       alrt.Labels,
+					Annotations:  alrt.Annotations,
+					GeneratorURL: externalQueryURL.String() + strutil.TableLinkForExpression(expr),
 				}
 				if !alrt.ResolvedAt.IsZero() {
 					a.EndsAt = alrt.ResolvedAt

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -92,5 +92,6 @@ Flags:
                                 expense of increased bandwidth usage.
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
                                 Explicit address to advertise in cluster.
-
+      --external.query.url=<external-query-url>
+                                The external Thanos Query URL
 ```

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -92,6 +92,5 @@ Flags:
                                 expense of increased bandwidth usage.
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS  
                                 Explicit address to advertise in cluster.
-      --external.query.url=<external-query-url>
-                                The external Thanos Query URL
+      --alert.query-url         The external Thanos Query URL that would be set in all alerts 'Source' field
 ```


### PR DESCRIPTION
## Changes
This change adds a new argument `external.query.url` that represents an externally accessible thanos query URL that is in turn used to populate the source/generatorURL for each alert.

Note: This field also powers the source button in Alertmanager.

Currently when the arg is not passed the empty URL will be concatenated with the query string and passed as the generatorURL for the alert. If required we can replicate the existing behaviour of omitting field when the URL is not present or supply a default value.

## Verification
Before
![image](https://user-images.githubusercontent.com/22008619/41858572-1da97aba-7892-11e8-9db6-a9293bd44dc1.png)


After
![image](https://user-images.githubusercontent.com/22008619/41858305-706eb8ba-7891-11e8-83af-d2edfd2eeb85.png)
