### PR TITLE
Add support for retrieving AWS credentials from sources other than command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ data/
 /.build
 /.release
 /.tarballs
+
+/.idea
+/*.iml

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -694,6 +694,7 @@
     "github.com/hashicorp/memberlist",
     "github.com/lovoo/gcloud-opentracing",
     "github.com/minio/minio-go",
+    "github.com/minio/minio-go/pkg/credentials",
     "github.com/minio/minio-go/pkg/encrypt",
     "github.com/oklog/run",
     "github.com/oklog/ulid",

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -17,7 +17,7 @@ NOTE: Currently Thanos requires strong consistency (write-read) for object store
 2. Implement [objstore.Bucket inteface](/pkg/objstore/objstore.go)
 3. Add `NewTestBucket` constructor for testing purposes, that creates and deletes temporary bucket.
 4. Use created `NewTestBucket` in [ForeachStore method](/pkg/objstore/objtesting/foreach.go) to ensure we can run tests against new provider. (In PR)
-5. RUN the [TestObjStoreAcceptanceTest](/pkg/objstore/objtesting/acceptance_test.go) against your provider to ensure it fits. Fix any found error until test passes. (In PR)
+5. RUN the [TestObjStoreAcceptanceTest](/pkg/objstore/objtesting/acceptance_e2e_test.go) against your provider to ensure it fits. Fix any found error until test passes. (In PR)
 6. Add client implementation to the factory in [factory](/pkg/objstore/client/factory.go) code. (Using as small amount of flags as possible in every command)
 
 At that point, anyone can use your provider!
@@ -29,9 +29,6 @@ Thanos uses minio client to upload Prometheus data into AWS s3.
 To configure S3 bucket as an object store you need to set these mandatory S3 flags:
 - --s3.endpoint
 - --s3.bucket
-- --s3.access-key
-
-and set `S3_SECRET_KEY` environment variable with AWS secret key.
 
 Instead of using flags you can pass all the configuration via environment variables:
 - `S3_BUCKET`
@@ -46,6 +43,15 @@ AWS region to endpoint mapping can be found in this [link](https://docs.aws.amaz
 Make sure you use a correct signature version with `--s3.signature-version2`, otherwise, you will get Access Denied error.
 
 For debug purposes you can `--s3.insecure` to switch to plain insecure HTTP instead of HTTPS
+
+### Credentials
+Credentials will by default try to retrieve from the following sources:
+
+1. IAM credentials retrieved from an instance profile
+1. From `~/.aws/credentials`
+1. From the standard AWS environment variable - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+
+To use specific credentials, use the `--s3.access-key` flag and set `S3_SECRET_KEY` environment variable with AWS secret key.
 
 ### AWS Policies
 

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -19,6 +19,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/minio/minio-go"
+	"github.com/minio/minio-go/pkg/credentials"
 	"github.com/minio/minio-go/pkg/encrypt"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -48,13 +49,13 @@ type Bucket struct {
 
 // Config encapsulates the necessary config values to instantiate an s3 client.
 type Config struct {
-	Bucket       string
-	Endpoint     string
-	AccessKey    string
-	SecretKey    string
-	Insecure     bool
-	SignatureV2  bool
-	SSEEnprytion bool
+	Bucket        string
+	Endpoint      string
+	AccessKey     string
+	secretKey     string
+	Insecure      bool
+	SignatureV2   bool
+	SSEEncryption bool
 }
 
 // RegisterS3Params registers the s3 flags and returns an initialized Config struct.
@@ -70,7 +71,7 @@ func RegisterS3Params(cmd *kingpin.CmdClause) *Config {
 	cmd.Flag("s3.access-key", "Access key for an S3-Compatible API.").
 		PlaceHolder("<key>").Envar("S3_ACCESS_KEY").StringVar(&s3config.AccessKey)
 
-	s3config.SecretKey = os.Getenv("S3_SECRET_KEY")
+	s3config.secretKey = os.Getenv("S3_SECRET_KEY")
 
 	cmd.Flag("s3.insecure", "Whether to use an insecure connection with an S3-Compatible API.").
 		Default("false").Envar("S3_INSECURE").BoolVar(&s3config.Insecure)
@@ -79,7 +80,7 @@ func RegisterS3Params(cmd *kingpin.CmdClause) *Config {
 		Default("false").Envar("S3_SIGNATURE_VERSION2").BoolVar(&s3config.SignatureV2)
 
 	cmd.Flag("s3.encrypt-sse", "Whether to use Server Side Encryption").
-		Default("false").Envar("S3_SSE_ENCRYPTION").BoolVar(&s3config.SSEEnprytion)
+		Default("false").Envar("S3_SSE_ENCRYPTION").BoolVar(&s3config.SSEEncryption)
 
 	return &s3config
 }
@@ -88,8 +89,8 @@ func RegisterS3Params(cmd *kingpin.CmdClause) *Config {
 func (conf *Config) Validate() error {
 	if conf.Bucket == "" ||
 		conf.Endpoint == "" ||
-		conf.AccessKey == "" ||
-		conf.SecretKey == "" {
+		(conf.AccessKey == "" && conf.secretKey != "") ||
+		(conf.AccessKey != "" && conf.secretKey == "") {
 		return errors.New("insufficient s3 configuration information")
 	}
 	return nil
@@ -99,7 +100,7 @@ func (conf *Config) Validate() error {
 func (conf *Config) ValidateForTests() error {
 	if conf.Endpoint == "" ||
 		conf.AccessKey == "" ||
-		conf.SecretKey == "" {
+		conf.secretKey == "" {
 		return errors.New("insufficient s3 test configuration information")
 	}
 	return nil
@@ -107,14 +108,35 @@ func (conf *Config) ValidateForTests() error {
 
 // NewBucket returns a new Bucket using the provided s3 config values.
 func NewBucket(logger log.Logger, conf *Config, reg prometheus.Registerer, component string) (*Bucket, error) {
-	var f func(string, string, string, bool) (*minio.Client, error)
-	if conf.SignatureV2 {
-		f = minio.NewV2
+	var chain []credentials.Provider
+	if conf.AccessKey != "" {
+		var signature credentials.SignatureType
+		if conf.SignatureV2 {
+			signature = credentials.SignatureV2
+		} else {
+			signature = credentials.SignatureV4
+		}
+
+		chain = []credentials.Provider{&credentials.Static{
+			Value: credentials.Value{
+				AccessKeyID:     conf.AccessKey,
+				SecretAccessKey: conf.secretKey,
+				SignerType:      signature,
+			},
+		}}
 	} else {
-		f = minio.NewV4
+		chain = []credentials.Provider{
+			&credentials.IAM{
+				Client: &http.Client{
+					Transport: http.DefaultTransport,
+				},
+			},
+			&credentials.FileAWSCredentials{},
+			&credentials.EnvAWS{},
+		}
 	}
 
-	client, err := f(conf.Endpoint, conf.AccessKey, conf.SecretKey, !conf.Insecure)
+	client, err := minio.NewWithCredentials(conf.Endpoint, credentials.NewChainCredentials(chain), !conf.Insecure, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize s3 client")
 	}
@@ -144,7 +166,7 @@ func NewBucket(logger log.Logger, conf *Config, reg prometheus.Registerer, compo
 	})
 
 	var sse encrypt.ServerSide
-	if conf.SSEEnprytion {
+	if conf.SSEEncryption {
 		sse = encrypt.NewSSE()
 	}
 
@@ -266,7 +288,7 @@ func configFromEnv() *Config {
 		Bucket:    os.Getenv("S3_BUCKET"),
 		Endpoint:  os.Getenv("S3_ENDPOINT"),
 		AccessKey: os.Getenv("S3_ACCESS_KEY"),
-		SecretKey: os.Getenv("S3_SECRET_KEY"),
+		secretKey: os.Getenv("S3_SECRET_KEY"),
 	}
 
 	insecure, err := strconv.ParseBool(os.Getenv("S3_INSECURE"))

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -110,11 +110,9 @@ func (conf *Config) ValidateForTests() error {
 func NewBucket(logger log.Logger, conf *Config, reg prometheus.Registerer, component string) (*Bucket, error) {
 	var chain []credentials.Provider
 	if conf.AccessKey != "" {
-		var signature credentials.SignatureType
+		signature := credentials.SignatureV4
 		if conf.SignatureV2 {
 			signature = credentials.SignatureV2
-		} else {
-			signature = credentials.SignatureV4
 		}
 
 		chain = []credentials.Provider{&credentials.Static{


### PR DESCRIPTION
Support retrieving credentials from IAM instance profile, `~/.aws/credentials` and standard AWS environment variables

Fixes #209

## Changes

Adds support for retrieving AWS credentials from sources other than just the command line, such as an instance profile or file. Backwards compatibility is maintained by using the static credentials if supplied from the command line.

## Verification

Tested by using the branch in a CI environment and having automated tests ensure that the system works correctly, such as querying data or checking data is uploaded to S3.