### PR TITLE
To install dep without user's GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,8 @@ $(DEP):
 	@echo ">> fetching dep from 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2 revision"
 	@if [ ! -d "$(TMP_GOPATH)/src/github.com/golang/dep" ]; then \
 		GOPATH=$(TMP_GOPATH) go get -d -u github.com/golang/dep/cmd/dep; \
+	else \
+		git fetch; \
 	fi
 	@cd $(TMP_GOPATH)/src/github.com/golang/dep && git checkout -f -q 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
 	@GOPATH=$(TMP_GOPATH) go install github.com/golang/dep/cmd/dep

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(she
 # but for simplicity sake we just make sure they exist in the first one, and
 # then keep using those.
 FIRST_GOPATH      ?= $(firstword $(subst :, ,$(shell go env GOPATH)))
+DEP_GOPATH        ?= /tmp/go
 GOIMPORTS         ?= $(FIRST_GOPATH)/bin/goimports
 PROMU             ?= $(FIRST_GOPATH)/bin/promu
 DEP               ?= $(FIRST_GOPATH)/bin/dep-45be32ba4708aad5e2a
@@ -136,13 +137,12 @@ $(PROMU):
 	GOOS= GOARCH= go get -u github.com/prometheus/promu
 
 # Always pin dep to the correct version. It changes too often.
-# TODO(bplotka): Install dep without using user's `github.com/golang/dep` package. (Use some tmp place).
 $(DEP):
 	@echo ">> fetching dep from 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2 revision"
-	@go get -d -u github.com/golang/dep/cmd/dep
-	@cd $(FIRST_GOPATH)/src/github.com/golang/dep && git checkout -f -q 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
-	@go install github.com/golang/dep/cmd/dep
-	@mv $(FIRST_GOPATH)/bin/dep $(DEP)
+	@GOPATH=$(DEP_GOPATH) go get -d -u github.com/golang/dep/cmd/dep
+	@cd $(DEP_GOPATH)/src/github.com/golang/dep && git checkout -f -q 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
+	@GOPATH=$(DEP_GOPATH) go install github.com/golang/dep/cmd/dep
+	@mv $(DEP_GOPATH)/bin/dep $(DEP)
 
 $(ERRCHECK):
 	@echo ">> fetching errcheck"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(she
 # but for simplicity sake we just make sure they exist in the first one, and
 # then keep using those.
 FIRST_GOPATH      ?= $(firstword $(subst :, ,$(shell go env GOPATH)))
-DEP_GOPATH        ?= /tmp/go
+TMP_GOPATH        ?= /tmp/thanos-go
 GOIMPORTS         ?= $(FIRST_GOPATH)/bin/goimports
 PROMU             ?= $(FIRST_GOPATH)/bin/promu
 DEP               ?= $(FIRST_GOPATH)/bin/dep-45be32ba4708aad5e2a
@@ -139,10 +139,12 @@ $(PROMU):
 # Always pin dep to the correct version. It changes too often.
 $(DEP):
 	@echo ">> fetching dep from 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2 revision"
-	@GOPATH=$(DEP_GOPATH) go get -d -u github.com/golang/dep/cmd/dep
-	@cd $(DEP_GOPATH)/src/github.com/golang/dep && git checkout -f -q 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
-	@GOPATH=$(DEP_GOPATH) go install github.com/golang/dep/cmd/dep
-	@mv $(DEP_GOPATH)/bin/dep $(DEP)
+	@if [ ! -d "$(TMP_GOPATH)/src/github.com/golang/dep" ]; then \
+		GOPATH=$(TMP_GOPATH) go get -d -u github.com/golang/dep/cmd/dep; \
+	fi
+	@cd $(TMP_GOPATH)/src/github.com/golang/dep && git checkout -f -q 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
+	@GOPATH=$(TMP_GOPATH) go install github.com/golang/dep/cmd/dep
+	@mv $(TMP_GOPATH)/bin/dep $(DEP)
 
 $(ERRCHECK):
 	@echo ">> fetching errcheck"


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->

To install dep without user's GOPATH, the tmp place is `/tmp/go`

## Verification
use `make deps`

<!-- How you tested it? How do you know it works? -->