### PR TITLE
Add thanos prefix to go-metrics and disable duplicate runtime metrics (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
     * S3_SIGNATURE_VERSION2
     * S3_SECRET_KEY
 - Add flag `--objstore.config-file` to reference to the bucket configuration file in yaml format. Note that detailed information in document [storage](docs/storage.md).
+- Add `thanos_` to member list metrics. Some metrics have been renamed, make sure to update your dashboards and rules.
 
 ## [v0.1.0](https://github.com/improbable-eng/thanos/releases/tag/v0.1.0) - 2018.09.14
 

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -118,8 +118,9 @@ func main() {
 		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "%s command failed", cmd))
 		os.Exit(1)
 	}
-	_, err = gmetrics.NewGlobal(gmetrics.DefaultConfig(cmd), sink)
-	if err != nil {
+	gmetricsConfig := gmetrics.DefaultConfig("thanos_" + cmd)
+	gmetricsConfig.EnableRuntimeMetrics = false
+	if _, err = gmetrics.NewGlobal(gmetricsConfig, sink); err != nil {
 		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "%s command failed", cmd))
 		os.Exit(1)
 	}


### PR DESCRIPTION
Greetings !

It took some time to found the culprit but I found it before the weekend !

Fix #463

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

* Add `thanos_` prefix to go-metrics metrics :smirk: 
* Disable runtime metrics collection of go-metrics since it's already taken care of by the official Prometheus client

## Verification

```diff
1,7c1,8
< # HELP thanos_query_memberlist_gossip thanos_query_memberlist_gossip
< # TYPE thanos_query_memberlist_gossip summary
< thanos_query_memberlist_gossip{quantile="0.5"} 0.022954000160098076
< thanos_query_memberlist_gossip{quantile="0.9"} 0.02971700020134449
< thanos_query_memberlist_gossip{quantile="0.99"} 0.042089998722076416
< thanos_query_memberlist_gossip_sum 0.6567779900506139
< thanos_query_memberlist_gossip_count 30
\ No newline at end of file
---
> # HELP query_memberlist_gossip query_memberlist_gossip
> # TYPE query_memberlist_gossip summary
> query_memberlist_gossip{quantile="0.5"} 0.015239999629557133
> query_memberlist_gossip{quantile="0.9"} 0.02016099914908409
> query_memberlist_gossip{quantile="0.99"} 0.02717600017786026
> query_memberlist_gossip_sum 11281.907937059179
> query_memberlist_gossip_count 769728
> 
``` 