### PR TITLE
Fix tarball publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ crossbuild: deps $(PROMU)
 	$(PROMU) crossbuild -v
 
 .PHONY: tarballs-release
-tarballs-release: crossbuild
+tarballs-release: $(PROMU)
 	@echo ">> Publishing tarballs"
 	$(PROMU) crossbuild tarballs
 	$(PROMU) checksum .tarballs


### PR DESCRIPTION
## Changes

Depend only on promu, not crossbuild, as crossbuild does not work in
docker.