### PR TITLE
[file-sd-part-4] Added flag for query addresses to ruler

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -78,6 +78,9 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 
 	objStoreConfig := regCommonObjStoreFlags(cmd, "")
 
+	queries := cmd.Flag("query", "Addresses of statically configured query API servers (repeatable).").
+		PlaceHolder("<query>").Strings()
+
 	fileSDFiles := cmd.Flag("query.file-sd-config.files", "Path to file that contain addresses of query peers. The path can be a glob pattern (repeatable).").
 		PlaceHolder("<path>").Strings()
 
@@ -104,6 +107,15 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			Retention:        *tsdbRetention,
 			NoLockfile:       true,
 			WALFlushInterval: 30 * time.Second,
+		}
+
+		lookupQueries := map[string]struct{}{}
+		for _, q := range *queries {
+			if _, ok := lookupQueries[q]; ok {
+				return errors.Errorf("Address %s is duplicated for --query flag.", q)
+			}
+
+			lookupQueries[q] = struct{}{}
 		}
 
 		var fileSD *file.Discovery
@@ -134,6 +146,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			tsdbOpts,
 			name,
 			alertQueryURL,
+			*queries,
 			fileSD,
 		)
 	}
@@ -161,6 +174,7 @@ func runRule(
 	tsdbOpts *tsdb.Options,
 	component string,
 	alertQueryURL *url.URL,
+	queryAddrs []string,
 	fileSD *file.Discovery,
 ) error {
 	configSuccess := prometheus.NewGauge(prometheus.GaugeOpts{
@@ -178,6 +192,12 @@ func runRule(
 	reg.MustRegister(configSuccess)
 	reg.MustRegister(configSuccessTime)
 	reg.MustRegister(duplicatedQuery)
+
+	for _, addr := range queryAddrs {
+		if addr == "" {
+			return errors.New("static querier address cannot be empty")
+		}
+	}
 
 	db, err := tsdb.Open(dataDir, log.With(logger, "component", "tsdb"), reg, tsdbOpts)
 	if err != nil {
@@ -200,6 +220,8 @@ func runRule(
 	// back or the context get canceled.
 	queryFn := func(ctx context.Context, q string, t time.Time) (promql.Vector, error) {
 		var addrs []string
+		// Add addresses from static flag
+		addrs = append(addrs, queryAddrs...)
 
 		// Add addresses from gossip
 		peers := peer.PeerStates(cluster.PeerTypeQuery)

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -133,6 +133,8 @@ Flags:
       --objstore.config=<bucket.config-yaml>  
                                  Alternative to 'objstore.config-file' flag.
                                  Object store configuration in YAML.
+      --query=<query> ...        Addresses of statically configured query API
+                                 servers (repeatable).
       --query.file-sd-config.files=<path> ...  
                                  Path to file that contain addresses of query
                                  peers. The path can be a glob pattern

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -23,41 +23,41 @@ type testConfig struct {
 var (
 	firstPromPort = promHTTPPort(1)
 
-	gossipSuite = newSpinupSuite().
-			Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), true)).
-			Add(scraper(2, defaultPromConfig("prom-ha", 0), true)).
-			Add(scraper(3, defaultPromConfig("prom-ha", 1), true)).
-			Add(querier(1, "replica")).
-			Add(querier(2, "replica"))
+	queryGossipSuite = newSpinupSuite().
+				Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), true)).
+				Add(scraper(2, defaultPromConfig("prom-ha", 0), true)).
+				Add(scraper(3, defaultPromConfig("prom-ha", 1), true)).
+				Add(querier(1, "replica")).
+				Add(querier(2, "replica"))
 
-	staticFlagsSuite = newSpinupSuite().
+	queryStaticFlagsSuite = newSpinupSuite().
 				Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), false)).
 				Add(scraper(2, defaultPromConfig("prom-ha", 0), false)).
 				Add(scraper(3, defaultPromConfig("prom-ha", 1), false)).
-				Add(querierWithStoreFlags(1, "replica", []string{sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)})).
-				Add(querierWithStoreFlags(2, "replica", []string{sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)}))
+				Add(querierWithStoreFlags(1, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3))).
+				Add(querierWithStoreFlags(2, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)))
 
-	fileSDSuite = newSpinupSuite().
-			Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), false)).
-			Add(scraper(2, defaultPromConfig("prom-ha", 0), false)).
-			Add(scraper(3, defaultPromConfig("prom-ha", 1), false)).
-			Add(querierWithFileSD(1, "replica", []string{sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)})).
-			Add(querierWithFileSD(2, "replica", []string{sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)}))
+	queryFileSDSuite = newSpinupSuite().
+				Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), false)).
+				Add(scraper(2, defaultPromConfig("prom-ha", 0), false)).
+				Add(scraper(3, defaultPromConfig("prom-ha", 1), false)).
+				Add(querierWithFileSD(1, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3))).
+				Add(querierWithFileSD(2, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)))
 )
 
 func TestQuery(t *testing.T) {
 	for _, tt := range []testConfig{
 		{
 			"gossip",
-			gossipSuite,
+			queryGossipSuite,
 		},
 		{
 			"staticFlag",
-			staticFlagsSuite,
+			queryStaticFlagsSuite,
 		},
 		{
 			"fileSD",
-			fileSDSuite,
+			queryFileSDSuite,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -15,14 +15,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/timestamp"
 )
 
-// TestRuleComponent tests the basic interaction between the rule component
-// and the querying layer.
-// Rules are evaluated against the query layer and the query layer in return
-// can access data written by the rules.
-func TestRuleComponent(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-
-	const alwaysFireRule = `
+const alwaysFireRule = `
 groups:
 - name: example
   rules:
@@ -33,6 +26,54 @@ groups:
     annotations:
       summary: "I always complain"
 `
+
+var (
+	ruleGossipSuite = newSpinupSuite().
+			Add(querier(1, "")).
+			Add(ruler(1, alwaysFireRule)).
+			Add(ruler(2, alwaysFireRule)).
+			Add(alertManager(1))
+
+	ruleStaticFlagsSuite = newSpinupSuite().
+				Add(querierWithStoreFlags(1, "", rulerGRPC(1), rulerGRPC(2))).
+				Add(rulerWithQueryFlags(1, alwaysFireRule, queryHTTP(1))).
+				Add(rulerWithQueryFlags(2, alwaysFireRule, queryHTTP(1))).
+				Add(alertManager(1))
+
+	ruleFileSDSuite = newSpinupSuite().
+			Add(querierWithFileSD(1, "", rulerGRPC(1), rulerGRPC(2))).
+			Add(rulerWithFileSD(1, alwaysFireRule, queryHTTP(1))).
+			Add(rulerWithFileSD(2, alwaysFireRule, queryHTTP(1))).
+			Add(alertManager(1))
+)
+
+func TestRule(t *testing.T) {
+	for _, tt := range []testConfig{
+		{
+			"gossip",
+			ruleGossipSuite,
+		},
+		{
+			"staticFlag",
+			ruleStaticFlagsSuite,
+		},
+		{
+			"fileSD",
+			ruleFileSDSuite,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testRuleComponent(t, tt)
+		})
+	}
+}
+
+// testRuleComponent tests the basic interaction between the rule component
+// and the querying layer.
+// Rules are evaluated against the query layer and the query layer in return
+// can access data written by the rules.
+func testRuleComponent(t *testing.T, conf testConfig) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 
 	exit, err := newSpinupSuite().
 		Add(querier(1, "")).


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
Adds the option to statically configure the queriers that ruler talks to via a command line flag.

Not exactly fileSD related, but it can be useful as a static alternative to gossip.

<!-- Enumerate changes you made -->

## Verification
Validated in a following PR - (https://github.com/improbable-eng/thanos/pull/556)

<!-- How you tested it? How do you know it works? -->