### PR TITLE
Fixed miss current sample when do to seek to specify timestamp

### DIFF
--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -677,12 +677,13 @@ func (it *CounterSeriesIterator) At() (t int64, v float64) {
 
 func (it *CounterSeriesIterator) Seek(x int64) bool {
 	for {
+		if t, _ := it.At(); t >= x {
+			return true
+		}
+
 		ok := it.Next()
 		if !ok {
 			return false
-		}
-		if t, _ := it.At(); t >= x {
-			return true
 		}
 	}
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
To switch the `it.At()` position to read the current item in the `CounterSeriesIterator.Seek()` first. If not, it will skip the current item.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
related #439 