### PR TITLE
downsample: Fix for Issue 494

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ $ mkdir -p $GOPATH/src/github.com/improbable-eng
 $ cd $GOPATH/src/github.com/improbable-eng
 $ git clone https://github.com/<your_github_id>/thanos.git
 $ cd thanos
-$ git add remote upstream https://github.com/improbable-eng/thanos.git
+$ git remote add upstream https://github.com/improbable-eng/thanos.git
 $ git remote update
 $ git merge upstream/master
 $ make build

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -34,7 +34,7 @@ func registerDownsample(m map[string]setupFunc, app *kingpin.Application, name s
 		Default("./data").String()
 
 	gcsBucket := cmd.Flag("gcs.bucket", "Google Cloud Storage bucket name for stored blocks.").
-		PlaceHolder("<bucket>").Required().String()
+		PlaceHolder("<bucket>").String()
 
 	s3Config := s3.RegisterS3Params(cmd)
 


### PR DESCRIPTION
This is a very simple fix for issue 494, and a small change to the Contributors instructions

## Changes

- Removed "Required()" option as part of gcs.bucket cmd flag.  This now matches how it is used in all other code (such as compact.go and rule.go).
- Fixed line in contributors guide on how to configure the upstream remote properly

## Verification

I have run the test suite, but I do not have access to S3 or GCS to fully test this functionality, however I do not expect it to be an issue based on the scope of change.