### PR TITLE
[file-sd-part-5] Rule e2e test uses different service discovery options

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -70,7 +70,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 		Default("2h"))
 	tsdbRetention := modelDuration(cmd.Flag("tsdb.retention", "Block retention time on local disk.").
 		Default("48h"))
-
+	//TODO(ivan): add alertmanagers urls to file sd
 	alertmgrs := cmd.Flag("alertmanagers.url", "Alertmanager URLs to push firing alerts to. The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect Alertmanager IPs through respective DNS lookups. The port defaults to 9093 or the SRV record's value. The URL path is used as a prefix for the regular Alertmanager API path.").
 		Strings()
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -70,7 +70,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 		Default("2h"))
 	tsdbRetention := modelDuration(cmd.Flag("tsdb.retention", "Block retention time on local disk.").
 		Default("48h"))
-	//TODO(ivan): add alertmanagers urls to file sd
+
 	alertmgrs := cmd.Flag("alertmanagers.url", "Alertmanager URLs to push firing alerts to. The scheme may be prefixed with 'dns+' or 'dnssrv+' to detect Alertmanager IPs through respective DNS lookups. The port defaults to 9093 or the SRV record's value. The URL path is used as a prefix for the regular Alertmanager API path.").
 		Strings()
 

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -23,41 +23,41 @@ type testConfig struct {
 var (
 	firstPromPort = promHTTPPort(1)
 
-	gossipSuite = newSpinupSuite().
-			Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), true)).
-			Add(scraper(2, defaultPromConfig("prom-ha", 0), true)).
-			Add(scraper(3, defaultPromConfig("prom-ha", 1), true)).
-			Add(querier(1, "replica")).
-			Add(querier(2, "replica"))
+	queryGossipSuite = newSpinupSuite().
+				Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), true)).
+				Add(scraper(2, defaultPromConfig("prom-ha", 0), true)).
+				Add(scraper(3, defaultPromConfig("prom-ha", 1), true)).
+				Add(querier(1, "replica")).
+				Add(querier(2, "replica"))
 
-	staticFlagsSuite = newSpinupSuite().
+	queryStaticFlagsSuite = newSpinupSuite().
 				Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), false)).
 				Add(scraper(2, defaultPromConfig("prom-ha", 0), false)).
 				Add(scraper(3, defaultPromConfig("prom-ha", 1), false)).
-				Add(querierWithStoreFlags(1, "replica", []string{sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)})).
-				Add(querierWithStoreFlags(2, "replica", []string{sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)}))
+				Add(querierWithStoreFlags(1, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3))).
+				Add(querierWithStoreFlags(2, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)))
 
-	fileSDSuite = newSpinupSuite().
-			Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), false)).
-			Add(scraper(2, defaultPromConfig("prom-ha", 0), false)).
-			Add(scraper(3, defaultPromConfig("prom-ha", 1), false)).
-			Add(querierWithFileSD(1, "replica", []string{sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)})).
-			Add(querierWithFileSD(2, "replica", []string{sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)}))
+	queryFileSDSuite = newSpinupSuite().
+				Add(scraper(1, defaultPromConfig("prom-"+firstPromPort, 0), false)).
+				Add(scraper(2, defaultPromConfig("prom-ha", 0), false)).
+				Add(scraper(3, defaultPromConfig("prom-ha", 1), false)).
+				Add(querierWithFileSD(1, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3))).
+				Add(querierWithFileSD(2, "replica", sidecarGRPC(1), sidecarGRPC(2), sidecarGRPC(3)))
 )
 
 func TestQuery(t *testing.T) {
 	for _, tt := range []testConfig{
 		{
 			"gossip",
-			gossipSuite,
+			queryGossipSuite,
 		},
 		{
 			"staticFlag",
-			staticFlagsSuite,
+			queryStaticFlagsSuite,
 		},
 		{
 			"fileSD",
-			fileSDSuite,
+			queryFileSDSuite,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -68,7 +68,7 @@ func TestRule(t *testing.T) {
 	}
 }
 
-// TestRuleComponent tests the basic interaction between the rule component
+// testRuleComponent tests the basic interaction between the rule component
 // and the querying layer.
 // Rules are evaluated against the query layer and the query layer in return
 // can access data written by the rules.

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -15,14 +15,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/timestamp"
 )
 
-// TestRuleComponent tests the basic interaction between the rule component
-// and the querying layer.
-// Rules are evaluated against the query layer and the query layer in return
-// can access data written by the rules.
-func TestRuleComponent(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-
-	const alwaysFireRule = `
+const alwaysFireRule = `
 groups:
 - name: example
   rules:
@@ -33,6 +26,54 @@ groups:
     annotations:
       summary: "I always complain"
 `
+
+var (
+	ruleGossipSuite = newSpinupSuite().
+			Add(querier(1, "")).
+			Add(ruler(1, alwaysFireRule)).
+			Add(ruler(2, alwaysFireRule)).
+			Add(alertManager(1))
+
+	ruleStaticFlagsSuite = newSpinupSuite().
+				Add(querierWithStoreFlags(1, "", rulerGRPC(1), rulerGRPC(2))).
+				Add(rulerWithQueryFlags(1, alwaysFireRule, queryHTTP(1))).
+				Add(rulerWithQueryFlags(2, alwaysFireRule, queryHTTP(1))).
+				Add(alertManager(1))
+
+	ruleFileSDSuite = newSpinupSuite().
+			Add(querierWithFileSD(1, "", rulerGRPC(1), rulerGRPC(2))).
+			Add(rulerWithFileSD(1, alwaysFireRule, queryHTTP(1))).
+			Add(rulerWithFileSD(2, alwaysFireRule, queryHTTP(1))).
+			Add(alertManager(1))
+)
+
+func TestRule(t *testing.T) {
+	for _, tt := range []testConfig{
+		{
+			"gossip",
+			ruleGossipSuite,
+		},
+		{
+			"staticFlag",
+			ruleStaticFlagsSuite,
+		},
+		{
+			"fileSD",
+			ruleFileSDSuite,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testRuleComponent(t, tt)
+		})
+	}
+}
+
+// TestRuleComponent tests the basic interaction between the rule component
+// and the querying layer.
+// Rules are evaluated against the query layer and the query layer in return
+// can access data written by the rules.
+func testRuleComponent(t *testing.T, conf testConfig) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 
 	exit, err := newSpinupSuite().
 		Add(querier(1, "")).

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -211,7 +211,7 @@ func rulerWithFileSD(i int, rules string, queryAddresses ...string) (cmdSchedule
 
 		args := append(defaultRulerFlags(i, dbDir),
 			"--query.file-sd-config.files", path.Join(ruleFileSDDir, "filesd.json"),
-			"--store.file-sd-config.interval", "5s")
+			"--query.file-sd-config.interval", "5s")
 
 		return []*exec.Cmd{exec.Command("thanos", args...)}, nil
 	}, ""

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -210,7 +210,8 @@ func rulerWithFileSD(i int, rules string, queryAddresses ...string) (cmdSchedule
 		}
 
 		args := append(defaultRulerFlags(i, dbDir),
-			"--query.file-sd-config.files", path.Join(ruleFileSDDir, "filesd.json"))
+			"--query.file-sd-config.files", path.Join(ruleFileSDDir, "filesd.json"),
+			"--store.file-sd-config.interval", "5s")
 
 		return []*exec.Cmd{exec.Command("thanos", args...)}, nil
 	}, ""

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -210,7 +210,7 @@ func rulerWithFileSD(i int, rules string, queryAddresses ...string) (cmdSchedule
 		}
 
 		args := append(defaultRulerFlags(i, dbDir),
-			"--query-sd-file", path.Join(ruleFileSDDir, "filesd.json"))
+			"--query.file-sd-config", path.Join(ruleFileSDDir, "filesd.json"))
 
 		return []*exec.Cmd{exec.Command("thanos", args...)}, nil
 	}, ""

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -210,7 +210,7 @@ func rulerWithFileSD(i int, rules string, queryAddresses ...string) (cmdSchedule
 		}
 
 		args := append(defaultRulerFlags(i, dbDir),
-			"--query.file-sd-config", path.Join(ruleFileSDDir, "filesd.json"))
+			"--query.file-sd-config.files", path.Join(ruleFileSDDir, "filesd.json"))
 
 		return []*exec.Cmd{exec.Command("thanos", args...)}, nil
 	}, ""


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
ref: https://github.com/improbable-eng/thanos/issues/492
## Changes
The rule e2e test now runs 3 times with different service discovery options:
* only gossip
* only static flag configuration
* only file sd
<!-- Enumerate changes you made -->

## Verification
The tests pass
<!-- How you tested it? How do you know it works? -->