### PR TITLE
store: Use Prometheus base URL for remote read

### DIFF
--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -186,7 +186,7 @@ func (p *PrometheusStore) promSeries(ctx context.Context, q prompb.Query) (*prom
 	}
 
 	u := *p.base
-	u.Path = "/api/v1/read"
+	u.Path = path.Join(u.Path, "/api/v1/read")
 
 	preq, err := http.NewRequest("POST", u.String(), bytes.NewReader(snappy.Encode(nil, reqb)))
 	if err != nil {


### PR DESCRIPTION
## Changes
Fixes #478 

This will use the value provided by prometheus.url for the remote read API.

## Verification
I checked which URL it retrieves when executing a query, which is now correctly using the prometheus.url