### PR TITLE
run all in one example: No such file or directory when execute "pushd ${DIR}/bin" in run-local.sh

### DIFF
--- a/kube/run-local.sh
+++ b/kube/run-local.sh
@@ -7,7 +7,7 @@ source ${DIR}/envs.sh
 usage() { echo "Usage: $0 [-d <vm-driver>] (specify vm-driver, by default none - works only on linux) [-i] (install required binaries)" 1>&2; exit 1; }
 
 install() {
-    mkdir -p bin
+    mkdir -p ${DIR}/bin
     pushd ${DIR}/bin
         echo "Downloading kubectl 1.9 locally"
         curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl && chmod +x kubectl


### PR DESCRIPTION
## Verification
run bash ./kube/run-local.sh -i -d none
It would raise error: "./kube/run-local.sh: line 11:
pushd: /root/thanos/kube/bin: No such file or directory"