### PR TITLE
Fixed catch the error when failed to list objects for s3

### DIFF
--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -196,6 +196,10 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error) err
 	}
 
 	for object := range b.client.ListObjects(b.bucket, dir, false, ctx.Done()) {
+		// catch the error when failed to list objects
+		if object.Err != nil {
+			return object.Err
+		}
 		// this sometimes happens with empty buckets
 		if object.Key == "" {
 			continue


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
Fixed #261 

## Verification

<!-- How you tested it? How do you know it works? -->
Just use a bucket that does not exist to execute `thanos bucket ls`.