### PR TITLE
Changed the file SD flags names

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -71,7 +71,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	fileSDFiles := cmd.Flag("store.sd-files", "Path to files that contain addresses of store API servers. The path can be a glob pattern (repeatable).").
 		PlaceHolder("<path>").Strings()
 
-	fileSDInterval := modelDuration(cmd.Flag("store.sd-interval", "Refresh interval to re-read file SD files. (used as a fallback)").
+	fileSDInterval := modelDuration(cmd.Flag("store.sd-interval", "Refresh interval to re-read file SD files. It is used as a resync fallback.").
 		Default("5m"))
 
 	enableAutodownsampling := cmd.Flag("query.auto-downsampling", "Enable automatic adjustment (step / 5) to what source of data should be used in store gateways if no max_source_resolution param is specified. ").

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -68,10 +68,10 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	stores := cmd.Flag("store", "Addresses of statically configured store API servers (repeatable).").
 		PlaceHolder("<store>").Strings()
 
-	fileSDFiles := cmd.Flag("store.file-sd-config.files", "Path to files that contain addresses of store API servers. The path can be a glob pattern (repeatable).").
+	fileSDFiles := cmd.Flag("store.sd-files", "Path to files that contain addresses of store API servers. The path can be a glob pattern (repeatable).").
 		PlaceHolder("<path>").Strings()
 
-	fileSDInterval := modelDuration(cmd.Flag("store.file-sd-config.interval", "Refresh interval to re-read file SD files. (used as a fallback)").
+	fileSDInterval := modelDuration(cmd.Flag("store.sd-interval", "Refresh interval to re-read file SD files. (used as a fallback)").
 		Default("5m"))
 
 	enableAutodownsampling := cmd.Flag("query.auto-downsampling", "Enable automatic adjustment (step / 5) to what source of data should be used in store gateways if no max_source_resolution param is specified. ").

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -81,10 +81,10 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 	queries := cmd.Flag("query", "Addresses of statically configured query API servers (repeatable).").
 		PlaceHolder("<query>").Strings()
 
-	fileSDFiles := cmd.Flag("query.file-sd-config.files", "Path to file that contain addresses of query peers. The path can be a glob pattern (repeatable).").
+	fileSDFiles := cmd.Flag("query.sd-files", "Path to file that contain addresses of query peers. The path can be a glob pattern (repeatable).").
 		PlaceHolder("<path>").Strings()
 
-	fileSDInterval := modelDuration(cmd.Flag("query.file-sd-config.interval", "Refresh interval to re-read file SD files. (used as a fallback)").
+	fileSDInterval := modelDuration(cmd.Flag("query.sd-interval", "Refresh interval to re-read file SD files. (used as a fallback)").
 		Default("5m"))
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -133,8 +133,8 @@ Flags:
                                  Path to files that contain addresses of store
                                  API servers. The path can be a glob pattern
                                  (repeatable).
-      --store.sd-interval=5m     Refresh interval to re-read file SD files.
-                                 (used as a fallback)
+      --store.sd-interval=5m     Refresh interval to re-read file SD files. It
+                                 is used as a resync fallback.
       --query.auto-downsampling  Enable automatic adjustment (step / 5) to what
                                  source of data should be used in store gateways
                                  if no max_source_resolution param is specified.

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -129,12 +129,11 @@ Flags:
                                  info endpoint (repeated).
       --store=<store> ...        Addresses of statically configured store API
                                  servers (repeatable).
-      --store.file-sd-config.files=<path> ...  
+      --store.sd-files=<path> ...  
                                  Path to files that contain addresses of store
                                  API servers. The path can be a glob pattern
                                  (repeatable).
-      --store.file-sd-config.interval=5m  
-                                 Refresh interval to re-read file SD files.
+      --store.sd-interval=5m     Refresh interval to re-read file SD files.
                                  (used as a fallback)
       --query.auto-downsampling  Enable automatic adjustment (step / 5) to what
                                  source of data should be used in store gateways

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -135,12 +135,11 @@ Flags:
                                  Object store configuration in YAML.
       --query=<query> ...        Addresses of statically configured query API
                                  servers (repeatable).
-      --query.file-sd-config.files=<path> ...  
+      --query.sd-files=<path> ...  
                                  Path to file that contain addresses of query
                                  peers. The path can be a glob pattern
                                  (repeatable).
-      --query.file-sd-config.interval=5m  
-                                 Refresh interval to re-read file SD files.
+      --query.sd-interval=5m     Refresh interval to re-read file SD files.
                                  (used as a fallback)
 
 ```

--- a/test/e2e/spinup_test.go
+++ b/test/e2e/spinup_test.go
@@ -152,8 +152,8 @@ func querierWithFileSD(i int, replicaLabel string, storesAddresses ...string) cm
 		}
 
 		args := append(defaultQuerierFlags(i, replicaLabel),
-			"--store.file-sd-config.files", path.Join(queryFileSDDir, "filesd.json"),
-			"--store.file-sd-config.interval", "5s")
+			"--store.sd-files", path.Join(queryFileSDDir, "filesd.json"),
+			"--store.sd-interval", "5s")
 
 		return []*exec.Cmd{exec.Command("thanos", args...)}, nil
 	}
@@ -274,8 +274,8 @@ func rulerWithFileSD(i int, rules string, queryAddresses ...string) (cmdSchedule
 		}
 
 		args := append(defaultRulerFlags(i, dbDir),
-			"--query.file-sd-config.files", path.Join(ruleFileSDDir, "filesd.json"),
-			"--query.file-sd-config.interval", "5s")
+			"--query.sd-files", path.Join(ruleFileSDDir, "filesd.json"),
+			"--query.sd-interval", "5s")
 
 		return []*exec.Cmd{exec.Command("thanos", args...)}, nil
 	}, ""


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
@bwplotka proposed to make the file SD flags a bit less verbose.

Any thoughts on this format:
* `--store.sd-files`
* `--store.sd-interval`

Bare in mind we will also add dns lookup interval flag. It will look like that:
* `--store.sd-dns-interval`
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->