### PR TITLE
sidecar: Handle empty series from Prometheus remote read.

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -198,7 +198,7 @@ func runSidecar(
 		if err != nil {
 			return errors.Wrap(err, "listen API address")
 		}
-		logger := log.With(logger, "component", "store")
+		logger := log.With(logger, "component", "sidecar")
 
 		var client http.Client
 


### PR DESCRIPTION
Fixes https://github.com/improbable-eng/thanos/issues/381

PTAL @dmitriy-lukyanchikov

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Verification

CI only