### PR TITLE
Add bucket ls -o wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Thanos compact --retention.default flag, for configuring storage bucket retention period.
 - Removes support for multiple units in duration. For example: 1m0s won't work, while 1m will work.
 - Adds support for y,w,d time units 
+- Add Thanos bucket ls -o wide, which provides more detailed information about blocks stored in the bucket.
 
 Newest release candidate: [v0.1.0-rc.2](https://github.com/improbable-eng/thanos/releases/tag/v0.1.0-rc.2)
 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -153,6 +153,23 @@ func registerBucket(m map[string]setupFunc, app *kingpin.Application, name strin
 				fmt.Fprintln(os.Stdout, id.String())
 				return nil
 			}
+		case "wide":
+			printBlock = func(id ulid.ULID) error {
+				m, err := block.DownloadMeta(ctx, logger, bkt, id)
+				if err != nil {
+					return err
+				}
+
+				minTime := time.Unix(m.MinTime/1000, 0)
+				maxTime := time.Unix(m.MaxTime/1000, 0)
+
+				if _, err = fmt.Fprintf(os.Stdout, "%s -- %s - %s Diff: %s, Compaction: %d, Downsample: %d, Source: %s\n",
+					m.ULID, minTime.Format("2006-01-02 15:04"), maxTime.Format("2006-01-02 15:04"), maxTime.Sub(minTime),
+					m.Compaction.Level, m.Thanos.Downsample.Resolution, m.Thanos.Source); err != nil {
+					return err
+				}
+				return nil
+			}
 		case "json":
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "\t")


### PR DESCRIPTION
## Changes

Not sure if you would be happy with this, but maybe adding `-o wide`, with default printing make sense?

I tried something like:
```
thanos bucket ls -o  '{{.ULID}} {{.MinTime }} -- {{.MaxTime}} - Compact: {{.Compaction.Level}}, Downsample: {{.Thanos.Downsample}}, Source {{.Thanos.Source}}'
```
But couldn't figure out how to format dates nicely.

## Verification

```
thanos bucket ls -o wide --s3.bucket=dev-sys-mon-prometheus-storage
```
```
01CMRNWKTDD87W80957X47YNH8 -- 2018-08-11 03:00 - 2018-08-13 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CMRP2RDN93TJF4AF7BKJ2W2D -- 2018-08-11 03:00 - 2018-08-13 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CMXTSBTZSP4TGYNZ9K74ZXJ7 -- 2018-08-13 03:00 - 2018-08-15 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CMXTZNCTJPDJY97MH3DSB6R3 -- 2018-08-13 03:00 - 2018-08-15 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CN301H10T3V1DJH3RH0J7SEV -- 2018-08-15 03:00 - 2018-08-17 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CN30EY9V0ZRYG70YMKF2DC0R -- 2018-08-15 03:00 - 2018-08-17 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CN849001DD34K3YRASA2B2FZ -- 2018-08-17 03:00 - 2018-08-19 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CN84EEZR4F9MGRJE9NZCEHPD -- 2018-08-17 03:00 - 2018-08-19 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CND8Y7CF0XGHCZPM1JM6B56Z -- 2018-08-19 03:00 - 2018-08-21 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CND92T4P2H07VXEZ6CXQJQ08 -- 2018-08-19 03:00 - 2018-08-21 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CNJDR94C93YM7FR0RNNC67AY -- 2018-08-21 03:00 - 2018-08-23 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CNJDX6W2F6H3VDB9011F5VRM -- 2018-08-21 03:00 - 2018-08-23 03:00 Diff: 48h0m0s, Compaction: 3, Downsample: 300000, Source: compactor
01CNK8VP33BHPRS3MYZ6XFJDY6 -- 2018-08-23 03:00 - 2018-08-23 11:00 Diff: 8h0m0s, Compaction: 2, Downsample: 0, Source: compactor
01CNK8WC09YF6KVDV9C1D545RM -- 2018-08-23 03:00 - 2018-08-23 11:00 Diff: 8h0m0s, Compaction: 2, Downsample: 0, Source: compactor
01CNM4T70Y4C8ZZAM7X2B5Y3MH -- 2018-08-23 11:00 - 2018-08-23 19:00 Diff: 8h0m0s, Compaction: 2, Downsample: 0, Source: compactor
01CNM4VBEH46SPQ3SFR20WAVTS -- 2018-08-23 11:00 - 2018-08-23 19:00 Diff: 8h0m0s, Compaction: 2, Downsample: 0, Source: compactor
01CNMZTGA8GJWJME0Q0RDYXP2H -- 2018-08-23 19:00 - 2018-08-24 03:00 Diff: 8h0m0s, Compaction: 2, Downsample: 0, Source: compactor
01CNMZV4AGTAHYZYPHQ4474AEF -- 2018-08-23 19:00 - 2018-08-24 03:00 Diff: 8h0m0s, Compaction: 2, Downsample: 0, Source: compactor
```