### PR TITLE
Add Thanos alert examples

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -232,3 +232,7 @@ You can find one-box example with minikube [here](../kube/README.md).
 # Dashboards
 
 You can find Grafana dashboards [here](../examples/grafana/monitoring.md)
+
+# Alerts
+
+You can find Alert configuration examples [here](../examples/alerts/alerts.md)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -231,8 +231,8 @@ You can find one-box example with minikube [here](../kube/README.md).
 
 # Dashboards
 
-You can find Grafana dashboards [here](../examples/grafana/monitoring.md)
+You can find example Grafana dashboards [here](../examples/grafana/monitoring.md)
 
 # Alerts
 
-You can find Alert configuration examples [here](../examples/alerts/alerts.md)
+You can find example Alert configuration [here](../examples/alerts/alerts.md)

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -1,0 +1,143 @@
+# Alerts
+
+Here are some example alerts configured for Kubernetes environment.
+
+## Compaction
+
+```
+- alert: ThanosCompactHalted
+  expr: thanos_compactor_halted{app="thanos-compact"} == 1
+  for: 5m
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos compaction has failed to run and now is halted
+    impact: Long term storage queries will be slower 
+    action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
+    dashboard: COMPACTION_URL
+- alert: ThanosCompactCompactionsFailed
+  expr: rate(prometheus_tsdb_compactions_failed_total{app="thanos-compact"}[5m]) > 0
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Compact is failing compaction
+    impact: Long term storage queries will be slower 
+    action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
+    dashboard: COMPACTION_URL
+- alert: ThanosCompactBucketOperationsFailed
+  expr: rate(thanos_objstore_bucket_operation_failures_total{app="thanos-compact"}[5m]) > 0
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Compact bucket operations are failing
+    impact: Long term storage queries will be slower 
+    action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
+    dashboard: COMPACTION_URL
+```
+
+## Ruler
+
+For Thanos ruler we run alerts some alerts in local Prometheus:
+
+```
+- alert: ThanosRuleIsDown
+  expr: up{app="thanos-rule"} == 0 or absent(up{app="thanos-rule"})
+  for: 5m
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Rule is down
+    impact: Alerts are not working
+    action: 'check {{ $labels.kubernetes_pod_name }} pod in {{ $labels.kubernetes_namespace}} namespace'
+    dashboard: RULE_DASHBOARD
+- alert: ThanosRuleIsDroppingAlerts
+  expr: rate(thanos_alert_queue_alerts_dropped_total{app="thanos-rule"}[5m]) > 0
+  for: 5m
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Rule is dropping alerts
+    impact: Alerts are not working
+    action: 'check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace'
+    dashboard: RULE_DASHBOARD
+```
+
+And some alerts running in thanos rule:
+
+```
+- alert: ThanosRuleGrpcErrorRate
+  expr: rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable",app="thanos-rule"}[5m]) > 0
+  for: 5m
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Rule is returning Internal/Unavailable errors
+    impact: Recording Rules are not working
+    action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
+    dashboard: RULE_DASHBOARD
+```
+
+## Store Gateway
+
+```
+- alert: ThanosStoreGrpcErrorRate
+  expr: rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable",app="thanos-store"}[5m]) > 0
+  for: 5m
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Store is returning Internal/Unavailable errors 
+    impact: Long Term Storage Prometheus queries are failing
+    action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
+    dashboard: GATEWAY_URL
+```
+
+## Sidecar
+
+```
+- alert: ThanosSidecarPrometheusDown
+  expr: thanos_sidecar_prometheus_up{name="prometheus"} == 0
+  for: 5m
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Sidecar cannot connect to Prometheus
+    impact: Prometheus configuration is not being refreshed
+    action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
+    dashboard: SIDECAR_URL
+- alert: ThanosSidecarBucketOperationsFailed
+  expr: rate(thanos_objstore_bucket_operation_failures_total{name="prometheus"}[5m]) > 0
+  for: 5m
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Sidecar bucket operations are failing
+    impact: We will lose metrics data if not fixed in 24h
+    action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
+    dashboard: SIDECAR_URL
+- alert: ThanosSidecarGrpcErrorRate
+  expr: rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable",name="prometheus"}[5m]) > 0
+  for: 5m
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Sidecar is returning Internal/Unavailable errors 
+    impact: Prometheus queries are failing
+    action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
+    dashboard: SIDECAR_URL
+```
+
+## Query
+
+```
+- alert: ThanosQueryGrpcErrorRate
+  expr: rate(grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable",name="prometheus"}[5m]) > 0
+  for: 5m
+  labels:
+    team: TEAM
+  annotations:
+    summary: Thanos Query is returning Internal/Unavailable errors 
+    impact: Grafana is not showing metrics
+    action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
+    dashboard: QUERY_URL
+```


### PR DESCRIPTION
## Changes

Adds example alerts for Thanos for running in Kubernetes environment.
This is not meant to be suited for all environments, this is just example that you can start with and adapt to your needs.


## Verification

Here is how it looks rendered -> https://github.com/povilasv/thanos/blob/alert-examples/examples/alerts/alerts.md
