### PR TITLE
Split build/publish in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # NOTE: Current plan gives 1500 build minutes per month.
 version: 2
 jobs:
-  build:
+  test:
     docker:
       # Available from https://hub.docker.com/r/circleci/golang/
       - image: circleci/golang:1.10
@@ -32,15 +32,53 @@ jobs:
             echo "Skipping AWS tests."
 
             make test
+
+  build:
+    machine: true
+    working_directory: /home/circleci/.go_workspace/src/github.com/improbable-eng/thanos
+    steps:
+      - checkout
+      - run: make promu
+      - run: make crossbuild
+      - persist_to_workspace:
+          root: .
+          paths:
+          - .build
+
+  publish_master:
+    docker:
+      # Available from https://hub.docker.com/r/circleci/golang/
+      - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/improbable-eng/thanos
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 17.07.0-ce
+      - attach_workspace:
+          at: .
+      - run: ln -s .build/linux-amd64/thanos thanos
       - run: make docker
-      - run: 
-          name: Run tests on generated Docker image
-          command: |
-            docker run thanos --help
-      - deploy:
-          name: Push Docker image
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
-              make docker-push
-            fi
+      - run: docker run thanos --help
+      - run: docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
+      - run: make docker-push
+
+
+workflows:
+  version: 2
+  thanos:
+    jobs:
+    - test:
+        filters:
+          tags:
+            only: /.*/
+    - build:
+        filters:
+          tags:
+            only: /.*/
+    - publish_master:
+        requires:
+        - test
+        - build
+        filters:
+          branches:
+            only: master

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ kube/.minikube
 
 # Ignore e2e working dirs.
 data/
+
+# Ignore promu artifacts.
+/.build
+/.release
+/.tarballs

--- a/.promu.yml
+++ b/.promu.yml
@@ -11,3 +11,9 @@ build:
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.Branch={{.Branch}}
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
+crossbuild:
+    platforms:
+        - linux/amd64
+        - darwin/amd64
+        - linux/arm64
+        - windows/amd64

--- a/Makefile
+++ b/Makefile
@@ -36,17 +36,28 @@ errcheck:
 	@echo ">> errchecking the code"
 	@errcheck -verbose -exclude .errcheck_excludes.txt ./...
 
-build: deps $(PROMU)
+build: deps promu
 	@echo ">> building binaries"
 	@$(PROMU) build --prefix $(PREFIX)
+
+.PHONY: crossbuild
+crossbuild: deps promu
+	@echo ">> crossbuilding all binaries"
+	$(PROMU) crossbuild -v
+
+.PHONY: tarball
+tarball: promu
+	@echo ">> building release tarball"
+	$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
 
 $(GOIMPORTS):
 	@echo ">> fetching goimports"
 	@go get -u golang.org/x/tools/cmd/goimports
 
-$(PROMU):
+.PHONY: promu
+promu:
 	@echo ">> fetching promu"
-	@go get -u github.com/prometheus/promu
+	GOOS= GOARCH= go get -u github.com/prometheus/promu
 
 $(DEP):
 	@echo ">> fetching dep"


### PR DESCRIPTION
## Changes

* Split the test, build, and publish steps with CircleCI workflows.
* Fixup `promu` target so it can be used outside of make.
* Update git ignore list for promu use.
* Update promu crossbuild list to avoid 32-bit builds.
* Siplify publish step with workflow filter.

## Verification

Tested promu crossbuild locally.