### PR TITLE
Added Service Discovery doc.

### DIFF
--- a/docs/discovering_thanos_components.md
+++ b/docs/discovering_thanos_components.md
@@ -1,0 +1,61 @@
+# Discovering Thanos Components
+
+Thanos is a set of components. In order to successfully run Thanos these components need to be able to talk to each other. 
+More specifically:
+* `Thanos Query` needs to know about `Thanos Store` API servers in order to query metrics from them.
+* `Thanos Rule` needs to know about `Thanos Query` API servers in order to evaluate recording and alerting rules.
+
+Currently there are several ways to configure this and they are described below.
+
+## Static Flags
+The simplest way to tell a component about a peer is to use a static flag.
+
+### Thanos Query
+The repeatable flag `--store=<store>` can be used to specify a `Thanos Store` that `Thanos Query` should use. 
+
+### Thanos Rule
+The repeatable flag `--query=<query>` can be used to specify a `Thanos Query` that `Thanos Rule` should use. 
+
+## File Service Discovery
+File Service Discovery is another mechanism for configuring components. With File SD, a 
+list of files can be watched for updates, and the new configuration will be dynamically loaded when a change occurs.   
+The list of files to watch is passed to a component via a flag shown in the component specific sections below. 
+
+The format of the configuration file is the same as the one used in [Prometheus' File SD](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config).
+Both YAML and JSON files can be used. The format of the files is this:
+
+* JSON:
+```
+[
+	{
+		"targets": ["localhost:9090", "example.org:443"],
+	}
+]
+```
+
+* YAML:
+```
+- targets: ['localhost:9090', 'example.org:443']
+```
+
+As a fallback, the file contents are periodically re-read at an interval that can be set using a flag specific for the component and shown below.
+The default value for all File SD re-read intervals is 5 minutes.
+
+### Thanos Query
+The repeatable flag `--store.file-sd-config.files=<path>` can be used to specify the path to files that contain addresses of `Thanos Stores`.
+The `<path>` can be a glob pattern so you can specify several files using a single flag. 
+
+The flag `--store.file-sd-config.interval=<5m>` can be used to change the fallback re-read interval from the default 5 minutes.
+
+### Thanos Rule
+The repeatable flag `--query.file-sd-config.files=<path>` can be used to specify the path to files that contain addresses of `Thanos Queries`.
+Again, the `<path>` can be a glob pattern. 
+
+The flag `--query.file-sd-config.interval=<5m>` can be used to change the fallback re-read interval.
+
+## DNS Service Discovery
+Coming soon as part of both File SD and Static Flags. 
+
+## Other
+Currently, there are no plans of adding other Service Discovery mechanisms like Consul SD, kube SD, etc. However, we welcome 
+people implementing their preferred Service Discovery by writing the results to File SD which will propagate them to the different Thanos components.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
Added a doc that describes how to use static flags and file SD to configure Thanos components.

The doc will later on contain information about DNS SD as well.
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->