### PR TITLE
Add thanos cluster to be able to work in public networks

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -23,28 +24,28 @@ func regCommonServerFlags(cmd *kingpin.CmdClause) (*string, *string, func(log.Lo
 	clusterBindAddr := cmd.Flag("cluster.address", "Listen ip:port address for gossip cluster.").
 		Default("0.0.0.0:10900").String()
 
-	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "Explicit (external) ip:port address to advertise for gossip in gossip cluster. Used internally for membership only").
+	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "Explicit (external) ip:port address to advertise for gossip in gossip cluster. Used internally for membership only.").
 		String()
 
 	peers := cmd.Flag("cluster.peers", "Initial peers to join the cluster. It can be either <ip:port>, or <domain:port>. A lookup resolution is done only at the startup.").Strings()
 
-	gossipInterval := cmd.Flag("cluster.gossip-interval", "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
+	gossipInterval := cmd.Flag("cluster.gossip-interval", "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth. Default is used from a specified network-type.").
 		PlaceHolder("<gossip interval>").Duration()
 
-	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
+	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage. Default is used from a specified network-type.").
 		PlaceHolder("<push-pull interval>").Duration()
 
 	refreshInterval := cmd.Flag("cluster.refresh-interval", "Interval for membership to refresh cluster.peers state, 0 disables refresh.").Default(cluster.DefaultRefreshInterval.String()).Duration()
 
 	secretKey := cmd.Flag("cluster.secret-key", "Initial secret key to encrypt cluster gossip. Can be one of AES-128, AES-192, or AES-256 in hexadecimal format.").HexBytes()
 
-	networkType := cmd.Flag("cluster.network-type", "Network type with predefined peers configurations. Sets of configurations accounting the latency differences between network types: local, lan or wan").
+	networkType := cmd.Flag("cluster.network-type",
+		fmt.Sprintf("Network type with predefined peers configurations. Sets of configurations accounting the latency differences between network types: %s.",
+			strings.Join(cluster.NetworkPeerTypes, ", "),
+		),
+	).
 		Default(cluster.LanNetworkPeerType).
-		Enum(
-			cluster.LocalNetworkPeerType,
-			cluster.LanNetworkPeerType,
-			cluster.WanNetworkPeerType,
-		)
+		Enum(cluster.NetworkPeerTypes...)
 
 	return grpcBindAddr,
 		httpBindAddr,

--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -36,6 +36,16 @@ func regCommonServerFlags(cmd *kingpin.CmdClause) (*string, *string, func(log.Lo
 
 	refreshInterval := cmd.Flag("cluster.refresh-interval", "Interval for membership to refresh cluster.peers state, 0 disables refresh.").Default(cluster.DefaultRefreshInterval.String()).Duration()
 
+	secretKey := cmd.Flag("cluster.secret-key", "Initial secret key to communicate cluster with encryption. Could be AES-128, AES-192, or AES-256 (hexadecimal data only)").HexBytes()
+
+	networkType := cmd.Flag("cluster.network-type", "Network type with predefined peers configurations. Sets of configurations accounting the latency differences between network types: local, lan or wan").
+		Default(cluster.DefaultLanPeerType).
+		Enum(
+			cluster.DefaultLocalPeerType,
+			cluster.DefaultLanPeerType,
+			cluster.DefaultWanPeerType,
+		)
+
 	return grpcBindAddr,
 		httpBindAddr,
 		func(logger log.Logger, reg *prometheus.Registry, waitIfEmpty bool, httpAdvertiseAddr string, queryAPIEnabled bool) (*cluster.Peer, error) {
@@ -68,7 +78,7 @@ func regCommonServerFlags(cmd *kingpin.CmdClause) (*string, *string, func(log.Lo
 				level.Info(logger).Log("msg", "QueryAPI address that will be propagated through gossip", "address", advQueryAPIAddress)
 			}
 
-			return cluster.New(logger, reg, *clusterBindAddr, *clusterAdvertiseAddr, advStoreAPIAddress, advQueryAPIAddress, *peers, waitIfEmpty, *gossipInterval, *pushPullInterval, *refreshInterval)
+			return cluster.New(logger, reg, *clusterBindAddr, *clusterAdvertiseAddr, advStoreAPIAddress, advQueryAPIAddress, *peers, waitIfEmpty, *gossipInterval, *pushPullInterval, *refreshInterval, *secretKey, *networkType)
 		}
 }
 

--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -29,21 +29,21 @@ func regCommonServerFlags(cmd *kingpin.CmdClause) (*string, *string, func(log.Lo
 	peers := cmd.Flag("cluster.peers", "Initial peers to join the cluster. It can be either <ip:port>, or <domain:port>. A lookup resolution is done only at the startup.").Strings()
 
 	gossipInterval := cmd.Flag("cluster.gossip-interval", "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth.").
-		Default(cluster.DefaultGossipInterval.String()).Duration()
+		PlaceHolder("<gossip interval>").Duration()
 
 	pushPullInterval := cmd.Flag("cluster.pushpull-interval", "Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage.").
-		Default(cluster.DefaultPushPullInterval.String()).Duration()
+		PlaceHolder("<push-pull interval>").Duration()
 
 	refreshInterval := cmd.Flag("cluster.refresh-interval", "Interval for membership to refresh cluster.peers state, 0 disables refresh.").Default(cluster.DefaultRefreshInterval.String()).Duration()
 
-	secretKey := cmd.Flag("cluster.secret-key", "Initial secret key to communicate cluster with encryption. Could be AES-128, AES-192, or AES-256 (hexadecimal data only)").HexBytes()
+	secretKey := cmd.Flag("cluster.secret-key", "Initial secret key to encrypt cluster gossip. Can be one of AES-128, AES-192, or AES-256 in hexadecimal format.").HexBytes()
 
 	networkType := cmd.Flag("cluster.network-type", "Network type with predefined peers configurations. Sets of configurations accounting the latency differences between network types: local, lan or wan").
-		Default(cluster.DefaultLanPeerType).
+		Default(cluster.LanNetworkPeerType).
 		Enum(
-			cluster.DefaultLocalPeerType,
-			cluster.DefaultLanPeerType,
-			cluster.DefaultWanPeerType,
+			cluster.LocalNetworkPeerType,
+			cluster.LanNetworkPeerType,
+			cluster.WanNetworkPeerType,
 		)
 
 	return grpcBindAddr,

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -45,10 +45,15 @@ type Peer struct {
 const (
 	DefaultRefreshInterval = 60 * time.Second
 
-	// Peer's network types. This are used as a predefined peer configurations for a specified network type.
+	// Peer's network types. These are used as a predefined peer configurations for a specified network type.
 	LocalNetworkPeerType = "local"
 	LanNetworkPeerType   = "lan"
 	WanNetworkPeerType   = "wan"
+)
+
+var (
+	// NetworkPeerTypes is a list of available peers' network types.
+	NetworkPeerTypes = []string{LocalNetworkPeerType, LanNetworkPeerType, WanNetworkPeerType}
 )
 
 // PeerType describes a peer's role in the cluster.
@@ -142,7 +147,7 @@ func New(
 		return nil, err
 	}
 
-	cfg, err := makeConfig(networkType)
+	cfg, err := parseNetworkConfig(networkType)
 	if err != nil {
 		return nil, err
 	}
@@ -513,7 +518,7 @@ func IsUnroutable(host string) bool {
 	return false
 }
 
-func makeConfig(networkType string) (*memberlist.Config, error) {
+func parseNetworkConfig(networkType string) (*memberlist.Config, error) {
 	var mc *memberlist.Config
 
 	switch networkType {
@@ -524,7 +529,10 @@ func makeConfig(networkType string) (*memberlist.Config, error) {
 	case LocalNetworkPeerType:
 		mc = memberlist.DefaultLocalConfig()
 	default:
-		return mc, errors.New("unexpected network type, should be either: local, lan or wan")
+		return nil, errors.Errorf("unexpected network type %s, should be one of: %s",
+			networkType,
+			strings.Join(NetworkPeerTypes, ", "),
+		)
 	}
 
 	return mc, nil

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -40,7 +40,7 @@ func joinPeer(num int, knownPeers []string) (peerAddr string, peer *Peer, err er
 		50*time.Millisecond,
 		30*time.Millisecond,
 		nil,
-		DefaultLanPeerType,
+		LanNetworkPeerType,
 	)
 	if err != nil {
 		return "", nil, err

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -39,6 +39,8 @@ func joinPeer(num int, knownPeers []string) (peerAddr string, peer *Peer, err er
 		100*time.Millisecond,
 		50*time.Millisecond,
 		30*time.Millisecond,
+		nil,
+		DefaultLanPeerType,
 	)
 	if err != nil {
 		return "", nil, err


### PR DESCRIPTION
Make thanos components available to make cluster communication over public networks.

Affected all components

## Changes

 For the initial step, it was added two additional cluster options:
* cluster.secret-key - AES key, which could be one of the AES-128, AES-192, or AES-256. Specified as a hexadecimal string
* cluster.network-type - predefined peers configurations to be able to work in a specified network type: local, lan or wan (lan by default)

## Verification

Tested `secret-key` on the local environment\

cc @Bplotka @mattbostock 