### PR TITLE
query, rule: add path prefix support

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/improbable-eng/thanos/pkg/extprom"
@@ -55,6 +56,10 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	key := cmd.Flag("grpc-client-tls-key", "TLS Key for the client's certificate").Default("").String()
 	caCert := cmd.Flag("grpc-client-tls-ca", "TLS CA Certificates to use to verify gRPC servers").Default("").String()
 	serverName := cmd.Flag("grpc-client-server-name", "Server name to verify the hostname on the returned gRPC certificates. See https://tools.ietf.org/html/rfc4366#section-3.1").Default("").String()
+
+	webRoutePrefix := cmd.Flag("web.route-prefix", "Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path. This option is analogous to --web.route-prefix of Promethus.").Default("").String()
+	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
+	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
 
 	queryTimeout := modelDuration(cmd.Flag("query.timeout", "Maximum time to process query by query node.").
 		Default("2m"))
@@ -129,6 +134,9 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 			*caCert,
 			*serverName,
 			*httpBindAddr,
+			*webRoutePrefix,
+			*webExternalPrefix,
+			*webPrefixHeaderName,
 			*maxConcurrentQueries,
 			time.Duration(*queryTimeout),
 			*replicaLabel,
@@ -241,6 +249,9 @@ func runQuery(
 	caCert string,
 	serverName string,
 	httpBindAddr string,
+	webRoutePrefix string,
+	webExternalPrefix string,
+	webPrefixHeaderName string,
 	maxConcurrentQueries int,
 	queryTimeout time.Duration,
 	replicaLabel string,
@@ -252,6 +263,7 @@ func runQuery(
 	fileSD *file.Discovery,
 	dnsSDInterval time.Duration,
 ) error {
+	// TODO(bplotka in PR #513 review): Move arguments into struct.
 	duplicatedStores := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "thanos_query_duplicated_store_address",
 		Help: "The number of times a duplicated store addresses is detected from the different configs in query",
@@ -375,10 +387,25 @@ func runQuery(
 	// Start query API + UI HTTP server.
 	{
 		router := route.New()
-		ui.NewQueryUI(logger, stores, nil).Register(router)
+
+		// redirect from / to /webRoutePrefix
+		if webRoutePrefix != "" {
+			router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, webRoutePrefix, http.StatusFound)
+			})
+		}
+
+		flagsMap := map[string]string{
+			// TODO(bplotka in PR #513 review): pass all flags, not only the flags needed by prefix rewriting.
+			"web.external-prefix": webExternalPrefix,
+			"web.prefix-header":   webPrefixHeaderName,
+		}
+
+		ui.NewQueryUI(logger, stores, flagsMap).Register(router.WithPrefix(webRoutePrefix))
 
 		api := v1.NewAPI(logger, reg, engine, queryableCreator, enableAutodownsampling, enablePartialResponse)
-		api.Register(router.WithPrefix("/api/v1"), tracer, logger)
+
+		api.Register(router.WithPrefix(path.Join(webRoutePrefix, "/api/v1")), tracer, logger)
 
 		router.Get("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -83,6 +83,9 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 
 	alertExcludeLabels := cmd.Flag("alert.label-drop", "Labels by name to drop before sending to alertmanager. This allows alert to be deduplicated on replica label (repeated). Similar Prometheus alert relabelling").
 		Strings()
+	webRoutePrefix := cmd.Flag("web.route-prefix", "Prefix for API and UI endpoints. This allows thanos UI to be served on a sub-path. This option is analogous to --web.route-prefix of Promethus.").Default("").String()
+	webExternalPrefix := cmd.Flag("web.external-prefix", "Static prefix for all HTML links and redirect URLs in the UI query web interface. Actual endpoints are still served on / or the web.route-prefix. This allows thanos UI to be served behind a reverse proxy that strips a URL sub-path.").Default("").String()
+	webPrefixHeaderName := cmd.Flag("web.prefix-header", "Name of HTTP request header used for dynamic prefixing of UI links and redirects. This option is ignored if web.external-prefix argument is set. Security risk: enable this option only if a reverse proxy in front of thanos is resetting the header. The --web.prefix-header=X-Forwarded-Prefix option can be useful, for example, if Thanos UI is served via Traefik reverse proxy with PathPrefixStrip option enabled, which sends the stripped prefix value in X-Forwarded-Prefix header. This allows thanos UI to be served on a sub-path.").Default("").String()
 
 	objStoreConfig := regCommonObjStoreFlags(cmd, "")
 
@@ -150,6 +153,9 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			*key,
 			*clientCA,
 			*httpBindAddr,
+			*webRoutePrefix,
+			*webExternalPrefix,
+			*webPrefixHeaderName,
 			time.Duration(*evalInterval),
 			*dataDir,
 			*ruleFiles,
@@ -181,6 +187,9 @@ func runRule(
 	key string,
 	clientCA string,
 	httpBindAddr string,
+	webRoutePrefix string,
+	webExternalPrefix string,
+	webPrefixHeaderName string,
 	evalInterval time.Duration,
 	dataDir string,
 	ruleFiles []string,
@@ -529,11 +538,25 @@ func runRule(
 	// Start UI & metrics HTTP server.
 	{
 		router := route.New()
-		router.Post("/-/reload", func(w http.ResponseWriter, r *http.Request) {
+
+		// redirect from / to /webRoutePrefix
+		if webRoutePrefix != "" {
+			router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, webRoutePrefix, http.StatusFound)
+			})
+		}
+
+		router.WithPrefix(webRoutePrefix).Post("/-/reload", func(w http.ResponseWriter, r *http.Request) {
 			reload <- struct{}{}
 		})
 
-		ui.NewRuleUI(logger, mgr, alertQueryURL.String()).Register(router)
+		flagsMap := map[string]string{
+			// TODO(bplotka in PR #513 review): pass all flags, not only the flags needed by prefix rewriting.
+			"web.external-prefix": webExternalPrefix,
+			"web.prefix-header":   webPrefixHeaderName,
+		}
+
+		ui.NewRuleUI(logger, mgr, alertQueryURL.String(), flagsMap).Register(router.WithPrefix(webRoutePrefix))
 
 		mux := http.NewServeMux()
 		registerMetrics(mux, reg)

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -142,6 +142,29 @@ Flags:
                                  alertmanager. This allows alert to be
                                  deduplicated on replica label (repeated).
                                  Similar Prometheus alert relabelling
+      --web.route-prefix=""      Prefix for API and UI endpoints. This allows
+                                 thanos UI to be served on a sub-path. This
+                                 option is analogous to --web.route-prefix of
+                                 Promethus.
+      --web.external-prefix=""   Static prefix for all HTML links and redirect
+                                 URLs in the UI query web interface. Actual
+                                 endpoints are still served on / or the
+                                 web.route-prefix. This allows thanos UI to be
+                                 served behind a reverse proxy that strips a URL
+                                 sub-path.
+      --web.prefix-header=""     Name of HTTP request header used for dynamic
+                                 prefixing of UI links and redirects. This
+                                 option is ignored if web.external-prefix
+                                 argument is set. Security risk: enable this
+                                 option only if a reverse proxy in front of
+                                 thanos is resetting the header. The
+                                 --web.prefix-header=X-Forwarded-Prefix option
+                                 can be useful, for example, if Thanos UI is
+                                 served via Traefik reverse proxy with
+                                 PathPrefixStrip option enabled, which sends the
+                                 stripped prefix value in X-Forwarded-Prefix
+                                 header. This allows thanos UI to be served on a
+                                 sub-path.
       --objstore.config-file=<bucket.config-yaml-path>  
                                  Path to YAML file that contains object store
                                  configuration.

--- a/pkg/ui/ui_test.go
+++ b/pkg/ui/ui_test.go
@@ -1,0 +1,68 @@
+package ui
+
+import "testing"
+
+func TestSanitizePrefix(t *testing.T) {
+	type args struct {
+		prefix string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			"InvalidEscaping",
+			args{
+				prefix: "/%%",
+			},
+			"",
+			true,
+		},
+		{
+			"URL",
+			args{
+				prefix: "http://www.example.com/some%20path/two?foo=bar?foo1=bar1#id",
+			},
+			"/some path/two",
+			false,
+		},
+		{
+			"DelimiterNotAllowed",
+			args{
+				prefix: "http://www.example.com/host%3A%2F%2Fpath/",
+			},
+			"/host:/path",
+			false,
+		},
+		{
+			"EmptyPrefix",
+			args{
+				prefix: "",
+			},
+			"",
+			false,
+		},
+		{
+			"Root",
+			args{
+				prefix: "/",
+			},
+			"",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SanitizePrefix(tt.args.prefix)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SanitizePrefix() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SanitizePrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The UI links are prefixed with a value of "X-Forwarded-Prefix" header.
This fixes https://github.com/improbable-eng/thanos/issues/364 in a more dynamic way in comparison to static options used by `prometheus`.

For example, this header [is used in Spring](https://github.com/spring-projects/spring-framework/blob/a9a38fe67e5750d8cd71e68273462bd1e8f2a60a/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java#L44) Java framework.

Support of "X-Forwarded-Prefix" allows to expose `thanos query` on a sub-path behind `Traefik` kubernetes ingress controller or any other reverse proxy by simply stripping of the sub-path, without a need to parse and rewrite response header and body.

## Changes

The http.Header.Get() returns empty string if a header is not set. Therefore, such value can be safely used as a prefix for various UI addresses, such as HTTP302 redirects and HTML templates.

## Verification

I've deployed this PR branch behind the `Traefik` kubernetes ingress controller and used the `Ingress` object given below. Then, i've requested the https://ingress.host.name/thanos-query/ and received proper 302 redirect to /thanos-query/graph. Then, browser was able to download all static resources on all UI pages, proving that HTML was also generated with a right prefix value.

```yaml
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    traefik.frontend.rule.type: PathPrefixStrip
  labels:
    app: thanos-query
  name: thanos-query
spec:
  rules:
  - http:
      paths:
      - backend:
          serviceName: thanos-query
          servicePort: 9090
        path: /thanos-query
```