### PR TITLE
docs: Fixed Thanos cost description to include scrape interval.

### DIFF
--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -13,7 +13,7 @@ $ thanos rule \
     --data-dir          "/path/to/data" \
     --eval-interval     "30s" \
     --rule-file         "/path/to/rules/*.rules.yaml" \
-    --alert.query-url   "0.0.0.0:9090" \
+    --alert.query-url   "http://0.0.0.0:9090" \
     --alertmanagers.url "alert.thanos.io"
     --gcs.bucket        "example-bucket" \
     --cluster.peers     "thanos-cluster.example.org"

--- a/docs/design.md
+++ b/docs/design.md
@@ -152,11 +152,28 @@ Data that is just accessed locally in conventional Prometheus setups has to be t
 
 Typical object storage prices per GB are at about $0.02. The number of retrievals (typically priced at $0.004 per 10,0000) by the store nodes strongly depend on individual querying pattern. Adding 20% to the total storage cost to account for retrievals and running of store nodes seems like a conservative estimate.
 
-Suppose we want to store 100TB of metric data. At about 1.07 bytes/sample in total data size, this is equivalent to storing 6.5 years of data across an average of 1 million active time series.  
+Suppose we want to store 100TB of metric data. At about 1.07 bytes/sample in total data size, this is equivalent to:
+* storing 48.88 years of data across an average of 1 million active time series with default 15s scrape interval.
+* storing 3.25 years of data across an average of 1 million active time series with 1s scrape interval.
+
+<details>
+<summary>Calculations</summary>
+<br>
+Storing 100TB with 1.07 bytes/sample.
+100 (TB) / 1.07 (bytes/sample) = 1.027580961×10¹⁴ samples.
+We assume avg of 1mln time series, so 102758096.1 samples "available" for single series to fit into 100TB overall.
+
+With 15s scrape interval (4 samples/min):
+102758096.1 (samples) / 4 (samples/min) = 25689524.025 min = ~48.88 years
+
+With 1s scrape interval (60 samples/min):
+102758096.1 (samples) / 60 (samples/min) = 1712634.935 min = ~3.25 years
+</details>
+
+
 The cost for this amount of metric data would cost approximately $2400/month on top of the baseline Prometheus setup.
-In return, being able to reduce the retention time of Prometheus instances from weeks to hours will provide cost savings for local SSD or network block storage (typically $0.17/GB) and reduce memory consumption. This calculation does not yet account for shorter retention spans of low-priority data and downsampling.
-
-
+In return, being able to reduce the retention time of Prometheus instances from weeks to hours will provide cost savings for local SSD or network block storage (typically $0.17/GB) and reduce memory consumption.
+This calculation does not yet account for shorter retention spans of low-priority data and downsampling.
 
 [tsdb-format]: https://github.com/prometheus/tsdb/tree/master/Documentation/format
 [tsdb-talk]: https://www.slideshare.net/FabianReinartz/storing-16-bytes-at-scale-81282712


### PR DESCRIPTION
Fixes https://github.com/improbable-eng/thanos/issues/416

Please double check my quick math here (:

PTAL @kamelkev @tonglil

Storing 100TB with 1.07 bytes/sample.
100 (TB) / 1.07 (bytes/sample) = 1.027580961×10¹⁴ samples.
We assume avg of 1mln time series, so 102758096.1 samples "available" for single series to fit into 100TB overall.

With 15s scrape interval (4 samples/min):
102758096.1 (samples) / 4 (samples/min) = 25689524.025 min = ~48.88 years

With 1s scrape interval (60 samples/min):
102758096.1 (samples) / 60 (samples/min) = 1712634.935 min = ~3.25 years

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>

## Changes

- Cost description
- Rule flag (sorry for the unrelated thing)

## Verification
I used Calculator :eyes: 