### PR TITLE
Fixed an e2e test not using the table test confs

### DIFF
--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -75,11 +75,7 @@ func TestRule(t *testing.T) {
 func testRuleComponent(t *testing.T, conf testConfig) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 
-	exit, err := newSpinupSuite().
-		Add(querier(1, ""), queryCluster(1)).
-		Add(ruler(1, alwaysFireRule)).
-		Add(ruler(2, alwaysFireRule)).
-		Add(alertManager(1), "").Exec(t, ctx, "test_rule_component")
+	exit, err := conf.suite.Exec(t, ctx, "test_rule_component")
 	if err != nil {
 		t.Errorf("spinup failed: %v", err)
 		cancel()


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
I must have missed this in the last merge. Noticed it while working on dns sd, and thought it is worth a separate pr.


<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->