### PR TITLE
Fix typo in getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -142,7 +142,7 @@ thanos sidecar \
     --cluster.peers             127.0.0.1:19391 \          # Static cluster peer where the node will get info about the cluster (repeatable)
 ```
 
-With the above configuration a single node will advertise itself in the cluster and query for other members of the cluster (from itself) when you add more sidecars / components you will probably want to sent `cluset.peers` to a well known peer that will allow you to discover other peers within the cluster.
+With the above configuration a single node will advertise itself in the cluster and query for other members of the cluster (from itself) when you add more sidecars / components you will probably want to sent `cluster.peers` to a well known peer that will allow you to discover other peers within the cluster.
 
 When a peer advertises itself / joins a gossip cluster it sends information about all the peers it currently knows about (including itself). This information for each peer allows you to see what type of component a peer is (Source, Store, Query), the peers Store API address (used for querying) and meta data about the external labels and time window the peer holds information about.
 


### PR DESCRIPTION
Fix typo in getting_started.md

## Changes

Changed `cluset.peers` to `cluster.peers` in Communication Between Components section.

## Verification

This is a documentation change.