### PR TITLE
Fix IPv6 support for `grpc-advertise-address` and `http-advertise-add…

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -55,7 +55,7 @@ func regCommonServerFlags(cmd *kingpin.CmdClause) (*string, *string, func(log.Lo
 				return nil, errors.Wrapf(err, "calculate advertise StoreAPI addr for gossip based on bindAddr: %s and advAddr: %s", *grpcBindAddr, *grpcAdvertiseAddr)
 			}
 
-			advStoreAPIAddress := fmt.Sprintf("%s:%d", host, port)
+			advStoreAPIAddress := net.JoinHostPort(host, strconv.Itoa(port))
 			if cluster.IsUnroutable(advStoreAPIAddress) {
 				level.Warn(logger).Log("msg", "this component advertises its gRPC StoreAPI on an unroutable address. This will not work cross-cluster", "addr", advStoreAPIAddress)
 				level.Warn(logger).Log("msg", "provide --grpc-address as routable ip:port or --grpc-advertise-address as a routable host:port")
@@ -70,7 +70,7 @@ func regCommonServerFlags(cmd *kingpin.CmdClause) (*string, *string, func(log.Lo
 					return nil, errors.Wrapf(err, "calculate advertise QueryAPI addr for gossip based on bindAddr: %s and advAddr: %s", *httpBindAddr, advQueryAPIAddress)
 				}
 
-				advQueryAPIAddress = fmt.Sprintf("%s:%d", host, port)
+				advQueryAPIAddress = net.JoinHostPort(host, strconv.Itoa(port))
 				if cluster.IsUnroutable(advQueryAPIAddress) {
 					level.Warn(logger).Log("msg", "this component advertises its HTTP QueryAPI on an unroutable address. This will not work cross-cluster", "addr", advQueryAPIAddress)
 					level.Warn(logger).Log("msg", "provide --http-address as routable ip:port or --http-advertise-address as a routable host:port")

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -3,8 +3,10 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"net"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -185,6 +187,11 @@ func TestCalculateAdvAddress(t *testing.T) {
 			bind:     "0.0.0.0:5555",
 			expected: privateIP + ":5555",
 		},
+		{
+			bind:      "[::]:1234",
+			advertise: "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1234",
+			expected:  "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1234",
+		},
 	} {
 		if ok := t.Run("", func(t *testing.T) {
 			host, port, err := CalculateAdvertiseAddress(tc.bind, tc.advertise)
@@ -194,7 +201,7 @@ func TestCalculateAdvAddress(t *testing.T) {
 				return
 			}
 			testutil.Ok(t, err)
-			testutil.Equals(t, tc.expected, fmt.Sprintf("%s:%d", host, port))
+			testutil.Equals(t, tc.expected, net.JoinHostPort(host, strconv.Itoa(port)))
 
 		}); !ok {
 			return


### PR DESCRIPTION
…ress`.

```
thanos sidecar \
  --grpc-advertise-address [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:19091  
```
produces 

```
msg="StoreAPI address that will be propagated through gossip" address=2001:0db8:85a3:0000:0000:8a2e:0370:7334:19091
```

which seems incorrect. This results in `thanos query` failing with 

```
caller=storeset.go:282 component=storeset msg="update of store node failed" err="initial store client info fetch: rpc error: code = DeadlineExceeded desc = context deadline exceeded" address=2001:0db8:85a3:0000:0000:8a2e:0370:7334:19091
```

## Changes

Updated `cmd/thanos/flags.go` to join `host` and `port` properly.

## Verification

I didn't find existing test cases for `flags.go` but I added a test case to demonstrate the failure.