### PR TITLE
Update misspelled words reported by Go report card

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -22,7 +22,7 @@ import (
 )
 
 func registerCompact(m map[string]setupFunc, app *kingpin.Application, name string) {
-	cmd := app.Command(name, "continously compacts blocks in an object store bucket")
+	cmd := app.Command(name, "continuously compacts blocks in an object store bucket")
 
 	haltOnError := cmd.Flag("debug.halt-on-error", "Halt the process if a critical compaction error is detected.").
 		Hidden().Default("true").Bool()

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -28,7 +28,7 @@ import (
 )
 
 func registerDownsample(m map[string]setupFunc, app *kingpin.Application, name string) {
-	cmd := app.Command(name, "continously downsamples blocks in an object store bucket")
+	cmd := app.Command(name, "continuously downsamples blocks in an object store bucket")
 
 	dataDir := cmd.Flag("data-dir", "Data directory in which to cache blocks and process downsamplings.").
 		Default("./data").String()
@@ -169,7 +169,7 @@ func downsampleBucket(
 			}
 			// Only downsample blocks once we are sure to get roughly 2 chunks out of it.
 			// NOTE(fabxc): this must match with at which block size the compactor creates downsampled
-			// blockes. Otherwise we may never downsample some data.
+			// blocks. Otherwise we may never downsample some data.
 			if m.MaxTime-m.MinTime < 40*60*60*1000 {
 				continue
 			}
@@ -190,7 +190,7 @@ func downsampleBucket(
 			}
 			// Only downsample blocks once we are sure to get roughly 2 chunks out of it.
 			// NOTE(fabxc): this must match with at which block size the compactor creates downsampled
-			// blockes. Otherwise we may never downsample some data.
+			// blocks. Otherwise we may never downsample some data.
 			if m.MaxTime-m.MinTime < 10*24*60*60*1000 {
 				continue
 			}

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -102,7 +102,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 	}
 }
 
-// runRule runs a rule evaluation component that continously evaluates alerting and recording
+// runRule runs a rule evaluation component that continuously evaluates alerting and recording
 // rules. It sends alert notifications and writes TSDB data for results like a regular Prometheus server.
 func runRule(
 	g *run.Group,

--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -236,7 +236,7 @@ func (b *memBlock) Close() error {
 // currentWindow returns the end timestamp of the window that t falls into.
 func currentWindow(t, r int64) int64 {
 	// The next timestamp is the next number after s.t that's aligned with window.
-	// We substract 1 because block ranges are [from, to) and the last sample would
+	// We subtract 1 because block ranges are [from, to) and the last sample would
 	// go out of bounds otherwise.
 	return t - (t % r) + r - 1
 }
@@ -692,7 +692,7 @@ func (it *CounterSeriesIterator) Err() error {
 	return it.chks[it.i].Err()
 }
 
-// AverageChunkIterator emits an artifical series of average samples based in aggregate
+// AverageChunkIterator emits an artificial series of average samples based in aggregate
 // chunks with sum and count aggregates.
 type AverageChunkIterator struct {
 	cntIt chunkenc.Iterator

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -23,7 +23,7 @@ type StoreSpec interface {
 	// Metadata returns current labels and min, max ranges for store.
 	// It can change for every call for this method.
 	// If metadata call fails we assume that store is no longer accessible and we should not use it.
-	// NOTE: It is implementation responsibility to retry until context timeout, but a caller responsibilty to manage
+	// NOTE: It is implementation responsibility to retry until context timeout, but a caller responsibility to manage
 	// given store connection.
 	Metadata(ctx context.Context, client storepb.StoreClient) (labels []storepb.Label, mint int64, maxt int64, err error)
 }

--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -1,5 +1,5 @@
 // Package reloader contains helpers to trigger reloads of Prometheus instances
-// on configuration changes and to substitude environment variables in config files.
+// on configuration changes and to substitute environment variables in config files.
 package reloader
 
 import (


### PR DESCRIPTION
## Changes 

Misspelled words in the following files

```
        modified:   cmd/thanos/compact.go
        modified:   cmd/thanos/downsample.go
        modified:   cmd/thanos/rule.go
        modified:   pkg/compact/downsample/downsample.go
        modified:   pkg/query/storeset.go
        modified:   pkg/reloader/reloader.go
```

## Verification

Document update