### PR TITLE
do not clean root, instead explicitly clean downsample dir

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -134,8 +134,8 @@ func runCompact(
 		downsamplingDir = path.Join(dataDir, "downsample")
 	)
 
-	if err := os.RemoveAll(dataDir); err != nil {
-		return errors.Wrap(err, "clean working temporary directory")
+	if err := os.RemoveAll(downsamplingDir); err != nil {
+		return errors.Wrap(err, "clean working downsample directory")
 	}
 
 	compactor := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt)


### PR DESCRIPTION
Fixes #580 

Should now clean the down sample dir explicitly rather than root as root could be the volume mount.