### PR TITLE
Add /-/healthy endpoint to Querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 - `thanos rule` now supports static configuration of query nodes via `--query`
 - `thanos rule` now supports file based discovery of query nodes using `--query.file-sd-config.files`
 - `thanos query` now supports file based discovery of store nodes using `--store.file-sd-config.files`
+- Add `/-/healthy` endpoint to Querier.
 
 ### Fixed
 - [#566](https://github.com/improbable-eng/thanos/issues/566) - Fixed issue whereby the Proxy Store could end up in a deadlock if there were more than 9 stores being queried and all returned an error.

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -366,6 +366,13 @@ func runQuery(
 		api := v1.NewAPI(logger, reg, engine, queryableCreator, enableAutodownsampling)
 		api.Register(router.WithPrefix("/api/v1"), tracer, logger)
 
+		router.Get("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			if _, err := fmt.Fprintf(w, "Thanos Querier is Healthy.\n"); err != nil {
+				level.Error(logger).Log("msg", "Could not write health check response.")
+			}
+		})
+
 		mux := http.NewServeMux()
 		registerMetrics(mux, reg)
 		registerProfile(mux)

--- a/kube/manifests/thanos-query.yaml
+++ b/kube/manifests/thanos-query.yaml
@@ -36,6 +36,10 @@ spec:
           containerPort: 10901
         - name: cluster
           containerPort: 10900
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: http
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Add `/-/healthy` endpoint to Querier.

For a related discussion on this change, you can find [a similar discussion](https://github.com/prometheus/pushgateway/issues/105) on the Prometheus Push Gateway repository.

This endpoint implementation is naive and in the future, we could maybe add verification of gRPC peers or anything else.

## Verification

<!-- How you tested it? How do you know it works? -->

```curl http://127.0.0.1:10902/-/healthy -v
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 10902 (#0)
> GET /-/healthy HTTP/1.1
> Host: 127.0.0.1:10902
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Fri, 12 Oct 2018 11:26:48 GMT
< Content-Length: 19
< Content-Type: text/plain; charset=utf-8
< 
Thanos is Healthy.
* Connection #0 to host 127.0.0.1 left intact
```