### PR TITLE
Fixed targetPort of k8s service for sidecar http metrics

### DIFF
--- a/kube/manifests/prometheus-gcs.yaml
+++ b/kube/manifests/prometheus-gcs.yaml
@@ -43,7 +43,7 @@ spec:
         - "--storage.tsdb.max-block-duration=2h"
         - "--web.enable-lifecycle"
         ports:
-        - name: http
+        - name: prom-http
           containerPort: 9090
         volumeMounts:
         - name: config-shared
@@ -66,7 +66,7 @@ spec:
         - "--reloader.config-file=/etc/prometheus/prometheus.yml.tmpl"
         - "--reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yml"
         ports:
-        - name: http
+        - name: sidecar-http
           containerPort: 10902
         - name: grpc
           containerPort: 10901
@@ -168,11 +168,11 @@ spec:
   ports:
   - port: 9090
     protocol: TCP
-    targetPort: 9090
+    targetPort: prom-http
     name: http-prometheus
   - port: 10902
     protocol: TCP
-    targetPort: http
+    targetPort: sidecar-http
     name: http-sidecar-metrics
   selector:
     app: prometheus

--- a/kube/manifests/prometheus.yaml
+++ b/kube/manifests/prometheus.yaml
@@ -43,7 +43,7 @@ spec:
         - "--storage.tsdb.max-block-duration=2h"
         - "--web.enable-lifecycle"
         ports:
-        - name: http
+        - name: prom-http
           containerPort: 9090
         volumeMounts:
         - name: config-shared
@@ -61,7 +61,7 @@ spec:
         - "--reloader.config-file=/etc/prometheus/prometheus.yml.tmpl"
         - "--reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yml"
         ports:
-        - name: http
+        - name: sidecar-http
           containerPort: 10902
         - name: grpc
           containerPort: 10901
@@ -156,11 +156,11 @@ spec:
   ports:
   - port: 9090
     protocol: TCP
-    targetPort: 9090
+    targetPort: prom-http
     name: http-prometheus
   - port: 10902
     protocol: TCP
-    targetPort: http
+    targetPort: sidecar-http
     name: http-sidecar-metrics
   selector:
     app: prometheus


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

To fix the targetPort of k8s service for sidecar http metrics in [Example Kubernetes manifest](https://github.com/improbable-eng/thanos/blob/master/kube/manifests/prometheus.yaml) and [Example Kubernetes manifest with GCS upload](https://github.com/improbable-eng/thanos/blob/master/kube/manifests/prometheus-gcs.yaml)

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->

The targets of Kubernetes SD contain the sidecar instance.
