### PR TITLE
e2e: Run Query Simple e2e tests against pinned version of Prometheus.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,38 @@ DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(she
 # then keep using those.
 FIRST_GOPATH      ?= $(firstword $(subst :, ,$(shell go env GOPATH)))
 TMP_GOPATH        ?= /tmp/thanos-go
-GOIMPORTS         ?= $(FIRST_GOPATH)/bin/goimports
-PROMU             ?= $(FIRST_GOPATH)/bin/promu
-DEP               ?= $(FIRST_GOPATH)/bin/dep-45be32ba4708aad5e2a
+BIN_DIR           ?= $(FIRST_GOPATH)/bin
+GOIMPORTS         ?= $(BIN_DIR)/goimports
+PROMU             ?= $(BIN_DIR)/promu
 DEP_FINISHED      ?= .dep-finished
-ERRCHECK          ?= $(FIRST_GOPATH)/bin/errcheck
-EMBEDMD           ?= $(FIRST_GOPATH)/bin/embedmd
+ERRCHECK          ?= $(BIN_DIR)/errcheck
+EMBEDMD           ?= $(BIN_DIR)/embedmd
+
+DEP               ?= $(BIN_DIR)/dep-$(DEP_VERSION)
+
+DEP_VERSION             ?=45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
+# TODO(bplotka): Add more recent version after https://github.com/prometheus/prometheus/issues/4551 is fixed.
+SUPPORTED_PROM_VERSIONS ?=v2.0.0 v2.2.1
+ALERTMANAGER_VERSION    ?=v0.15.2
+
+# fetch_go_bin_version downloads (go gets) the binary from specific version and installs it in $(BIN_DIR)/<bin>-<version>
+# arguments:
+# $(1): Install path. (e.g github.com/golang/dep/cmd/dep)
+# $(2): Tag or revision for checkout.
+define fetch_go_bin_version
+	@echo ">> fetching $(1)@$(2) revision/version"
+	@if [ ! -d "$(TMP_GOPATH)/src/$(1)" ]; then \
+    	GOPATH=$(TMP_GOPATH) go get -d -u $(1); \
+    else \
+    	git fetch; \
+    fi
+    @cd $(TMP_GOPATH)/src/$(1) && git checkout -f -q $(2)
+    @echo ">> installing $(1)@$(2)"
+    @GOBIN=$(TMP_GOPATH)/bin GOPATH=$(TMP_GOPATH) go install $(1)
+    @mv $(TMP_GOPATH)/bin/$(shell basename $(1)) $(BIN_DIR)/$(shell basename $(1))-$(2)
+    @echo ">> produced $(BIN_DIR)/$(shell basename $(1))-$(2)"
+
+endef
 
 .PHONY: all
 all: deps format errcheck build
@@ -108,19 +134,21 @@ tarballs-release: $(PROMU)
 	$(PROMU) checksum .tarballs
 	$(PROMU) release .tarballs
 
-# test runs all Thanos golang tests.
+# test runs all Thanos golang tests against each supported version of Prometheus.
 .PHONY: test
 test: test-deps
 	@echo ">> running all tests. Do export THANOS_SKIP_GCS_TESTS="true" or/and  export THANOS_SKIP_S3_AWS_TESTS="true" if you want to skip e2e tests against real store buckets"
-	@go test $(shell go list ./... | grep -v /vendor/ | grep -v /benchmark/)
-
+	@for ver in $(SUPPORTED_PROM_VERSIONS); do \
+		THANOS_TEST_PROMETHEUS_PATH="prometheus-$$ver" THANOS_TEST_ALERTMANAGER_PATH="alertmanager-$(ALERTMANAGER_VERSION)" go test $(shell go list ./... | grep -v /vendor/ | grep -v /benchmark/); \
+	done
 
 # test-deps installs dependency for e2e tets.
+# It installs current Thanos, supported versions of Prometheus and alertmanager to test against in e2e.
 .PHONY: test-deps
 test-deps: deps
 	@go install github.com/improbable-eng/thanos/cmd/thanos
-	@go get -u github.com/prometheus/prometheus/cmd/prometheus
-	@go get -u github.com/prometheus/alertmanager/cmd/alertmanager
+	$(foreach ver,$(SUPPORTED_PROM_VERSIONS),$(call fetch_go_bin_version,github.com/prometheus/prometheus/cmd/prometheus,$(ver)))
+	$(call fetch_go_bin_version,github.com/prometheus/alertmanager/cmd/alertmanager,$(ALERTMANAGER_VERSION))
 
 # vet vets the code.
 .PHONY: vet
@@ -142,17 +170,8 @@ $(PROMU):
 	@echo ">> fetching promu"
 	GOOS= GOARCH= go get -u github.com/prometheus/promu
 
-# Always pin dep to the correct version. It changes too often.
 $(DEP):
-	@echo ">> fetching dep from 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2 revision"
-	@if [ ! -d "$(TMP_GOPATH)/src/github.com/golang/dep" ]; then \
-		GOPATH=$(TMP_GOPATH) go get -d -u github.com/golang/dep/cmd/dep; \
-	else \
-		git fetch; \
-	fi
-	@cd $(TMP_GOPATH)/src/github.com/golang/dep && git checkout -f -q 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
-	@GOPATH=$(TMP_GOPATH) go install github.com/golang/dep/cmd/dep
-	@mv $(TMP_GOPATH)/bin/dep $(DEP)
+	$(call fetch_go_bin_version,github.com/golang/dep/cmd/dep,$(DEP_VERSION))
 
 $(DEP_FINISHED):
 	@touch $(DEP_FINISHED)

--- a/benchmark/cmd/thanosbench/resources.go
+++ b/benchmark/cmd/thanosbench/resources.go
@@ -12,7 +12,6 @@ import (
 	prom "github.com/prometheus/prometheus/config"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -155,7 +155,7 @@ func TestQueryStore_Series_SameExtSet(t *testing.T) {
 					storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
 				},
 			},
-			labels: []storepb.Label{{"ext", "1"}},
+			labels:  []storepb.Label{{"ext", "1"}},
 			minTime: 1,
 			maxTime: 300,
 		},
@@ -165,7 +165,7 @@ func TestQueryStore_Series_SameExtSet(t *testing.T) {
 					storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
 				},
 			},
-			labels:[]storepb.Label{{"ext", "1"}},
+			labels:  []storepb.Label{{"ext", "1"}},
 			minTime: 1,
 			maxTime: 300,
 		},
@@ -181,8 +181,8 @@ func TestQueryStore_Series_SameExtSet(t *testing.T) {
 	// This should return empty response, since there is external label mismatch.
 	err := q.Series(
 		&storepb.SeriesRequest{
-			MinTime:  1,
-			MaxTime:  300,
+			MinTime: 1,
+			MaxTime: 300,
 		}, s1,
 	)
 	testutil.Ok(t, err)

--- a/pkg/testutil/prometheus.go
+++ b/pkg/testutil/prometheus.go
@@ -22,6 +22,31 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	// TODO(bplotka): Change default version to something more recent after https://github.com/prometheus/prometheus/issues/4551 is fixed.
+	defaultPrometheusVersion   = "v2.2.1"
+	defaultAlertmanagerVersion = "v0.15.2"
+
+	promBinEnvVar         = "THANOS_TEST_PROMETHEUS_PATH"
+	alertmanagerBinEnvVar = "THANOS_TEST_ALERTMANAGER_PATH"
+)
+
+func PrometheusBinary() string {
+	b := os.Getenv(promBinEnvVar)
+	if b == "" {
+		return fmt.Sprintf("prometheus-%s", defaultPrometheusVersion)
+	}
+	return b
+}
+
+func AlertmanagerBinary() string {
+	b := os.Getenv(alertmanagerBinEnvVar)
+	if b == "" {
+		return fmt.Sprintf("prometheus-%s", defaultAlertmanagerVersion)
+	}
+	return b
+}
+
 // Prometheus represents a test instance for integration testing.
 // It can be populated with data before being started.
 type Prometheus struct {
@@ -86,7 +111,7 @@ func (p *Prometheus) Start() error {
 
 	p.addr = fmt.Sprintf("localhost:%d", port)
 	p.cmd = exec.Command(
-		"prometheus",
+		PrometheusBinary(),
 		"--storage.tsdb.path="+p.db.Dir(),
 		"--web.listen-address="+p.addr,
 		"--web.route-prefix="+p.prefix,

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -24,7 +24,7 @@ func TestQuerySimple(t *testing.T) {
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, os.RemoveAll(dir)) }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 
 	firstPromPort := promHTTPPort(1)
 	exit, err := spinup(t, ctx, config{

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/improbable-eng/thanos/pkg/testutil"
+
 	"github.com/oklog/run"
 	"github.com/pkg/errors"
 )
@@ -79,7 +81,7 @@ func spinup(t testing.TB, ctx context.Context, cfg config) (chan error, error) {
 			return nil, errors.Wrap(err, "creating prom config failed")
 		}
 
-		commands = append(commands, exec.Command("prometheus",
+		commands = append(commands, exec.Command(testutil.PrometheusBinary(),
 			"--config.file", promDir+"/prometheus.yml",
 			"--storage.tsdb.path", promDir,
 			"--log.level", "info",
@@ -174,7 +176,7 @@ receivers:
 		if err != nil {
 			return nil, errors.Wrap(err, "creating alertmanager config file failed")
 		}
-		commands = append(commands, exec.Command("alertmanager",
+		commands = append(commands, exec.Command(testutil.AlertmanagerBinary(),
 			"--config.file", dir+"/config.yaml",
 			"--web.listen-address", "127.0.0.1:29093",
 			"--log.level", "debug",


### PR DESCRIPTION
Problems: Because of https://github.com/prometheus/prometheus/issues/4551 Thanos
e2e tests were not passing (98% time). This caused CI to be almost always red.

PTAL @povilasv @vglafirov 
Signed-off-by: Bartek Plotka <bwplotka@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

- Added Makefile step to install pinned version of Golang binaries.
- Test e2e against pinned version fo Prometheus and alertmanager for reproducible builds.
- Additonally: make format.

## Verification

- CI
- Local `make test`
- Local `GOCACHE=off go test -v ./test/e2e/...`