### PR TITLE
Fixed clean up old compact chunks when compact starts

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"time"
 
@@ -147,6 +148,14 @@ func runCompact(
 
 	ctx, cancel := context.WithCancel(context.Background())
 	f := func() error {
+		// Clean up the compactor temporary directory before beginning.
+		if err := os.RemoveAll(compactDir); err != nil {
+			return errors.Wrap(err, "clean compactor temporary directory")
+		}
+		if err := os.MkdirAll(compactDir, 0777); err != nil {
+			return errors.Wrap(err, "create compactor temporary directory")
+		}
+
 		if err := compactor.Compact(ctx); err != nil {
 			return errors.Wrap(err, "compaction failed")
 		}

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -134,6 +134,10 @@ func runCompact(
 		downsamplingDir = path.Join(dataDir, "downsample")
 	)
 
+	if err := os.RemoveAll(dataDir); err != nil {
+		return errors.Wrap(err, "clean working temporary directory")
+	}
+
 	compactor := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt)
 
 	if retentionByResolution[compact.ResolutionLevelRaw].Seconds() != 0 {
@@ -148,9 +152,6 @@ func runCompact(
 
 	ctx, cancel := context.WithCancel(context.Background())
 	f := func() error {
-		if err := os.RemoveAll(downsamplingDir); err != nil {
-			return errors.Wrap(err, "clean downsampling temporary directory")
-		}
 		if err := compactor.Compact(ctx); err != nil {
 			return errors.Wrap(err, "compaction failed")
 		}

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -99,12 +99,10 @@ func downsampleBucket(
 	bkt objstore.Bucket,
 	dir string,
 ) error {
-	downsamplingDir := path.Join(dir, "downsample")
-
-	if err := os.RemoveAll(downsamplingDir); err != nil {
+	if err := os.RemoveAll(dir); err != nil {
 		return errors.Wrap(err, "clean working directory")
 	}
-	if err := os.MkdirAll(downsamplingDir, 0777); err != nil {
+	if err := os.MkdirAll(dir, 0777); err != nil {
 		return errors.Wrap(err, "create dir")
 	}
 	var metas []*block.Meta
@@ -174,7 +172,7 @@ func downsampleBucket(
 			if m.MaxTime-m.MinTime < 40*60*60*1000 {
 				continue
 			}
-			if err := processDownsampling(ctx, logger, bkt, m, downsamplingDir, 5*60*1000); err != nil {
+			if err := processDownsampling(ctx, logger, bkt, m, dir, 5*60*1000); err != nil {
 				return err
 			}
 
@@ -195,7 +193,7 @@ func downsampleBucket(
 			if m.MaxTime-m.MinTime < 10*24*60*60*1000 {
 				continue
 			}
-			if err := processDownsampling(ctx, logger, bkt, m, downsamplingDir, 60*60*1000); err != nil {
+			if err := processDownsampling(ctx, logger, bkt, m, dir, 60*60*1000); err != nil {
 				return err
 			}
 		}

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -99,10 +99,12 @@ func downsampleBucket(
 	bkt objstore.Bucket,
 	dir string,
 ) error {
-	if err := os.RemoveAll(dir); err != nil {
+	downsamplingDir := path.Join(dir, "downsample")
+
+	if err := os.RemoveAll(downsamplingDir); err != nil {
 		return errors.Wrap(err, "clean working directory")
 	}
-	if err := os.MkdirAll(dir, 0777); err != nil {
+	if err := os.MkdirAll(downsamplingDir, 0777); err != nil {
 		return errors.Wrap(err, "create dir")
 	}
 	var metas []*block.Meta
@@ -172,7 +174,7 @@ func downsampleBucket(
 			if m.MaxTime-m.MinTime < 40*60*60*1000 {
 				continue
 			}
-			if err := processDownsampling(ctx, logger, bkt, m, dir, 5*60*1000); err != nil {
+			if err := processDownsampling(ctx, logger, bkt, m, downsamplingDir, 5*60*1000); err != nil {
 				return err
 			}
 
@@ -193,7 +195,7 @@ func downsampleBucket(
 			if m.MaxTime-m.MinTime < 10*24*60*60*1000 {
 				continue
 			}
-			if err := processDownsampling(ctx, logger, bkt, m, dir, 60*60*1000); err != nil {
+			if err := processDownsampling(ctx, logger, bkt, m, downsamplingDir, 60*60*1000); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
fixes: #470 

Related discussion: [comment](https://github.com/improbable-eng/thanos/issues/470#issuecomment-426691885)

Clean up the temporary directory before compactor beginning.

## Verification
<!-- How you tested it? How do you know it works? -->