### PR TITLE
sidecar: Add support for prometheus with --web.route-prefix.

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -37,7 +37,7 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application, name stri
 
 	grpcBindAddr, httpBindAddr, newPeerFn := regCommonServerFlags(cmd)
 
-	promURL := cmd.Flag("prometheus.url", "URL at which to reach Prometheus's API.").
+	promURL := cmd.Flag("prometheus.url", "URL at which to reach Prometheus's API. For better performance use local network.").
 		Default("http://localhost:9090").URL()
 
 	dataDir := cmd.Flag("tsdb.path", "Data directory of TSDB.").

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -89,7 +89,8 @@ Flags:
                                  accounting the latency differences between
                                  network types: local, lan, wan.
       --prometheus.url=http://localhost:9090  
-                                 URL at which to reach Prometheus's API.
+                                 URL at which to reach Prometheus's API. For
+                                 better performance use local network.
       --tsdb.path="./data"       Data directory of TSDB.
       --gcs.bucket=<bucket>      Google Cloud Storage bucket name for stored
                                  blocks. If empty, sidecar won't store any block

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -186,7 +186,7 @@ func (p *PrometheusStore) promSeries(ctx context.Context, q prompb.Query) (*prom
 	}
 
 	u := *p.base
-	u.Path = "/api/v1/read"
+	u.Path = path.Join(u.Path, "api/v1/read")
 
 	preq, err := http.NewRequest("POST", u.String(), bytes.NewReader(snappy.Encode(nil, reqb)))
 	if err != nil {

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -16,9 +16,20 @@ import (
 )
 
 func TestPrometheusStore_Series_e2e(t *testing.T) {
+	testPrometheusStoreSeriesE2e(t, "")
+}
+
+// Regression test for https://github.com/improbable-eng/thanos/issues/478.
+func TestPrometheusStore_Series_promOnPath_e2e(t *testing.T) {
+	testPrometheusStoreSeriesE2e(t, "/prometheus/sub/path")
+}
+
+func testPrometheusStoreSeriesE2e(t *testing.T, prefix string) {
+	t.Helper()
+
 	defer leaktest.CheckTimeout(t, 10*time.Second)()
 
-	p, err := testutil.NewPrometheus()
+	p, err := testutil.NewPrometheusOnPath(prefix)
 	testutil.Ok(t, err)
 
 	baseT := timestamp.FromTime(time.Now()) / 1000 * 1000


### PR DESCRIPTION
Fixes https://github.com/improbable-eng/thanos/issues/478

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>
