### PR TITLE
compact: add bucket retention by resolution

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -138,13 +138,13 @@ func runCompact(
 	}
 
 	if retentionByResolution[downsample.ResLevel0].Seconds() != 0 {
-		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retention)
+		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retentionByResolution[downsample.ResLevel0])
 	}
 	if retentionByResolution[downsample.ResLevel1].Seconds() != 0 {
-		level.Info(logger).Log("msg", "retention policy of 5 min aggregated samples is enabled", "duration", retention)
+		level.Info(logger).Log("msg", "retention policy of 5 min aggregated samples is enabled", "duration", retentionByResolution[downsample.ResLevel0])
 	}
 	if retentionByResolution[downsample.ResLevel2].Seconds() != 0 {
-		level.Info(logger).Log("msg", "retention policy of 1 hour aggregated samples is enabled", "duration", retention)
+		level.Info(logger).Log("msg", "retention policy of 1 hour aggregated samples is enabled", "duration", retentionByResolution[downsample.ResLevel0])
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -48,7 +48,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 		Short('w').Bool()
 
 	// TODO(bplotka): Remove this flag once https://github.com/improbable-eng/thanos/issues/297 is fixed.
-	disableDownsampling := cmd.Flag("debug.disable-downsampling", "Disables downsampling. This is not recommended " +
+	disableDownsampling := cmd.Flag("debug.disable-downsampling", "Disables downsampling. This is not recommended "+
 		"as querying long time ranges without non-downsampled data is not efficient and not useful (is not possible to render all for human eye).").
 		Hidden().Default("false").Bool()
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -56,10 +56,10 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 			time.Duration(*syncDelay),
 			*haltOnError,
 			*wait,
-			map[int64]time.Duration{
-				downsample.ResLevel0: time.Duration(*retentionRaw),
-				downsample.ResLevel1: time.Duration(*retention5m),
-				downsample.ResLevel2: time.Duration(*retention1h),
+			map[compact.ResolutionLevel]time.Duration{
+				compact.ResolutionLevelRaw: time.Duration(*retentionRaw),
+				compact.ResolutionLevel5m:  time.Duration(*retention5m),
+				compact.ResolutionLevel1h:  time.Duration(*retention1h),
 			},
 			name,
 		)
@@ -77,7 +77,7 @@ func runCompact(
 	syncDelay time.Duration,
 	haltOnError bool,
 	wait bool,
-	retentionByResolution map[int64]time.Duration,
+	retentionByResolution map[compact.ResolutionLevel]time.Duration,
 	component string,
 ) error {
 	halted := prometheus.NewGauge(prometheus.GaugeOpts{
@@ -129,14 +129,14 @@ func runCompact(
 
 	compactor := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt)
 
-	if retentionByResolution[downsample.ResLevel0].Seconds() != 0 {
-		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retentionByResolution[downsample.ResLevel0])
+	if retentionByResolution[compact.ResolutionLevelRaw].Seconds() != 0 {
+		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retentionByResolution[compact.ResolutionLevelRaw])
 	}
-	if retentionByResolution[downsample.ResLevel1].Seconds() != 0 {
-		level.Info(logger).Log("msg", "retention policy of 5 min aggregated samples is enabled", "duration", retentionByResolution[downsample.ResLevel1])
+	if retentionByResolution[compact.ResolutionLevel5m].Seconds() != 0 {
+		level.Info(logger).Log("msg", "retention policy of 5 min aggregated samples is enabled", "duration", retentionByResolution[compact.ResolutionLevel5m])
 	}
-	if retentionByResolution[downsample.ResLevel2].Seconds() != 0 {
-		level.Info(logger).Log("msg", "retention policy of 1 hour aggregated samples is enabled", "duration", retentionByResolution[downsample.ResLevel2])
+	if retentionByResolution[compact.ResolutionLevel1h].Seconds() != 0 {
+		level.Info(logger).Log("msg", "retention policy of 1 hour aggregated samples is enabled", "duration", retentionByResolution[compact.ResolutionLevel1h])
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -177,7 +177,7 @@ func runCompact(
 		if err := compact.ApplyRetentionPolicyByResolution(ctx, logger, bkt, retentionByResolution); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("retention failed"))
 		}
-                level.Info(logger).Log("msg", "retention iterations done")
+		level.Info(logger).Log("msg", "retention iterations done")
 		return nil
 	}
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -177,7 +177,6 @@ func runCompact(
 		if err := compact.ApplyRetentionPolicyByResolution(ctx, logger, bkt, retentionByResolution); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("retention failed"))
 		}
-		level.Info(logger).Log("msg", "retention iterations done")
 		return nil
 	}
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -177,7 +177,7 @@ func runCompact(
 		if err := compact.ApplyRetentionPolicyByResolution(ctx, logger, bkt, retentionByResolution); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("retention failed"))
 		}
-    level.Info(logger).Log("msg", "retention iterations done")
+                level.Info(logger).Log("msg", "retention iterations done")
 		return nil
 	}
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -53,6 +53,12 @@ Flags:
                                before they are being processed.
       --retention.default=0d   How long to retain samples in bucket. 0d -
                                disables retention
+      --retention.res0=0d      How long to retain raw samples in bucket. 0d -
+                               disables this retention
+      --retention.res1=0d      How long to retain samples of resolution 1 (5
+                               minutes) in bucket. 0d - disables this retention
+      --retention.res2=0d      How long to retain samples of resolution 2 (1
+                               hour) in bucket. 0d - disables this retention
   -w, --wait                   Do not exit after all compactions have been
                                processed and wait for new work.
 

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -51,13 +51,14 @@ Flags:
       --s3.encrypt-sse         Whether to use Server Side Encryption
       --sync-delay=30m         Minimum age of fresh (non-compacted) blocks
                                before they are being processed.
-      --retention.default=0d   How long to retain samples in bucket. 0d -
-                               disables retention
-      --retention.res0=0d      How long to retain raw samples in bucket. 0d -
+      --retention.resolution-raw=0d  
+                               How long to retain raw samples in bucket. 0d -
                                disables this retention
-      --retention.res1=0d      How long to retain samples of resolution 1 (5
+      --retention.resolution-5m=0d  
+                               How long to retain samples of resolution 1 (5
                                minutes) in bucket. 0d - disables this retention
-      --retention.res2=0d      How long to retain samples of resolution 2 (1
+      --retention.resolution-1h=0d  
+                               How long to retain samples of resolution 2 (1
                                hour) in bucket. 0d - disables this retention
   -w, --wait                   Do not exit after all compactions have been
                                processed and wait for new work.

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -23,6 +23,14 @@ import (
 	"github.com/prometheus/tsdb/labels"
 )
 
+type ResolutionLevel int64
+
+const (
+	ResolutionLevelRaw = ResolutionLevel(downsample.ResLevel0)
+	ResolutionLevel5m  = ResolutionLevel(downsample.ResLevel1)
+	ResolutionLevel1h  = ResolutionLevel(downsample.ResLevel2)
+)
+
 // Syncer syncronizes block metas from a bucket into a local directory.
 // It sorts them into compaction groups based on equal label sets.
 type Syncer struct {

--- a/pkg/compact/retention.go
+++ b/pkg/compact/retention.go
@@ -13,7 +13,7 @@ import (
 
 // Apply removes blocks depending on the specified retentionByResolution based on blocks MaxTime.
 // A value of 0 disables the retention for its resolution.
-func ApplyRetentionPolicyByResolution(ctx context.Context, logger log.Logger, bkt objstore.Bucket, retentionByResolution map[int64]time.Duration) error {
+func ApplyRetentionPolicyByResolution(ctx context.Context, logger log.Logger, bkt objstore.Bucket, retentionByResolution map[ResolutionLevel]time.Duration) error {
 	level.Info(logger).Log("msg", "start retention")
 	if err := bkt.Iter(ctx, "", func(name string) error {
 		id, ok := block.IsBlockDir(name)
@@ -25,7 +25,7 @@ func ApplyRetentionPolicyByResolution(ctx context.Context, logger log.Logger, bk
 			return errors.Wrap(err, "download metadata")
 		}
 
-		retentionDuration, ok := retentionByResolution[m.Thanos.Downsample.Resolution]
+		retentionDuration, ok := retentionByResolution[ResolutionLevel(m.Thanos.Downsample.Resolution)]
 		if !ok {
 			level.Info(logger).Log("msg", "retention for resolution undefined", "resolution", m.Thanos.Downsample.Resolution)
 			return nil

--- a/pkg/compact/retention.go
+++ b/pkg/compact/retention.go
@@ -14,7 +14,7 @@ import (
 // Apply removes blocks depending on the specified retentionByResolution based on blocks MaxTime.
 // A value of 0 disables the retention for its resolution.
 func ApplyRetentionPolicyByResolution(ctx context.Context, logger log.Logger, bkt objstore.Bucket, retentionByResolution map[ResolutionLevel]time.Duration) error {
-	level.Info(logger).Log("msg", "start retention")
+	level.Info(logger).Log("msg", "start optional retention")
 	if err := bkt.Iter(ctx, "", func(name string) error {
 		id, ok := block.IsBlockDir(name)
 		if !ok {
@@ -25,14 +25,8 @@ func ApplyRetentionPolicyByResolution(ctx context.Context, logger log.Logger, bk
 			return errors.Wrap(err, "download metadata")
 		}
 
-		retentionDuration, ok := retentionByResolution[ResolutionLevel(m.Thanos.Downsample.Resolution)]
-		if !ok {
-			level.Info(logger).Log("msg", "retention for resolution undefined", "resolution", m.Thanos.Downsample.Resolution)
-			return nil
-		}
-
+		retentionDuration := retentionByResolution[ResolutionLevel(m.Thanos.Downsample.Resolution)]
 		if retentionDuration.Seconds() == 0 {
-			level.Info(logger).Log("msg", "skip retention for block", "id", id, "resolution", m.Thanos.Downsample.Resolution)
 			return nil
 		}
 
@@ -49,6 +43,6 @@ func ApplyRetentionPolicyByResolution(ctx context.Context, logger log.Logger, bk
 		return errors.Wrap(err, "retention")
 	}
 
-	level.Info(logger).Log("msg", "retention apply done")
+	level.Info(logger).Log("msg", "optional retention apply done")
 	return nil
 }

--- a/pkg/compact/retention_test.go
+++ b/pkg/compact/retention_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/compact"
+	"github.com/improbable-eng/thanos/pkg/compact/downsample"
 	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/inmem"
 	"github.com/improbable-eng/thanos/pkg/testutil"
@@ -40,10 +41,10 @@ func TestTimeBasedRetentionPolicyKeepsBucketsBeforeDuration(t *testing.T) {
 	logger := log.NewNopLogger()
 	bkt := inmem.NewBucket()
 
-	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW48", time.Now().Add(-3*24*time.Hour), time.Now().Add(-2*24*time.Hour))
-	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW49", time.Now().Add(-2*24*time.Hour), time.Now().Add(-24*time.Hour))
-	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW50", time.Now().Add(-24*time.Hour), time.Now().Add(-23*time.Hour))
-	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW51", time.Now().Add(-23*time.Hour), time.Now().Add(-6*time.Hour))
+	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW48", time.Now().Add(-3*24*time.Hour), time.Now().Add(-2*24*time.Hour), downsample.ResLevel0)
+	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW49", time.Now().Add(-2*24*time.Hour), time.Now().Add(-24*time.Hour), downsample.ResLevel1)
+	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW50", time.Now().Add(-24*time.Hour), time.Now().Add(-23*time.Hour), downsample.ResLevel2)
+	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW51", time.Now().Add(-23*time.Hour), time.Now().Add(-6*time.Hour), downsample.ResLevel0)
 	testutil.Ok(t, compact.ApplyDefaultRetentionPolicy(context.TODO(), logger, bkt, 24*time.Hour))
 
 	want := []string{"01CPHBEX20729MJQZXE3W0BW50/", "01CPHBEX20729MJQZXE3W0BW51/"}
@@ -57,13 +58,58 @@ func TestTimeBasedRetentionPolicyKeepsBucketsBeforeDuration(t *testing.T) {
 	testutil.Equals(t, got, want)
 }
 
-func uploadMockBlock(t *testing.T, bkt objstore.Bucket, id string, minTime, maxTime time.Time) {
+func TestTimeBasedRetentionPolicyByResolutionOnEmptyBucket(t *testing.T) {
+	logger := log.NewNopLogger()
+	bkt := inmem.NewBucket()
+
+	testutil.Ok(t, compact.ApplyRetentionPolicyByResolution(context.TODO(), logger, bkt, 24*time.Hour, downsample.ResLevel0))
+
+	var (
+		want []string
+		got  []string
+	)
+	testutil.Ok(t, bkt.Iter(context.TODO(), "", func(name string) error {
+		got = append(got, name)
+		return nil
+	}))
+
+	testutil.Equals(t, got, want)
+}
+
+func TestTimeBasedRetentionPolicyByResolutionKeepsBucketsBeforeDuration(t *testing.T) {
+	logger := log.NewNopLogger()
+	bkt := inmem.NewBucket()
+
+	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW48", time.Now().Add(-3*24*time.Hour), time.Now().Add(-2*24*time.Hour), downsample.ResLevel0)
+	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW49", time.Now().Add(-2*24*time.Hour), time.Now().Add(-24*time.Hour), downsample.ResLevel1)
+	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW50", time.Now().Add(-24*time.Hour), time.Now().Add(-23*time.Hour), downsample.ResLevel2)
+	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW51", time.Now().Add(-23*time.Hour), time.Now().Add(-6*time.Hour), downsample.ResLevel0)
+	testutil.Ok(t, compact.ApplyRetentionPolicyByResolution(context.TODO(), logger, bkt, 24*time.Hour, downsample.ResLevel0))
+
+	want := []string{"01CPHBEX20729MJQZXE3W0BW49/", "01CPHBEX20729MJQZXE3W0BW50/", "01CPHBEX20729MJQZXE3W0BW51/"}
+
+	var got []string
+	testutil.Ok(t, bkt.Iter(context.TODO(), "", func(name string) error {
+		got = append(got, name)
+		return nil
+	}))
+
+	testutil.Equals(t, got, want)
+}
+
+func uploadMockBlock(t *testing.T, bkt objstore.Bucket, id string, minTime, maxTime time.Time, resolutionLevel int64) {
+	t.Helper()
 	meta1 := block.Meta{
 		Version: 1,
 		BlockMeta: tsdb.BlockMeta{
 			ULID:    ulid.MustParse(id),
 			MinTime: minTime.Unix() * 1000,
 			MaxTime: maxTime.Unix() * 1000,
+		},
+		Thanos: block.ThanosMeta{
+			Downsample: block.ThanosDownsampleMeta{
+				Resolution: resolutionLevel,
+			},
 		},
 	}
 

--- a/pkg/compact/retention_test.go
+++ b/pkg/compact/retention_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/compact"
-	"github.com/improbable-eng/thanos/pkg/compact/downsample"
 	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/inmem"
 	"github.com/improbable-eng/thanos/pkg/testutil"
@@ -19,55 +18,253 @@ import (
 	"github.com/prometheus/tsdb"
 )
 
-func TestTimeBasedRetentionPolicyByResolutionOnEmptyBucket(t *testing.T) {
-	logger := log.NewNopLogger()
-	bkt := inmem.NewBucket()
-
-	retentionsByResolution := map[compact.ResolutionLevel]time.Duration{
-		compact.ResolutionLevelRaw: 24 * time.Hour,
-		compact.ResolutionLevel5m:  0,
-		compact.ResolutionLevel1h:  0,
+func TestApplyRetentionPolicyByResolution(t *testing.T) {
+	type testBlock struct {
+		id         string
+		minTime    time.Time
+		maxTime    time.Time
+		resolution compact.ResolutionLevel
+	}
+	type args struct {
+		blocks                []testBlock
+		retentionByResolution map[compact.ResolutionLevel]time.Duration
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			"empty bucket",
+			args{
+				blocks: []testBlock{},
+				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
+					compact.ResolutionLevelRaw: 24 * time.Hour,
+					compact.ResolutionLevel5m:  7 * 24 * time.Hour,
+					compact.ResolutionLevel1h:  14 * 24 * time.Hour,
+				},
+			},
+			[]string{},
+			false,
+		},
+		{
+			"only raw retention",
+			args{
+				blocks: []testBlock{
+					{
+						"01CPHBEX20729MJQZXE3W0BW48",
+						time.Now().Add(-3 * 24 * time.Hour),
+						time.Now().Add(-2 * 24 * time.Hour),
+						compact.ResolutionLevelRaw,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW49",
+						time.Now().Add(-2 * 24 * time.Hour),
+						time.Now().Add(-24 * time.Hour),
+						compact.ResolutionLevel5m,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW50",
+						time.Now().Add(-24 * time.Hour),
+						time.Now().Add(-23 * time.Hour),
+						compact.ResolutionLevel1h,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW51",
+						time.Now().Add(-23 * time.Hour),
+						time.Now().Add(-6 * time.Hour),
+						compact.ResolutionLevelRaw,
+					},
+				},
+				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
+					compact.ResolutionLevelRaw: 24 * time.Hour,
+					compact.ResolutionLevel5m:  0,
+					compact.ResolutionLevel1h:  0,
+				},
+			},
+			[]string{
+				"01CPHBEX20729MJQZXE3W0BW49/",
+				"01CPHBEX20729MJQZXE3W0BW50/",
+				"01CPHBEX20729MJQZXE3W0BW51/",
+			},
+			false,
+		},
+		{
+			"no retention",
+			args{
+				blocks: []testBlock{
+					{
+						"01CPHBEX20729MJQZXE3W0BW48",
+						time.Now().Add(-3 * 24 * time.Hour),
+						time.Now().Add(-2 * 24 * time.Hour),
+						compact.ResolutionLevelRaw,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW49",
+						time.Now().Add(-2 * 24 * time.Hour),
+						time.Now().Add(-24 * time.Hour),
+						compact.ResolutionLevel5m,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW50",
+						time.Now().Add(-24 * time.Hour),
+						time.Now().Add(-23 * time.Hour),
+						compact.ResolutionLevel1h,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW51",
+						time.Now().Add(-23 * time.Hour),
+						time.Now().Add(-6 * time.Hour),
+						compact.ResolutionLevelRaw,
+					},
+				},
+				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
+					compact.ResolutionLevelRaw: 0,
+					compact.ResolutionLevel5m:  0,
+					compact.ResolutionLevel1h:  0,
+				},
+			},
+			[]string{
+				"01CPHBEX20729MJQZXE3W0BW48/",
+				"01CPHBEX20729MJQZXE3W0BW49/",
+				"01CPHBEX20729MJQZXE3W0BW50/",
+				"01CPHBEX20729MJQZXE3W0BW51/",
+			},
+			false,
+		},
+		{
+			"no retention 1900",
+			args{
+				blocks: []testBlock{
+					{
+						"01CPHBEX20729MJQZXE3W0BW48",
+						time.Date(1900, 1, 1, 1, 0, 0, 0, time.Local),
+						time.Date(1900, 1, 1, 2, 0, 0, 0, time.Local),
+						compact.ResolutionLevelRaw,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW49",
+						time.Date(1900, 1, 1, 1, 0, 0, 0, time.Local),
+						time.Date(1900, 1, 1, 2, 0, 0, 0, time.Local),
+						compact.ResolutionLevel5m,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW50",
+						time.Date(1900, 1, 1, 1, 0, 0, 0, time.Local),
+						time.Date(1900, 1, 1, 2, 0, 0, 0, time.Local),
+						compact.ResolutionLevel1h,
+					},
+				},
+				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
+					compact.ResolutionLevelRaw: 0,
+					compact.ResolutionLevel5m:  0,
+					compact.ResolutionLevel1h:  0,
+				},
+			},
+			[]string{
+				"01CPHBEX20729MJQZXE3W0BW48/",
+				"01CPHBEX20729MJQZXE3W0BW49/",
+				"01CPHBEX20729MJQZXE3W0BW50/",
+			},
+			false,
+		},
+		{
+			"unknown resolution",
+			args{
+				blocks: []testBlock{
+					{
+						"01CPHBEX20729MJQZXE3W0BW48",
+						time.Now().Add(-3 * 24 * time.Hour),
+						time.Now().Add(-2 * 24 * time.Hour),
+						compact.ResolutionLevel(1),
+					},
+				},
+				retentionByResolution: map[compact.ResolutionLevel]time.Duration{},
+			},
+			[]string{
+				"01CPHBEX20729MJQZXE3W0BW48/",
+			},
+			false,
+		},
+		{
+			"every retention deletes",
+			args{
+				blocks: []testBlock{
+					{
+						"01CPHBEX20729MJQZXE3W0BW40",
+						time.Now().Add(-1 * 24 * time.Hour),
+						time.Now().Add(-0 * 24 * time.Hour),
+						compact.ResolutionLevelRaw,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW41",
+						time.Now().Add(-2 * 24 * time.Hour),
+						time.Now().Add(-1 * 24 * time.Hour),
+						compact.ResolutionLevelRaw,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW42",
+						time.Now().Add(-7 * 24 * time.Hour),
+						time.Now().Add(-6 * 24 * time.Hour),
+						compact.ResolutionLevel5m,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW43",
+						time.Now().Add(-8 * 24 * time.Hour),
+						time.Now().Add(-7 * 24 * time.Hour),
+						compact.ResolutionLevel5m,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW44",
+						time.Now().Add(-14 * 24 * time.Hour),
+						time.Now().Add(-13 * 24 * time.Hour),
+						compact.ResolutionLevel1h,
+					},
+					{
+						"01CPHBEX20729MJQZXE3W0BW45",
+						time.Now().Add(-15 * 24 * time.Hour),
+						time.Now().Add(-14 * 24 * time.Hour),
+						compact.ResolutionLevel1h,
+					},
+				},
+				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
+					compact.ResolutionLevelRaw: 24 * time.Hour,
+					compact.ResolutionLevel5m:  7 * 24 * time.Hour,
+					compact.ResolutionLevel1h:  14 * 24 * time.Hour,
+				},
+			},
+			[]string{
+				"01CPHBEX20729MJQZXE3W0BW40/",
+				"01CPHBEX20729MJQZXE3W0BW42/",
+				"01CPHBEX20729MJQZXE3W0BW44/",
+			},
+			false,
+		},
 	}
 
-	testutil.Ok(t, compact.ApplyRetentionPolicyByResolution(context.TODO(), logger, bkt, retentionsByResolution))
-
-	var (
-		want []string
-		got  []string
-	)
-	testutil.Ok(t, bkt.Iter(context.TODO(), "", func(name string) error {
-		got = append(got, name)
-		return nil
-	}))
-
-	testutil.Equals(t, got, want)
-}
-
-func TestTimeBasedRetentionPolicyByResolutionKeepsBucketsBeforeDuration(t *testing.T) {
 	logger := log.NewNopLogger()
-	bkt := inmem.NewBucket()
+	ctx := context.TODO()
 
-	retentionsByResolution := map[compact.ResolutionLevel]time.Duration{
-		compact.ResolutionLevelRaw: 24 * time.Hour,
-		compact.ResolutionLevel5m:  0,
-		compact.ResolutionLevel1h:  0,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bkt := inmem.NewBucket()
+			for _, b := range tt.args.blocks {
+				uploadMockBlock(t, bkt, b.id, b.minTime, b.maxTime, int64(b.resolution))
+			}
+			if err := compact.ApplyRetentionPolicyByResolution(ctx, logger, bkt, tt.args.retentionByResolution); (err != nil) != tt.wantErr {
+				t.Errorf("ApplyRetentionPolicyByResolution() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			got := []string{}
+			testutil.Ok(t, bkt.Iter(context.TODO(), "", func(name string) error {
+				got = append(got, name)
+				return nil
+			}))
+
+			testutil.Equals(t, got, tt.want)
+		})
 	}
-
-	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW48", time.Now().Add(-3*24*time.Hour), time.Now().Add(-2*24*time.Hour), downsample.ResLevel0)
-	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW49", time.Now().Add(-2*24*time.Hour), time.Now().Add(-24*time.Hour), downsample.ResLevel1)
-	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW50", time.Now().Add(-24*time.Hour), time.Now().Add(-23*time.Hour), downsample.ResLevel2)
-	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW51", time.Now().Add(-23*time.Hour), time.Now().Add(-6*time.Hour), downsample.ResLevel0)
-	testutil.Ok(t, compact.ApplyRetentionPolicyByResolution(context.TODO(), logger, bkt, retentionsByResolution))
-
-	want := []string{"01CPHBEX20729MJQZXE3W0BW49/", "01CPHBEX20729MJQZXE3W0BW50/", "01CPHBEX20729MJQZXE3W0BW51/"}
-
-	var got []string
-	testutil.Ok(t, bkt.Iter(context.TODO(), "", func(name string) error {
-		got = append(got, name)
-		return nil
-	}))
-
-	testutil.Equals(t, got, want)
 }
 
 func uploadMockBlock(t *testing.T, bkt objstore.Bucket, id string, minTime, maxTime time.Time, resolutionLevel int64) {

--- a/pkg/compact/retention_test.go
+++ b/pkg/compact/retention_test.go
@@ -25,63 +25,60 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 		maxTime    time.Time
 		resolution compact.ResolutionLevel
 	}
-	type args struct {
+
+	logger := log.NewNopLogger()
+	ctx := context.TODO()
+
+	for _, tt := range []struct {
+		name                  string
 		blocks                []testBlock
 		retentionByResolution map[compact.ResolutionLevel]time.Duration
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []string
-		wantErr bool
+		want                  []string
+		wantErr               bool
 	}{
 		{
 			"empty bucket",
-			args{
-				blocks: []testBlock{},
-				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
-					compact.ResolutionLevelRaw: 24 * time.Hour,
-					compact.ResolutionLevel5m:  7 * 24 * time.Hour,
-					compact.ResolutionLevel1h:  14 * 24 * time.Hour,
-				},
+			[]testBlock{},
+			map[compact.ResolutionLevel]time.Duration{
+				compact.ResolutionLevelRaw: 24 * time.Hour,
+				compact.ResolutionLevel5m:  7 * 24 * time.Hour,
+				compact.ResolutionLevel1h:  14 * 24 * time.Hour,
 			},
 			[]string{},
 			false,
 		},
 		{
 			"only raw retention",
-			args{
-				blocks: []testBlock{
-					{
-						"01CPHBEX20729MJQZXE3W0BW48",
-						time.Now().Add(-3 * 24 * time.Hour),
-						time.Now().Add(-2 * 24 * time.Hour),
-						compact.ResolutionLevelRaw,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW49",
-						time.Now().Add(-2 * 24 * time.Hour),
-						time.Now().Add(-24 * time.Hour),
-						compact.ResolutionLevel5m,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW50",
-						time.Now().Add(-24 * time.Hour),
-						time.Now().Add(-23 * time.Hour),
-						compact.ResolutionLevel1h,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW51",
-						time.Now().Add(-23 * time.Hour),
-						time.Now().Add(-6 * time.Hour),
-						compact.ResolutionLevelRaw,
-					},
+			[]testBlock{
+				{
+					"01CPHBEX20729MJQZXE3W0BW48",
+					time.Now().Add(-3 * 24 * time.Hour),
+					time.Now().Add(-2 * 24 * time.Hour),
+					compact.ResolutionLevelRaw,
 				},
-				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
-					compact.ResolutionLevelRaw: 24 * time.Hour,
-					compact.ResolutionLevel5m:  0,
-					compact.ResolutionLevel1h:  0,
+				{
+					"01CPHBEX20729MJQZXE3W0BW49",
+					time.Now().Add(-2 * 24 * time.Hour),
+					time.Now().Add(-24 * time.Hour),
+					compact.ResolutionLevel5m,
 				},
+				{
+					"01CPHBEX20729MJQZXE3W0BW50",
+					time.Now().Add(-24 * time.Hour),
+					time.Now().Add(-23 * time.Hour),
+					compact.ResolutionLevel1h,
+				},
+				{
+					"01CPHBEX20729MJQZXE3W0BW51",
+					time.Now().Add(-23 * time.Hour),
+					time.Now().Add(-6 * time.Hour),
+					compact.ResolutionLevelRaw,
+				},
+			},
+			map[compact.ResolutionLevel]time.Duration{
+				compact.ResolutionLevelRaw: 24 * time.Hour,
+				compact.ResolutionLevel5m:  0,
+				compact.ResolutionLevel1h:  0,
 			},
 			[]string{
 				"01CPHBEX20729MJQZXE3W0BW49/",
@@ -92,38 +89,36 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 		},
 		{
 			"no retention",
-			args{
-				blocks: []testBlock{
-					{
-						"01CPHBEX20729MJQZXE3W0BW48",
-						time.Now().Add(-3 * 24 * time.Hour),
-						time.Now().Add(-2 * 24 * time.Hour),
-						compact.ResolutionLevelRaw,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW49",
-						time.Now().Add(-2 * 24 * time.Hour),
-						time.Now().Add(-24 * time.Hour),
-						compact.ResolutionLevel5m,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW50",
-						time.Now().Add(-24 * time.Hour),
-						time.Now().Add(-23 * time.Hour),
-						compact.ResolutionLevel1h,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW51",
-						time.Now().Add(-23 * time.Hour),
-						time.Now().Add(-6 * time.Hour),
-						compact.ResolutionLevelRaw,
-					},
+			[]testBlock{
+				{
+					"01CPHBEX20729MJQZXE3W0BW48",
+					time.Now().Add(-3 * 24 * time.Hour),
+					time.Now().Add(-2 * 24 * time.Hour),
+					compact.ResolutionLevelRaw,
 				},
-				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
-					compact.ResolutionLevelRaw: 0,
-					compact.ResolutionLevel5m:  0,
-					compact.ResolutionLevel1h:  0,
+				{
+					"01CPHBEX20729MJQZXE3W0BW49",
+					time.Now().Add(-2 * 24 * time.Hour),
+					time.Now().Add(-24 * time.Hour),
+					compact.ResolutionLevel5m,
 				},
+				{
+					"01CPHBEX20729MJQZXE3W0BW50",
+					time.Now().Add(-24 * time.Hour),
+					time.Now().Add(-23 * time.Hour),
+					compact.ResolutionLevel1h,
+				},
+				{
+					"01CPHBEX20729MJQZXE3W0BW51",
+					time.Now().Add(-23 * time.Hour),
+					time.Now().Add(-6 * time.Hour),
+					compact.ResolutionLevelRaw,
+				},
+			},
+			map[compact.ResolutionLevel]time.Duration{
+				compact.ResolutionLevelRaw: 0,
+				compact.ResolutionLevel5m:  0,
+				compact.ResolutionLevel1h:  0,
 			},
 			[]string{
 				"01CPHBEX20729MJQZXE3W0BW48/",
@@ -135,32 +130,30 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 		},
 		{
 			"no retention 1900",
-			args{
-				blocks: []testBlock{
-					{
-						"01CPHBEX20729MJQZXE3W0BW48",
-						time.Date(1900, 1, 1, 1, 0, 0, 0, time.Local),
-						time.Date(1900, 1, 1, 2, 0, 0, 0, time.Local),
-						compact.ResolutionLevelRaw,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW49",
-						time.Date(1900, 1, 1, 1, 0, 0, 0, time.Local),
-						time.Date(1900, 1, 1, 2, 0, 0, 0, time.Local),
-						compact.ResolutionLevel5m,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW50",
-						time.Date(1900, 1, 1, 1, 0, 0, 0, time.Local),
-						time.Date(1900, 1, 1, 2, 0, 0, 0, time.Local),
-						compact.ResolutionLevel1h,
-					},
+			[]testBlock{
+				{
+					"01CPHBEX20729MJQZXE3W0BW48",
+					time.Date(1900, 1, 1, 1, 0, 0, 0, time.Local),
+					time.Date(1900, 1, 1, 2, 0, 0, 0, time.Local),
+					compact.ResolutionLevelRaw,
 				},
-				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
-					compact.ResolutionLevelRaw: 0,
-					compact.ResolutionLevel5m:  0,
-					compact.ResolutionLevel1h:  0,
+				{
+					"01CPHBEX20729MJQZXE3W0BW49",
+					time.Date(1900, 1, 1, 1, 0, 0, 0, time.Local),
+					time.Date(1900, 1, 1, 2, 0, 0, 0, time.Local),
+					compact.ResolutionLevel5m,
 				},
+				{
+					"01CPHBEX20729MJQZXE3W0BW50",
+					time.Date(1900, 1, 1, 1, 0, 0, 0, time.Local),
+					time.Date(1900, 1, 1, 2, 0, 0, 0, time.Local),
+					compact.ResolutionLevel1h,
+				},
+			},
+			map[compact.ResolutionLevel]time.Duration{
+				compact.ResolutionLevelRaw: 0,
+				compact.ResolutionLevel5m:  0,
+				compact.ResolutionLevel1h:  0,
 			},
 			[]string{
 				"01CPHBEX20729MJQZXE3W0BW48/",
@@ -171,17 +164,15 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 		},
 		{
 			"unknown resolution",
-			args{
-				blocks: []testBlock{
-					{
-						"01CPHBEX20729MJQZXE3W0BW48",
-						time.Now().Add(-3 * 24 * time.Hour),
-						time.Now().Add(-2 * 24 * time.Hour),
-						compact.ResolutionLevel(1),
-					},
+			[]testBlock{
+				{
+					"01CPHBEX20729MJQZXE3W0BW48",
+					time.Now().Add(-3 * 24 * time.Hour),
+					time.Now().Add(-2 * 24 * time.Hour),
+					compact.ResolutionLevel(1),
 				},
-				retentionByResolution: map[compact.ResolutionLevel]time.Duration{},
 			},
+			map[compact.ResolutionLevel]time.Duration{},
 			[]string{
 				"01CPHBEX20729MJQZXE3W0BW48/",
 			},
@@ -189,50 +180,48 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 		},
 		{
 			"every retention deletes",
-			args{
-				blocks: []testBlock{
-					{
-						"01CPHBEX20729MJQZXE3W0BW40",
-						time.Now().Add(-1 * 24 * time.Hour),
-						time.Now().Add(-0 * 24 * time.Hour),
-						compact.ResolutionLevelRaw,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW41",
-						time.Now().Add(-2 * 24 * time.Hour),
-						time.Now().Add(-1 * 24 * time.Hour),
-						compact.ResolutionLevelRaw,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW42",
-						time.Now().Add(-7 * 24 * time.Hour),
-						time.Now().Add(-6 * 24 * time.Hour),
-						compact.ResolutionLevel5m,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW43",
-						time.Now().Add(-8 * 24 * time.Hour),
-						time.Now().Add(-7 * 24 * time.Hour),
-						compact.ResolutionLevel5m,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW44",
-						time.Now().Add(-14 * 24 * time.Hour),
-						time.Now().Add(-13 * 24 * time.Hour),
-						compact.ResolutionLevel1h,
-					},
-					{
-						"01CPHBEX20729MJQZXE3W0BW45",
-						time.Now().Add(-15 * 24 * time.Hour),
-						time.Now().Add(-14 * 24 * time.Hour),
-						compact.ResolutionLevel1h,
-					},
+			[]testBlock{
+				{
+					"01CPHBEX20729MJQZXE3W0BW40",
+					time.Now().Add(-1 * 24 * time.Hour),
+					time.Now().Add(-0 * 24 * time.Hour),
+					compact.ResolutionLevelRaw,
 				},
-				retentionByResolution: map[compact.ResolutionLevel]time.Duration{
-					compact.ResolutionLevelRaw: 24 * time.Hour,
-					compact.ResolutionLevel5m:  7 * 24 * time.Hour,
-					compact.ResolutionLevel1h:  14 * 24 * time.Hour,
+				{
+					"01CPHBEX20729MJQZXE3W0BW41",
+					time.Now().Add(-2 * 24 * time.Hour),
+					time.Now().Add(-1 * 24 * time.Hour),
+					compact.ResolutionLevelRaw,
 				},
+				{
+					"01CPHBEX20729MJQZXE3W0BW42",
+					time.Now().Add(-7 * 24 * time.Hour),
+					time.Now().Add(-6 * 24 * time.Hour),
+					compact.ResolutionLevel5m,
+				},
+				{
+					"01CPHBEX20729MJQZXE3W0BW43",
+					time.Now().Add(-8 * 24 * time.Hour),
+					time.Now().Add(-7 * 24 * time.Hour),
+					compact.ResolutionLevel5m,
+				},
+				{
+					"01CPHBEX20729MJQZXE3W0BW44",
+					time.Now().Add(-14 * 24 * time.Hour),
+					time.Now().Add(-13 * 24 * time.Hour),
+					compact.ResolutionLevel1h,
+				},
+				{
+					"01CPHBEX20729MJQZXE3W0BW45",
+					time.Now().Add(-15 * 24 * time.Hour),
+					time.Now().Add(-14 * 24 * time.Hour),
+					compact.ResolutionLevel1h,
+				},
+			},
+			map[compact.ResolutionLevel]time.Duration{
+				compact.ResolutionLevelRaw: 24 * time.Hour,
+				compact.ResolutionLevel5m:  7 * 24 * time.Hour,
+				compact.ResolutionLevel1h:  14 * 24 * time.Hour,
 			},
 			[]string{
 				"01CPHBEX20729MJQZXE3W0BW40/",
@@ -241,18 +230,13 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 			},
 			false,
 		},
-	}
-
-	logger := log.NewNopLogger()
-	ctx := context.TODO()
-
-	for _, tt := range tests {
+	} {
 		t.Run(tt.name, func(t *testing.T) {
 			bkt := inmem.NewBucket()
-			for _, b := range tt.args.blocks {
+			for _, b := range tt.blocks {
 				uploadMockBlock(t, bkt, b.id, b.minTime, b.maxTime, int64(b.resolution))
 			}
-			if err := compact.ApplyRetentionPolicyByResolution(ctx, logger, bkt, tt.args.retentionByResolution); (err != nil) != tt.wantErr {
+			if err := compact.ApplyRetentionPolicyByResolution(ctx, logger, bkt, tt.retentionByResolution); (err != nil) != tt.wantErr {
 				t.Errorf("ApplyRetentionPolicyByResolution() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/pkg/compact/retention_test.go
+++ b/pkg/compact/retention_test.go
@@ -23,10 +23,10 @@ func TestTimeBasedRetentionPolicyByResolutionOnEmptyBucket(t *testing.T) {
 	logger := log.NewNopLogger()
 	bkt := inmem.NewBucket()
 
-	retentionsByResolution := map[int64]time.Duration{
-		downsample.ResLevel0: 24 * time.Hour,
-		downsample.ResLevel1: 0,
-		downsample.ResLevel2: 0,
+	retentionsByResolution := map[compact.ResolutionLevel]time.Duration{
+		compact.ResolutionLevelRaw: 24 * time.Hour,
+		compact.ResolutionLevel5m:  0,
+		compact.ResolutionLevel1h:  0,
 	}
 
 	testutil.Ok(t, compact.ApplyRetentionPolicyByResolution(context.TODO(), logger, bkt, retentionsByResolution))
@@ -47,10 +47,10 @@ func TestTimeBasedRetentionPolicyByResolutionKeepsBucketsBeforeDuration(t *testi
 	logger := log.NewNopLogger()
 	bkt := inmem.NewBucket()
 
-	retentionsByResolution := map[int64]time.Duration{
-		downsample.ResLevel0: 24 * time.Hour,
-		downsample.ResLevel1: 0,
-		downsample.ResLevel2: 0,
+	retentionsByResolution := map[compact.ResolutionLevel]time.Duration{
+		compact.ResolutionLevelRaw: 24 * time.Hour,
+		compact.ResolutionLevel5m:  0,
+		compact.ResolutionLevel1h:  0,
 	}
 
 	uploadMockBlock(t, bkt, "01CPHBEX20729MJQZXE3W0BW48", time.Now().Add(-3*24*time.Hour), time.Now().Add(-2*24*time.Hour), downsample.ResLevel0)


### PR DESCRIPTION
ref: #458 

## Changes

Adds retention analog to the implemented global retention.


Any feedback welcome :-)

## Verification

Small unit test and tested locally in a cluster using the parameters:
`--retention.res0=4d --retention.res1=8d`
```
level=info ts=2018-09-10T09:58:56.706891152Z caller=compact.go:141 msg="retention policy of raw samples is enabled" duration=96h0m0s
level=info ts=2018-09-10T09:58:56.707158971Z caller=compact.go:144 msg="retention policy of 5 min aggregated samples is enabled" duration=96h0m0s
level=info ts=2018-09-10T09:58:56.707404063Z caller=compact.go:234 msg="starting compact node"
level=info ts=2018-09-10T09:58:56.707904636Z caller=main.go:244 msg="Listening for metrics" address=0.0.0.0:10902
level=info ts=2018-09-10T09:58:56.708745619Z caller=compact.go:803 msg="start sync of metas"
level=debug ts=2018-09-10T09:58:58.006067661Z caller=compact.go:166 msg="download meta" block=01CPC5XX1RXDE10AMJG3MJF4F6
level=debug ts=2018-09-10T09:58:58.067181625Z caller=compact.go:166 msg="download meta" block=01CPC62WDQQ9M2KY50HCKV2EWW
level=debug ts=2018-09-10T09:58:58.101841426Z caller=compact.go:166 msg="download meta" block=01CPC668QDZH503TRWETSQ8M5N
level=debug ts=2018-09-10T09:58:58.137435259Z caller=compact.go:166 msg="download meta" block=01CPHAS35QM2CJRNQVNJM7ZVV1
level=debug ts=2018-09-10T09:58:58.171600886Z caller=compact.go:166 msg="download meta" block=01CPHAYPB23ACPS96MJ4YT2HWR
level=debug ts=2018-09-10T09:58:58.207135132Z caller=compact.go:166 msg="download meta" block=01CPHB2BMMGN9NBAQQP2M1X508
level=debug ts=2018-09-10T09:58:58.242003398Z caller=compact.go:166 msg="download meta" block=01CPPFFZPV69TM7DSDZ35MNX0X
level=debug ts=2018-09-10T09:58:58.278351871Z caller=compact.go:166 msg="download meta" block=01CPPFPWEFGXS191SA422DGA8B
level=debug ts=2018-09-10T09:58:58.317564077Z caller=compact.go:166 msg="download meta" block=01CPPFWZ8SZ16WQRDAZBPJQ7BK
level=debug ts=2018-09-10T09:58:58.360376212Z caller=compact.go:166 msg="download meta" block=01CQ0PQXPWG8CM1RQQKB7K84Q3
level=debug ts=2018-09-10T09:58:58.398685253Z caller=compact.go:166 msg="download meta" block=01CQ0PR4Y1AYWE6FN1YMGTTRAP
level=debug ts=2018-09-10T09:58:58.443498253Z caller=compact.go:166 msg="download meta" block=01CQ0PR7G3GW0N8TENN05W8WSA
level=debug ts=2018-09-10T09:58:58.477024934Z caller=compact.go:166 msg="download meta" block=01CQ0PR7J0Q8DAC0PV2PDBT5RS
level=debug ts=2018-09-10T09:58:58.52923108Z caller=compact.go:166 msg="download meta" block=01CQ0PR7RKZ4QF4BT115FV0SRH
level=debug ts=2018-09-10T09:58:58.568097476Z caller=compact.go:166 msg="download meta" block=01CQ0PRCTXGTFK2BJ74RVV507K
level=debug ts=2018-09-10T09:58:58.609144906Z caller=compact.go:166 msg="download meta" block=01CQ0PRDPX6N63ZE0D9C4ZEG2E
level=debug ts=2018-09-10T09:58:58.642434608Z caller=compact.go:166 msg="download meta" block=01CQ0PRGQX9Z73WSESZFR0STWW
level=debug ts=2018-09-10T09:58:58.679639439Z caller=compact.go:166 msg="download meta" block=01CQ0PRM9013EJ2TXCBNQM0Y01
level=debug ts=2018-09-10T09:58:58.720396844Z caller=compact.go:166 msg="download meta" block=01CQ0PRYDH7ZZ1MJAJ21K5KYBG
level=debug ts=2018-09-10T09:58:58.761512049Z caller=compact.go:166 msg="download meta" block=01CQ0PS3CKFRJXG7B60VQP56Q0
level=debug ts=2018-09-10T09:58:58.815964962Z caller=compact.go:166 msg="download meta" block=01CQ0PS46Q35N2ZGKW8VEXV2CP
level=debug ts=2018-09-10T09:58:58.861563498Z caller=compact.go:166 msg="download meta" block=01CQ0XKMZ30AK3NKF3M9SQJ48V
level=debug ts=2018-09-10T09:58:58.898210353Z caller=compact.go:166 msg="download meta" block=01CQ0XKW62C266J16CE07PXEW6
level=debug ts=2018-09-10T09:58:58.937481466Z caller=compact.go:166 msg="download meta" block=01CQ0XKYR329AKGHZN9KVADX0C
level=debug ts=2018-09-10T09:58:59.006450779Z caller=compact.go:166 msg="download meta" block=01CQ0XKYY8XZW5Y6A1CC9TWZCZ
level=debug ts=2018-09-10T09:58:59.044376932Z caller=compact.go:166 msg="download meta" block=01CQ0XKZ4WTE8HGDPTVPAA24YQ
level=debug ts=2018-09-10T09:58:59.088420639Z caller=compact.go:166 msg="download meta" block=01CQ0XM42WFPRQ40Z8RGC3C1AS
level=debug ts=2018-09-10T09:58:59.125686458Z caller=compact.go:166 msg="download meta" block=01CQ0XM529NZ2MKHEW6HCBTHT1
level=debug ts=2018-09-10T09:58:59.167193383Z caller=compact.go:166 msg="download meta" block=01CQ0XM7WA27B4M4RAPMGFHBPE
level=debug ts=2018-09-10T09:58:59.203284288Z caller=compact.go:166 msg="download meta" block=01CQ0XMBDRNBN6NE816RR9RG9B
level=debug ts=2018-09-10T09:58:59.234818893Z caller=compact.go:166 msg="download meta" block=01CQ0XMNN8E6X70D6E2DREP32R
level=debug ts=2018-09-10T09:58:59.271200066Z caller=compact.go:166 msg="download meta" block=01CQ0XMTPVJ46BRRTWDGGBPTZ2
level=debug ts=2018-09-10T09:58:59.307291596Z caller=compact.go:166 msg="download meta" block=01CQ0XMVF3G577KKQ86RFWGZ6S
level=debug ts=2018-09-10T09:58:59.348996079Z caller=compact.go:166 msg="download meta" block=01CQ13ZTBJ42BSA0C9NN8NWF7K
level=debug ts=2018-09-10T09:58:59.3856265Z caller=compact.go:166 msg="download meta" block=01CQ13ZYAXPHDAVBDWHGX3KHD6
level=debug ts=2018-09-10T09:58:59.420430873Z caller=compact.go:166 msg="download meta" block=01CQ140EPJZDHPWNY32B9M6N7S
level=debug ts=2018-09-10T09:58:59.46938535Z caller=compact.go:166 msg="download meta" block=01CQ140RDS45B2H0KDNSN66S3H
level=debug ts=2018-09-10T09:58:59.505138816Z caller=compact.go:166 msg="download meta" block=01CQ1413G2NYSF7M27MGHWPTWE
level=debug ts=2018-09-10T09:58:59.547272979Z caller=compact.go:166 msg="download meta" block=01CQ141G3QW74BPTGKVKE3PG1E
level=debug ts=2018-09-10T09:58:59.603385753Z caller=compact.go:166 msg="download meta" block=01CQ141TK2N9KD6FHX13ZVP43B
level=debug ts=2018-09-10T09:58:59.660881843Z caller=compact.go:166 msg="download meta" block=01CQ1425QBXX85KDYPZBTGSMKA
level=debug ts=2018-09-10T09:58:59.704928072Z caller=compact.go:166 msg="download meta" block=01CQ142H1TCREFQTBMDFS4578N
level=debug ts=2018-09-10T09:58:59.751728043Z caller=compact.go:166 msg="download meta" block=01CQ14FC8M08PSAMSETD5K5CZ0
level=debug ts=2018-09-10T09:58:59.783639869Z caller=compact.go:166 msg="download meta" block=01CQ14FJVC1T3782G795WKMYF1
level=debug ts=2018-09-10T09:58:59.827202739Z caller=compact.go:166 msg="download meta" block=01CQ14FKE3YQ5S9R37RDC5ZK15
level=debug ts=2018-09-10T09:58:59.863441456Z caller=compact.go:166 msg="download meta" block=01CQ14FP0Z23HJG9N97691MEMJ
level=debug ts=2018-09-10T09:58:59.905648021Z caller=compact.go:166 msg="download meta" block=01CQ14FP3PTC2JTFSN7N012VBV
level=debug ts=2018-09-10T09:58:59.933529246Z caller=compact.go:166 msg="download meta" block=01CQ14FPDY7CHDD18078TQPX48
level=debug ts=2018-09-10T09:58:59.971950708Z caller=compact.go:166 msg="download meta" block=01CQ14FTD2PB3ZKQ42PFKT3ZSC
level=debug ts=2018-09-10T09:59:00.037725643Z caller=compact.go:166 msg="download meta" block=01CQ14FVAVY4WM0YFPAFZJNE50
level=debug ts=2018-09-10T09:59:00.117736385Z caller=compact.go:166 msg="download meta" block=01CQ14FWEBYWB8XBE2GN0Y837X
level=debug ts=2018-09-10T09:59:00.171117414Z caller=compact.go:166 msg="download meta" block=01CQ14FZBX6Z9G0PPWNNH1RGB9
level=debug ts=2018-09-10T09:59:00.207893069Z caller=compact.go:166 msg="download meta" block=01CQ14G2W9NV886KGCMBC20ZCK
level=debug ts=2018-09-10T09:59:00.246156921Z caller=compact.go:166 msg="download meta" block=01CQ14GCXS6GHWMN2ANT57MC1E
level=debug ts=2018-09-10T09:59:00.285822488Z caller=compact.go:166 msg="download meta" block=01CQ14GDJ1K2BAT7G1ZB8GWYPT
level=debug ts=2018-09-10T09:59:00.323841178Z caller=compact.go:166 msg="download meta" block=01CQ14GHW474Z3MQBH9GBVNN3W
level=debug ts=2018-09-10T09:59:00.432439522Z caller=compact.go:166 msg="download meta" block=01CQ14GJPNTXADQ6F7ZX745VE0
level=debug ts=2018-09-10T09:59:00.494741078Z caller=compact.go:166 msg="download meta" block=01CQ14GV9K60BGK5YT24QKA4P6
level=debug ts=2018-09-10T09:59:00.537647167Z caller=compact.go:166 msg="download meta" block=01CQ14HJNZSD8FWKR6ZS34449Y
level=debug ts=2018-09-10T09:59:00.585972098Z caller=compact.go:166 msg="download meta" block=01CQ14J6ZRZQG74PZ0BHHJ2YKV
level=debug ts=2018-09-10T09:59:00.633981127Z caller=compact.go:166 msg="download meta" block=01CQ14JW8NVFASDRHHDFTJCR9F
level=debug ts=2018-09-10T09:59:00.676237402Z caller=compact.go:166 msg="download meta" block=01CQ14KMPY2M703KPY7JMDZCP2
level=debug ts=2018-09-10T09:59:00.722594241Z caller=compact.go:166 msg="download meta" block=01CQ14M6NHAT9RB0TWK0WYS4DJ
level=debug ts=2018-09-10T09:59:00.771265452Z caller=compact.go:166 msg="download meta" block=01CQ14RZVP778J5F7X36RZBEP8
level=debug ts=2018-09-10T09:59:00.822077915Z caller=compact.go:166 msg="download meta" block=01CQ14VAC84XF2F0C7B8ZQJEF8
level=debug ts=2018-09-10T09:59:00.862876306Z caller=compact.go:166 msg="download meta" block=01CQ14X9QB5BNQ6VC0R2EE241W
level=debug ts=2018-09-10T09:59:00.903928719Z caller=compact.go:166 msg="download meta" block=01CQ14YTRE6NNZQJCYXC9DXFGC
level=debug ts=2018-09-10T09:59:00.949948872Z caller=compact.go:166 msg="download meta" block=01CQ14ZX8G7V7TBMYN1FDCDJS4
level=debug ts=2018-09-10T09:59:00.98427944Z caller=compact.go:166 msg="download meta" block=01CQ150SASGXHBBDWSWRJKZ05J
level=debug ts=2018-09-10T09:59:01.025332215Z caller=compact.go:166 msg="download meta" block=01CQ153GMRFTRX1P926QCXTGN7
level=debug ts=2018-09-10T09:59:01.097612314Z caller=compact.go:166 msg="download meta" block=01CQ15FBYAW7VNWRE478HR9MA4
level=debug ts=2018-09-10T09:59:01.145442211Z caller=compact.go:166 msg="download meta" block=01CQ15RE6ES131EBPHDPP1KD6W
level=debug ts=2018-09-10T09:59:01.183098816Z caller=compact.go:166 msg="download meta" block=01CQ1BB3EYXRN9ZEVP8F7JKRDC
level=debug ts=2018-09-10T09:59:01.226946494Z caller=compact.go:166 msg="download meta" block=01CQ1BBAP4MRBVVGDH5V0ZK6PF
level=debug ts=2018-09-10T09:59:01.267433106Z caller=compact.go:166 msg="download meta" block=01CQ1BBD85A2HA3B7K1E10Q4BD
level=debug ts=2018-09-10T09:59:01.301871106Z caller=compact.go:166 msg="download meta" block=01CQ1BBDCZPSFN3E3QGSZXJE8P
level=debug ts=2018-09-10T09:59:01.340545731Z caller=compact.go:166 msg="download meta" block=01CQ1BBDT085T0PDGM0Z92EKB5
level=debug ts=2018-09-10T09:59:01.388227628Z caller=compact.go:166 msg="download meta" block=01CQ1BBJJWZ8MRHHP5EAGFH4AF
level=debug ts=2018-09-10T09:59:01.448516375Z caller=compact.go:166 msg="download meta" block=01CQ1BBKHEJXSBZW965QTMSBRN
level=debug ts=2018-09-10T09:59:01.481036512Z caller=compact.go:166 msg="download meta" block=01CQ1BBPCFNAAFWX8SZ6C40CSZ
level=debug ts=2018-09-10T09:59:01.519798883Z caller=compact.go:166 msg="download meta" block=01CQ1BBT36688WPC69DNQNRP14
level=debug ts=2018-09-10T09:59:01.560651164Z caller=compact.go:166 msg="download meta" block=01CQ1BC459J75BEM052YFYH43P
level=debug ts=2018-09-10T09:59:01.613148213Z caller=compact.go:166 msg="download meta" block=01CQ1BC98JBS42ZBVEKNDNWT1N
level=debug ts=2018-09-10T09:59:01.65414845Z caller=compact.go:166 msg="download meta" block=01CQ1BC9YNEQQ1C5EN5BBJ239N
level=info ts=2018-09-10T09:59:01.705275205Z caller=compact.go:809 msg="start of GC"
level=info ts=2018-09-10T09:59:02.013327069Z caller=compact.go:159 msg="start first pass of downsampling"
level=info ts=2018-09-10T09:59:06.921503502Z caller=compact.go:165 msg="start second pass of downsampling"
level=info ts=2018-09-10T09:59:11.857090144Z caller=retention.go:47 msg="start retention of resolution 0"
level=info ts=2018-09-10T09:59:16.419145826Z caller=retention.go:61 msg="deleting block" id=01CQ153GMRFTRX1P926QCXTGN7 maxTime="2018-09-06 00:00:00 +0000 UTC"
level=info ts=2018-09-10T09:59:17.188109388Z caller=retention.go:61 msg="deleting block" id=01CQ15FBYAW7VNWRE478HR9MA4 maxTime="2018-09-06 00:00:00 +0000 UTC"
level=info ts=2018-09-10T09:59:17.800448774Z caller=retention.go:61 msg="deleting block" id=01CQ15RE6ES131EBPHDPP1KD6W maxTime="2018-09-06 00:00:00 +0000 UTC"
level=info ts=2018-09-10T09:59:18.855796216Z caller=retention.go:73 msg="retention of resolution 0 apply done"
level=info ts=2018-09-10T09:59:18.856045515Z caller=retention.go:47 msg="start retention of resolution 300000"
level=info ts=2018-09-10T09:59:20.145363651Z caller=retention.go:61 msg="deleting block" id=01CPC5XX1RXDE10AMJG3MJF4F6 maxTime="2018-09-02 00:00:00 +0000 UTC"
level=info ts=2018-09-10T09:59:20.592034377Z caller=retention.go:61 msg="deleting block" id=01CPC62WDQQ9M2KY50HCKV2EWW maxTime="2018-09-02 00:00:00 +0000 UTC"
level=info ts=2018-09-10T09:59:20.921481825Z caller=retention.go:61 msg="deleting block" id=01CPC668QDZH503TRWETSQ8M5N maxTime="2018-09-02 00:00:00 +0000 UTC"
level=info ts=2018-09-10T09:59:24.681922283Z caller=retention.go:73 msg="retention of resolution 300000 apply done"
level=info ts=2018-09-10T09:59:24.68205212Z caller=compact.go:185 msg="compaction, downsampling and optional retention apply iteration done"
```