### PR TITLE
[file-sd-part-1] Added file sd to query

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -428,6 +428,8 @@
   digest = "1:b5ff9852eabe841003da4b0a4b742a2878c722dda6481003432344f633a814fc"
   name = "github.com/prometheus/prometheus"
   packages = [
+    "discovery/file",
+    "discovery/targetgroup",
     "pkg/labels",
     "pkg/rulefmt",
     "pkg/textparse",
@@ -694,6 +696,14 @@
   version = "v2.2.6"
 
 [[projects]]
+  digest = "1:b2106f1668ea5efc1ecc480f7e922a093adb9563fd9ce58585292871f0d0f229"
+  name = "gopkg.in/fsnotify/fsnotify.v1"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   branch = "v2"
   digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
@@ -739,6 +749,8 @@
     "github.com/prometheus/common/model",
     "github.com/prometheus/common/route",
     "github.com/prometheus/common/version",
+    "github.com/prometheus/prometheus/discovery/file",
+    "github.com/prometheus/prometheus/discovery/targetgroup",
     "github.com/prometheus/prometheus/pkg/labels",
     "github.com/prometheus/prometheus/pkg/timestamp",
     "github.com/prometheus/prometheus/pkg/value",

--- a/benchmark/cmd/thanosbench/resources.go
+++ b/benchmark/cmd/thanosbench/resources.go
@@ -12,6 +12,7 @@ import (
 	prom "github.com/prometheus/prometheus/config"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -207,7 +208,7 @@ func createPrometheus(opts *opts, name string, bucket string) *appsv1.StatefulSe
 		Name:      name,
 		Namespace: promNamespace,
 		Labels: map[string]string{
-			"app": name,
+			"app":                  name,
 			"thanos-gossip-member": "true",
 		},
 	}
@@ -370,7 +371,7 @@ func createThanosQuery(opts *opts) (*v1.Service, *v1.Pod) {
 		Name:      "thanos-query",
 		Namespace: thanosNamespace,
 		Labels: map[string]string{
-			"app": "thanos-query",
+			"app":                  "thanos-query",
 			"thanos-gossip-member": "true",
 		},
 	}

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -24,6 +24,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/alert"
 	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/cluster"
+	"github.com/improbable-eng/thanos/pkg/discovery/cache"
 	"github.com/improbable-eng/thanos/pkg/objstore/client"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/shipper"
@@ -37,6 +38,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
+	"github.com/prometheus/prometheus/discovery/file"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 	promlabels "github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/rules"
@@ -75,6 +78,15 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 
 	objStoreConfig := regCommonObjStoreFlags(cmd, "")
 
+	queries := cmd.Flag("query", "Addresses of statically configured query API servers (repeatable).").
+		PlaceHolder("<query>").Strings()
+
+	fileSDFiles := cmd.Flag("query.file-sd-config.files", "Path to file that contain addresses of query peers. The path can be a glob pattern (repeatable).").
+		PlaceHolder("<path>").Strings()
+
+	fileSDInterval := modelDuration(cmd.Flag("query.file-sd-config.interval", "Refresh interval to re-read file SD files. (used as a fallback)").
+		Default("5m"))
+
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
 		lset, err := parseFlagLabels(*labelStrs)
 		if err != nil {
@@ -96,6 +108,25 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			NoLockfile:       true,
 			WALFlushInterval: 30 * time.Second,
 		}
+
+		lookupQueries := map[string]struct{}{}
+		for _, q := range *queries {
+			if _, ok := lookupQueries[q]; ok {
+				return errors.Errorf("Address %s is duplicated for --query flag.", q)
+			}
+
+			lookupQueries[q] = struct{}{}
+		}
+
+		var fileSD *file.Discovery
+		if len(*fileSDFiles) > 0 {
+			conf := &file.SDConfig{
+				Files:           *fileSDFiles,
+				RefreshInterval: *fileSDInterval,
+			}
+			fileSD = file.NewDiscovery(conf, logger)
+		}
+
 		return runRule(g,
 			logger,
 			reg,
@@ -115,6 +146,8 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			tsdbOpts,
 			name,
 			alertQueryURL,
+			*queries,
+			fileSD,
 		)
 	}
 }
@@ -141,6 +174,8 @@ func runRule(
 	tsdbOpts *tsdb.Options,
 	component string,
 	alertQueryURL *url.URL,
+	queryAddrs []string,
+	fileSD *file.Discovery,
 ) error {
 	configSuccess := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_config_last_reload_successful",
@@ -150,9 +185,19 @@ func runRule(
 		Name: "thanos_config_last_reload_success_timestamp_seconds",
 		Help: "Timestamp of the last successful configuration reload.",
 	})
-
+	duplicatedQuery := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "thanos_rule_duplicated_query_address",
+		Help: "The number of times a duplicated query addresses is detected from the different configs in rule",
+	})
 	reg.MustRegister(configSuccess)
 	reg.MustRegister(configSuccessTime)
+	reg.MustRegister(duplicatedQuery)
+
+	for _, addr := range queryAddrs {
+		if addr == "" {
+			return errors.New("static querier address cannot be empty")
+		}
+	}
 
 	db, err := tsdb.Open(dataDir, log.With(logger, "component", "tsdb"), reg, tsdbOpts)
 	if err != nil {
@@ -168,9 +213,17 @@ func runRule(
 		})
 	}
 
+	// FileSD query addresses
+	fileSDCache := cache.New()
+
 	// Hit the HTTP query API of query peers in randomized order until we get a result
 	// back or the context get canceled.
 	queryFn := func(ctx context.Context, q string, t time.Time) (promql.Vector, error) {
+		var addrs []string
+		// Add addresses from static flag
+		addrs = append(addrs, queryAddrs...)
+
+		// Add addresses from gossip
 		peers := peer.PeerStates(cluster.PeerTypeQuery)
 		var ids []string
 		for id := range peers {
@@ -179,9 +232,19 @@ func runRule(
 		sort.Slice(ids, func(i int, j int) bool {
 			return strings.Compare(ids[i], ids[j]) < 0
 		})
+		for _, id := range ids {
+			addrs = append(addrs, peers[id].QueryAPIAddr)
+		}
 
-		for _, i := range rand.Perm(len(ids)) {
-			vec, err := queryPrometheusInstant(ctx, logger, peers[ids[i]].QueryAPIAddr, q, t)
+		// Add addresses from file sd
+		for _, addr := range fileSDCache.Addresses() {
+			addrs = append(addrs, addr)
+		}
+
+		removeDuplicateQueryAddrs(logger, duplicatedQuery, addrs)
+
+		for _, i := range rand.Perm(len(addrs)) {
+			vec, err := queryPrometheusInstant(ctx, logger, addrs[i], q, t)
 			if err != nil {
 				return nil, err
 			}
@@ -299,6 +362,39 @@ func runRule(
 			})
 		}, func(error) {
 			cancel()
+		})
+	}
+	// Run File Service Discovery and update the query addresses when the files are modified
+	if fileSD != nil {
+		var fileSDUpdates chan []*targetgroup.Group
+		ctxRun, cancelRun := context.WithCancel(context.Background())
+
+		fileSDUpdates = make(chan []*targetgroup.Group)
+
+		g.Add(func() error {
+			fileSD.Run(ctxRun, fileSDUpdates)
+			return nil
+		}, func(error) {
+			cancelRun()
+		})
+
+		ctxUpdate, cancelUpdate := context.WithCancel(context.Background())
+		g.Add(func() error {
+			for {
+				select {
+				case update := <-fileSDUpdates:
+					// Discoverers sometimes send nil updates so need to check for it to avoid panics
+					if update == nil {
+						continue
+					}
+					fileSDCache.Update(update)
+				case <-ctxUpdate.Done():
+					return nil
+				}
+			}
+		}, func(error) {
+			cancelUpdate()
+			close(fileSDUpdates)
 		})
 	}
 
@@ -648,4 +744,21 @@ func labelsTSDBToProm(lset labels.Labels) (res promlabels.Labels) {
 		})
 	}
 	return res
+}
+
+func removeDuplicateQueryAddrs(logger log.Logger, duplicatedQueriers prometheus.Counter, addrs []string) []string {
+	set := make(map[string]struct{})
+	for _, addr := range addrs {
+		if _, ok := set[addr]; ok {
+			level.Warn(logger).Log("msg", "Duplicate query address is provided - %v", addr)
+			duplicatedQueriers.Inc()
+		}
+		set[addr] = struct{}{}
+	}
+
+	deduplicated := make([]string, 0, len(set))
+	for key := range set {
+		deduplicated = append(deduplicated, key)
+	}
+	return deduplicated
 }

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -129,6 +129,13 @@ Flags:
                                  info endpoint (repeated).
       --store=<store> ...        Addresses of statically configured store API
                                  servers (repeatable).
+      --store.file-sd-config.files=<path> ...  
+                                 Path to files that contain addresses of store
+                                 API servers. The path can be a glob pattern
+                                 (repeatable).
+      --store.file-sd-config.interval=5m  
+                                 Refresh interval to re-read file SD files.
+                                 (used as a fallback)
       --query.auto-downsampling  Enable automatic adjustment (step / 5) to what
                                  source of data should be used in store gateways
                                  if no max_source_resolution param is specified.

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -133,5 +133,14 @@ Flags:
       --objstore.config=<bucket.config-yaml>  
                                  Alternative to 'objstore.config-file' flag.
                                  Object store configuration in YAML.
+      --query=<query> ...        Addresses of statically configured query API
+                                 servers (repeatable).
+      --query.file-sd-config.files=<path> ...  
+                                 Path to file that contain addresses of query
+                                 peers. The path can be a glob pattern
+                                 (repeatable).
+      --query.file-sd-config.interval=5m  
+                                 Refresh interval to re-read file SD files.
+                                 (used as a fallback)
 
 ```

--- a/pkg/discovery/cache/cache.go
+++ b/pkg/discovery/cache/cache.go
@@ -1,0 +1,50 @@
+package cache
+
+import (
+	"sync"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+// Cache is a store for target groups. It provides thread safe updates and a way for obtaining all addresses from
+// the stored target groups.
+type Cache struct {
+	tgs map[string]*targetgroup.Group
+	sync.Mutex
+}
+
+// New returns a new empty Cache.
+func New() *Cache {
+	return &Cache{
+		tgs: make(map[string]*targetgroup.Group),
+	}
+}
+
+// Update stores the targets for the given groups.
+// Note: targets for a group are replaced entirely on update. If a group with no target is given this is equivalent to
+// deleting all the targets for this group.
+func (c *Cache) Update(tgs []*targetgroup.Group) {
+	c.Lock()
+	defer c.Unlock()
+	for _, tg := range tgs {
+		// Some Discoverers send nil target group so need to check for it to avoid panics.
+		if tg == nil {
+			continue
+		}
+		c.tgs[tg.Source] = tg
+	}
+}
+
+// Addresses returns all the addresses from all target groups present in the Cache.
+func (c *Cache) Addresses() []string {
+	c.Lock()
+	defer c.Unlock()
+	var addresses []string
+	for _, group := range c.tgs {
+		for _, target := range group.Targets {
+			addresses = append(addresses, string(target[model.AddressLabel]))
+		}
+	}
+	return addresses
+}

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -141,7 +141,7 @@ func NewAPI(
 		instantQueryDuration:   instantQueryDuration,
 		rangeQueryDuration:     rangeQueryDuration,
 		enableAutodownsampling: enableAutodownsampling,
-		now: time.Now,
+		now:                    time.Now,
 	}
 }
 

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -238,7 +238,6 @@ func TestQueryStore_Series_FillResponseChannel(t *testing.T) {
 	testutil.Equals(t, 0, len(s1.Warnings))
 }
 
-
 type rawSeries struct {
 	lset    []storepb.Label
 	samples []sample

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -15,56 +15,63 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// TestQuerySimple runs a setup of Prometheus servers, sidecars, and query nodes and verifies that
+type testConfig struct {
+	name  string
+	suite *spinupSuite
+}
+
+var (
+	firstPromPort = promHTTPPort(1)
+
+	queryGossipSuite = newSpinupSuite().
+				Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), true)).
+				Add(scraper(2, defaultPromConfig("prom-ha", 0), true)).
+				Add(scraper(3, defaultPromConfig("prom-ha", 1), true)).
+				Add(querier(1, "replica"), queryCluster(1)).
+				Add(querier(2, "replica"), queryCluster(2))
+
+	queryStaticFlagsSuite = newSpinupSuite().
+				Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), false)).
+				Add(scraper(2, defaultPromConfig("prom-ha", 0), false)).
+				Add(scraper(3, defaultPromConfig("prom-ha", 1), false)).
+				Add(querierWithStoreFlags(1, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)), "").
+				Add(querierWithStoreFlags(2, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)), "")
+
+	queryFileSDSuite = newSpinupSuite().
+				Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), false)).
+				Add(scraper(2, defaultPromConfig("prom-ha", 0), false)).
+				Add(scraper(3, defaultPromConfig("prom-ha", 1), false)).
+				Add(querierWithFileSD(1, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)), "").
+				Add(querierWithFileSD(2, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)), "")
+)
+
+func TestQuery(t *testing.T) {
+	for _, tt := range []testConfig{
+		{
+			"gossip",
+			queryGossipSuite,
+		},
+		{
+			"staticFlag",
+			queryStaticFlagsSuite,
+		},
+		{
+			"fileSD",
+			queryFileSDSuite,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testQuerySimple(t, tt)
+		})
+	}
+}
+
+// testQuerySimple runs a setup of Prometheus servers, sidecars, and query nodes and verifies that
 // queries return data merged from all Prometheus servers. Additionally it verifies if deduplication works for query.
-func TestQuerySimple(t *testing.T) {
+func testQuerySimple(t *testing.T, conf testConfig) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 
-	firstPromPort := promHTTPPort(1)
-
-	exit, err := newSpinupSuite().
-		Add(scraper(1, fmt.Sprintf(`
-# Self scraping config with unique external label.
-global:
-  external_labels:
-    prometheus: prom-%s
-    replica: 0
-scrape_configs:
-- job_name: prometheus
-  scrape_interval: 1s
-  static_configs:
-  - targets:
-    - "localhost:%s"
-`, firstPromPort, firstPromPort))).
-		Add(scraper(2, fmt.Sprintf(`
-# Config for first of two HA replica Prometheus.
-global:
-  external_labels:
-    prometheus: prom-ha
-    replica: 0
-scrape_configs:
-- job_name: prometheus
-  scrape_interval: 1s
-  static_configs:
-  - targets:
-    - "localhost:%s"
-`, firstPromPort))).
-		Add(scraper(3, fmt.Sprintf(`
-# Config for second of two HA replica Prometheus.
-global:
-  external_labels:
-    prometheus: prom-ha
-    replica: 1
-scrape_configs:
-- job_name: prometheus
-  scrape_interval: 1s
-  static_configs:
-  - targets:
-    - "localhost:%s"
-`, firstPromPort))).
-		Add(querier(1, "replica"), queryCluster(1)).
-		Add(querier(2, "replica"), queryCluster(2)).
-		Exec(t, ctx, "test_query_simple")
+	exit, err := conf.suite.Exec(t, ctx, conf.name)
 	if err != nil {
 		t.Errorf("spinup failed: %v", err)
 		cancel()
@@ -189,4 +196,19 @@ func queryPrometheus(ctx context.Context, ustr string, ts time.Time, q string, d
 		return nil, err
 	}
 	return m.Data.Result, nil
+}
+
+func defaultPromConfig(name string, replicas int) string {
+	return fmt.Sprintf(`
+global:
+  external_labels:
+    prometheus: %s
+    replica: %v
+scrape_configs:
+- job_name: prometheus
+  scrape_interval: 1s
+  static_configs:
+  - targets:
+    - "localhost:%s"
+`, name, replicas, firstPromPort)
 }

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -15,14 +15,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/timestamp"
 )
 
-// TestRuleComponent tests the basic interaction between the rule component
-// and the querying layer.
-// Rules are evaluated against the query layer and the query layer in return
-// can access data written by the rules.
-func TestRuleComponent(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-
-	const alwaysFireRule = `
+const alwaysFireRule = `
 groups:
 - name: example
   rules:
@@ -33,6 +26,54 @@ groups:
     annotations:
       summary: "I always complain"
 `
+
+var (
+	ruleGossipSuite = newSpinupSuite().
+			Add(querier(1, ""), queryCluster(1)).
+			Add(ruler(1, alwaysFireRule)).
+			Add(ruler(2, alwaysFireRule)).
+			Add(alertManager(1), "")
+
+	ruleStaticFlagsSuite = newSpinupSuite().
+				Add(querierWithStoreFlags(1, "", rulerGRPC(1), rulerGRPC(2)), "").
+				Add(rulerWithQueryFlags(1, alwaysFireRule, queryHTTP(1))).
+				Add(rulerWithQueryFlags(2, alwaysFireRule, queryHTTP(1))).
+				Add(alertManager(1), "")
+
+	ruleFileSDSuite = newSpinupSuite().
+			Add(querierWithFileSD(1, "", rulerGRPC(1), rulerGRPC(2)), "").
+			Add(rulerWithFileSD(1, alwaysFireRule, queryHTTP(1))).
+			Add(rulerWithFileSD(2, alwaysFireRule, queryHTTP(1))).
+			Add(alertManager(1), "")
+)
+
+func TestRule(t *testing.T) {
+	for _, tt := range []testConfig{
+		{
+			"gossip",
+			ruleGossipSuite,
+		},
+		{
+			"staticFlag",
+			ruleStaticFlagsSuite,
+		},
+		{
+			"fileSD",
+			ruleFileSDSuite,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testRuleComponent(t, tt)
+		})
+	}
+}
+
+// testRuleComponent tests the basic interaction between the rule component
+// and the querying layer.
+// Rules are evaluated against the query layer and the query layer in return
+// can access data written by the rules.
+func testRuleComponent(t *testing.T, conf testConfig) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 
 	exit, err := newSpinupSuite().
 		Add(querier(1, ""), queryCluster(1)).


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
ref: https://github.com/improbable-eng/thanos/issues/492

## Changes

Added file sd to query. You can specify files to watch via a command line flag. Then the querier will load stores' addresses from the files whenever the files are updated.

We are reusing Prometheus' file sd.

<!-- Enumerate changes you made -->

## Verification
Tested in a following PR that adds the different SD options to the tests - (https://github.com/improbable-eng/thanos/pull/554)
<!-- How you tested it? How do you know it works? -->