### PR TITLE
pkg/objstore: Uppercase bucket type after reading config

### DIFF
--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -47,10 +48,10 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg *prometheus.Regist
 	}
 
 	var bucket objstore.Bucket
-	switch bucketConf.Type {
-	case GCS:
+	switch strings.ToUpper(string(bucketConf.Type)) {
+	case string(GCS):
 		bucket, err = gcs.NewBucket(context.Background(), logger, config, reg, component)
-	case S3:
+	case string(S3):
 		bucket, err = s3.NewBucket(logger, config, reg, component)
 	default:
 		return nil, errors.Errorf("bucket with type %s is not supported", bucketConf.Type)


### PR DESCRIPTION
## Changes

This will convert the type to uppercase `S3` or `GCS`, so that people that have a config like still works:
```
type: s3
...
```

## Verification

`make build` and then run `./thanos bucket ls` with config that has lowercase name.