### PR TITLE
Proxy Store should not lock when all clients error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ## Unreleased
 
+### Deprecated
 - Remove support of those flags for bucket
     - --gcs-bucket=\<bucket\>
     - --s3.bucket=\<bucket\>
@@ -25,7 +26,13 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
     * S3_INSECURE
     * S3_SIGNATURE_VERSION2
     * S3_SECRET_KEY
+
+### Added
 - Add flag `--objstore.config-file` to reference to the bucket configuration file in yaml format. Note that detailed information in document [storage](docs/storage.md).
+
+### Fixed
+- [#566](https://github.com/improbable-eng/thanos/issues/566) - Fixed issue whereby the Proxy Store could end up in a deadlock if there were more than 9 stores being queried and all returned an error.
+
 
 ## [v0.1.0](https://github.com/improbable-eng/thanos/releases/tag/v0.1.0) - 2018.09.14
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -83,13 +83,13 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 		return nil
 	}
 
+	stores, err := s.stores(srv.Context())
 	var (
-		respCh    = make(chan *storepb.SeriesResponse, 10)
 		seriesSet []storepb.SeriesSet
+		respCh = make(chan *storepb.SeriesResponse, len(stores) + 1)
 		g         errgroup.Group
 	)
 
-	stores, err := s.stores(srv.Context())
 	if err != nil {
 		level.Error(s.logger).Log("err", err)
 		return status.Errorf(codes.Unknown, err.Error())

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -47,7 +47,9 @@ func TestQueryStore_Series(t *testing.T) {
 		&testClient{
 			StoreClient: &storeClient{
 				RespSet: []*storepb.SeriesResponse{
-
+					storeSeriesResponse(t, labels.FromStrings("a", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
+					storepb.NewWarnSeriesResponse(errors.New("partial error")),
+					storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{2, 2}, {3, 3}, {4, 4}}),
 				},
 			},
 			minTime: 1,


### PR DESCRIPTION
When we are calling many stores we need to ensure that if they all (more than 10) return an error we do not halt the as we cannot add more the the respCh in doing so we are eating into the number of queries we are allowing Thanos.

## Changes

`respCh` should be one more than the number of stores we have ... this is so  we can push all error responses to the channel and also the final error if the series has no results.

## Verification

Added a test.