### PR TITLE
Support OpenStack Swift object storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,10 @@ jobs:
             fi
             export THANOS_SKIP_S3_AWS_TESTS="true"
             echo "Skipping AWS tests."
-            export THANOS_SKIP_SWIFT_TESTS="true"
-            echo "Skipping SWIFT tests."
-
             export THANOS_SKIP_AZURE_TESTS="true"
             echo "Skipping Azure tests."
+            export THANOS_SKIP_SWIFT_TESTS="true"
+            echo "Skipping SWIFT tests."
 
             make test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
             fi
             export THANOS_SKIP_S3_AWS_TESTS="true"
             echo "Skipping AWS tests."
+            export THANOS_SKIP_SWIFT_TESTS="true"
+            echo "Skipping SWIFT tests."
 
             export THANOS_SKIP_AZURE_TESTS="true"
             echo "Skipping Azure tests."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ $ git push origin <your_branch_for_new_pr>
 - THANOS_SKIP_GCS_TESTS to skip GCS tests.
 - THANOS_SKIP_S3_AWS_TESTS to skip AWS tests.
 - THANOS_SKIP_AZURE_TESTS to skip Azure tests.
+- THANOS_SKIP_SWIFT_TESTS to skip SWIFT tests.
 
 If you skip all of these, the store specific tests will be run against memory object storage only.
 CI runs GCS and inmem tests only for now. Not having these variables will produce auth errors against GCS, AWS or Azure tests.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -198,6 +198,25 @@
   version = "v2.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:e9aa4d37933cdd1978d83938e8af418c02b4c183e1d6c936efd00ce1628fadb7"
+  name = "github.com/gophercloud/gophercloud"
+  packages = [
+    ".",
+    "openstack",
+    "openstack/identity/v2/tenants",
+    "openstack/identity/v2/tokens",
+    "openstack/identity/v3/tokens",
+    "openstack/objectstorage/v1/accounts",
+    "openstack/objectstorage/v1/containers",
+    "openstack/objectstorage/v1/objects",
+    "openstack/utils",
+    "pagination",
+  ]
+  pruneopts = ""
+  revision = "0719c6b22f30132b0ae6c90b038e0d50992107b0"
+
+[[projects]]
   digest = "1:0bf81a189b23434fc792317c9276abfe7aee4eb3f85d3c3659a2e0f21acafe97"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
@@ -743,6 +762,11 @@
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/proto",
     "github.com/golang/snappy",
+    "github.com/gophercloud/gophercloud",
+    "github.com/gophercloud/gophercloud/openstack",
+    "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers",
+    "github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects",
+    "github.com/gophercloud/gophercloud/pagination",
     "github.com/grpc-ecosystem/go-grpc-middleware",
     "github.com/grpc-ecosystem/go-grpc-middleware/recovery",
     "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -79,3 +79,7 @@ ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
 [[constraint]]
   name = "github.com/Azure/azure-storage-blob-go"
   revision = "197d1c0aea1b9eedbbaee0a1a32bf81e879bde80"
+
+[[constraint]]
+  name = "github.com/rackspace/gophercloud"
+  version = "1.0.0"

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -23,7 +23,7 @@ import (
 
 // registerStore registers a store command.
 func registerStore(m map[string]setupFunc, app *kingpin.Application, name string) {
-	cmd := app.Command(name, "store node giving access to blocks in a bucket provider. Now supported GCS, S3 and Azure.")
+	cmd := app.Command(name, "store node giving access to blocks in a bucket provider. Now supported GCS, S3, Azure and Swift.")
 
 	grpcBindAddr, httpBindAddr, cert, key, clientCA, newPeerFn := regCommonServerFlags(cmd)
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -27,7 +27,7 @@ In general about 1MB of local disk space is required per TSDB block stored in th
 ```$
 usage: thanos store [<flags>]
 
-store node giving access to blocks in a bucket provider. Now supported GCS, S3, 
+store node giving access to blocks in a bucket provider. Now supported GCS, S3,
 Azure and Swift.
 
 Flags:

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -27,8 +27,8 @@ In general about 1MB of local disk space is required per TSDB block stored in th
 ```$
 usage: thanos store [<flags>]
 
-store node giving access to blocks in a bucket provider. Now supported GCS, S3
-and Azure.
+store node giving access to blocks in a bucket provider. Now supported GCS, S3, 
+Azure and Swift.
 
 Flags:
   -h, --help                     Show context-sensitive help (also try

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,7 +3,7 @@
 Thanos provides a global query view, data backup, and historical data access as its core features in a single binary. All three features can be run independently of each other. This allows you to have a subset of Thanos features ready for immediate benefit or testing, while also making it flexible for gradual roll outs in more complex environments. 
 
 In this quick-start guide, we will configure Thanos and all components mentioned to work against a Google Cloud Storage bucket. 
-At the moment, Thanos is able to use [GCS and S3 as storage providers](storage.md), with the ability to add more providers as necessary. You can substitute Google Cloud specific flags in this guide with those of your object store detailed in the [Storage document](storage.md).
+At the moment, Thanos is able to use [GCS, S3 and SWIFT as storage providers](storage.md), with the ability to add more providers as necessary. You can substitute Google Cloud specific flags in this guide with those of your object store detailed in the [Storage document](storage.md).
 
 ## Requirements
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -195,12 +195,12 @@ Below is an example configuration file for thanos to use OpenStack swift contain
 ```yaml
 type: SWIFT
 config:
-    authUrl: <identity endpoint aka auth URL>
+    auth_url: <identity endpoint aka auth URL>
     username: <username>
     password: <password>
-    tenantName: <tenantName>
-    regionName: <region>
-    containerName: <container>
+    tenant_name: <tenant name>
+    region_name: <region>
+    container_name: <container>
 ```
 
 Set the flags `--objstore.config-file` to reference to the configuration file.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -9,6 +9,7 @@ Current object storage client implementations:
 | Google Cloud Storage | Stable  (production usage)             | yes       | @bplotka   |
 | AWS S3               | Beta  (working PoCs, testing usage)               | no        | ?          |
 | Azure Storage Account | Alpha   | yes       | @vglafirov   |
+| OpenStack Swift      | Beta  (working PoCs, testing usage)               | no        | @sudhi-vm   |
 
 NOTE: Currently Thanos requires strong consistency (write-read) for object store implementation.
 
@@ -185,3 +186,21 @@ config:
     storage_account_key: <Storage Account key>
     container: <Blob container>
 ```
+
+### OpenStack Swift Configuration
+Thanos uses [gophercloud](http://gophercloud.io/) client to upload Prometheus data into [OpenStack Swift](https://docs.openstack.org/swift/latest/).
+
+Below is an example configuration file for thanos to use OpenStack swift container as an object store. 
+
+```yaml
+type: SWIFT
+config:
+    authUrl: <identity endpoint aka auth URL>
+    username: <username>
+    password: <password>
+    tenantName: <tenantName>
+    regionName: <region>
+    containerName: <container>
+```
+
+Set the flags `--objstore.config-file` to reference to the configuration file.

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -60,7 +60,7 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg *prometheus.Regist
 	case string(AZURE):
 		bucket, err = azure.NewBucket(logger, config, component)
 	case string(SWIFT):
-		bucket, err = swift.NewContainer(logger, config, reg)
+		bucket, err = swift.NewContainer(logger, config)
 	default:
 		return nil, errors.Errorf("bucket with type %s is not supported", bucketConf.Type)
 	}

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/objstore/azure"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
+	"github.com/improbable-eng/thanos/pkg/objstore/swift"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/yaml.v2"
@@ -22,6 +23,7 @@ const (
 	GCS   objProvider = "GCS"
 	S3    objProvider = "S3"
 	AZURE objProvider = "AZURE"
+	SWIFT objProvider = "SWIFT"
 )
 
 type BucketConfig struct {
@@ -57,6 +59,8 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg *prometheus.Regist
 		bucket, err = s3.NewBucket(logger, config, component)
 	case string(AZURE):
 		bucket, err = azure.NewBucket(logger, config, component)
+	case string(SWIFT):
+		bucket, err = swift.NewContainer(logger, config, reg)
 	default:
 		return nil, errors.Errorf("bucket with type %s is not supported", bucketConf.Type)
 	}

--- a/pkg/objstore/objtesting/acceptance_e2e_test.go
+++ b/pkg/objstore/objtesting/acceptance_e2e_test.go
@@ -3,6 +3,7 @@ package objtesting
 import (
 	"context"
 	"io/ioutil"
+	"sort"
 	"strings"
 	"testing"
 
@@ -62,7 +63,10 @@ func TestObjStore_AcceptanceTest_e2e(t *testing.T) {
 			seen = append(seen, fn)
 			return nil
 		}))
-		testutil.Equals(t, []string{"obj_5.some", "id1/", "id2/"}, seen)
+		expected := []string{"obj_5.some", "id1/", "id2/"}
+		sort.Strings(expected)
+		sort.Strings(seen)
+		testutil.Equals(t, expected, seen)
 
 		// Can we iter over items from id1/ dir?
 		seen = []string{}

--- a/pkg/objstore/objtesting/foreach.go
+++ b/pkg/objstore/objtesting/foreach.go
@@ -11,6 +11,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
 	"github.com/improbable-eng/thanos/pkg/objstore/inmem"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
+	"github.com/improbable-eng/thanos/pkg/objstore/swift"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 )
 
@@ -84,4 +85,21 @@ func ForeachStore(t *testing.T, testFn func(t testing.TB, bkt objstore.Bucket)) 
 		t.Log("THANOS_SKIP_AZURE_TESTS envvar present. Skipping test against Azure.")
 	}
 
+
+	// Optional SWIFT.
+	if _, ok := os.LookupEnv("THANOS_SKIP_SWIFT_TESTS"); !ok {
+		container, closeFn, err := swift.NewTestContainer(t)
+		testutil.Ok(t, err)
+
+		ok := t.Run("swift", func(t *testing.T) {
+			// TODO(bplotka): Add leaktest when https://github.com/GoogleCloudPlatform/google-cloud-go/issues/1025 is resolved.
+			testFn(t, container)
+		})
+		closeFn()
+		if !ok {
+			return
+		}
+	} else {
+		t.Log("THANOS_SKIP_SWIFT_TESTS envvar present. Skipping test against swift.")
+	}
 }

--- a/pkg/objstore/objtesting/foreach.go
+++ b/pkg/objstore/objtesting/foreach.go
@@ -85,14 +85,12 @@ func ForeachStore(t *testing.T, testFn func(t testing.TB, bkt objstore.Bucket)) 
 		t.Log("THANOS_SKIP_AZURE_TESTS envvar present. Skipping test against Azure.")
 	}
 
-
 	// Optional SWIFT.
 	if _, ok := os.LookupEnv("THANOS_SKIP_SWIFT_TESTS"); !ok {
 		container, closeFn, err := swift.NewTestContainer(t)
 		testutil.Ok(t, err)
 
 		ok := t.Run("swift", func(t *testing.T) {
-			// TODO(bplotka): Add leaktest when https://github.com/GoogleCloudPlatform/google-cloud-go/issues/1025 is resolved.
 			testFn(t, container)
 		})
 		closeFn()

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2018 eBay Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package swift implements common object storage abstractions against OpenStack swift APIs.
+package swift
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	"io"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/improbable-eng/thanos/pkg/objstore"
+
+	"github.com/go-kit/kit/log"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// Class A operations.
+	opObjectsList  = "objects.list"
+	opObjectInsert = "object.insert"
+
+	// Class B operation.
+	opObjectGet = "object.get"
+
+	// Free operations.
+	opObjectDelete = "object.delete"
+)
+
+// DirDelim is the delimiter used to model a directory structure in an object store bucket.
+const DirDelim = "/"
+
+type swiftConfig struct {
+	AuthUrl       string `yaml:"authUrl"`
+	Username      string `yaml:"username,omitempty"`
+	UserId        string `yaml:"userId,omitempty"`
+	Password      string `yaml:"password"`
+	DomainId      string `yaml:"domainId,omitempty"`
+	DomainName    string `yaml:"domainName,omitempty"`
+	TenantID      string `yaml:"tenantId,omitempty"`
+	TenantName    string `yaml:"tenantName,omitempty"`
+	RegionName    string `yaml:"regionName,omitempty"`
+	ContainerName string `yaml:"containerName"`
+}
+
+type Container struct {
+	logger   log.Logger
+	client   *gophercloud.ServiceClient
+	opsTotal *prometheus.CounterVec
+	name     string
+}
+
+func NewContainer(logger log.Logger, conf []byte, reg prometheus.Registerer) (*Container, error) {
+	var sc swiftConfig
+	if err := yaml.Unmarshal(conf, &sc); err != nil {
+		return nil, err
+	}
+
+	authOpts := gophercloud.AuthOptions{
+		IdentityEndpoint: sc.AuthUrl,
+		Username:         sc.Username,
+		UserID:           sc.UserId,
+		Password:         sc.Password,
+		DomainID:         sc.DomainId,
+		DomainName:       sc.DomainName,
+		TenantID:         sc.TenantID,
+		TenantName:       sc.TenantName,
+
+		// Allow Gophercloud to re-authenticate automatically.
+		AllowReauth: true,
+	}
+
+	provider, err := openstack.AuthenticatedClient(authOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := openstack.NewObjectStorageV1(provider, gophercloud.EndpointOpts{
+		Region: sc.RegionName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Container{
+		logger: logger,
+		client: client,
+		opsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name:        "thanos_objstore_swift_container_operations_total",
+			Help:        "Total number of operations that were executed against a Swift Storage container.",
+			ConstLabels: prometheus.Labels{"container": sc.ContainerName},
+		}, []string{"operation"}),
+		name: sc.ContainerName,
+	}
+
+	if reg != nil {
+		reg.MustRegister()
+	}
+
+	return c, nil
+}
+
+// Name returns the container name for swift.
+func (c *Container) Name() string {
+	return c.name
+}
+
+// Iter calls f for each entry in the given directory. The argument to f is the full
+// object name including the prefix of the inspected directory.
+func (c *Container) Iter(ctx context.Context, dir string, f func(string) error) error {
+	c.opsTotal.WithLabelValues(opObjectsList).Inc()
+	// Ensure the object name actually ends with a dir suffix. Otherwise we'll just iterate the
+	// object itself as one prefix item.
+	if dir != "" {
+		dir = strings.TrimSuffix(dir, DirDelim) + DirDelim
+	}
+
+	options := &objects.ListOpts{Full: false, Prefix: dir, Delimiter: DirDelim}
+	err := objects.List(c.client, c.name, options).EachPage(func(page pagination.Page) (bool, error) {
+		objectNames, err := objects.ExtractNames(page)
+		if err != nil {
+			return false, err
+		}
+		for _, objectName := range objectNames {
+			if err := f(objectName); err != nil {
+				return false, err
+			}
+		}
+
+		return true, nil
+	})
+
+	return err
+}
+
+// Get returns a reader for the given object name.
+func (c *Container) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	if name == "" {
+		return nil, fmt.Errorf("error, empty container name passed")
+	}
+	c.opsTotal.WithLabelValues(opObjectGet).Inc()
+	response := objects.Download(c.client, c.name, name, nil)
+	return response.Body, response.Err
+}
+
+// GetRange returns a new range reader for the given object name and range.
+func (c *Container) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	c.opsTotal.WithLabelValues(opObjectGet).Inc()
+	options := objects.DownloadOpts{
+		Newest: true,
+		Range:  fmt.Sprintf("bytes=%d-%d", off, off+length-1),
+	}
+	response := objects.Download(c.client, c.name, name, options)
+	return response.Body, response.Err
+}
+
+// Exists checks if the given object exists.
+func (c *Container) Exists(ctx context.Context, name string) (bool, error) {
+	c.opsTotal.WithLabelValues(opObjectGet).Inc()
+	err := objects.Get(c.client, c.name, name, nil).Err
+	if err == nil {
+		return true, nil
+	}
+
+	if _, ok := err.(gophercloud.ErrDefault404); ok {
+		return false, nil
+	}
+
+	return false, err
+}
+
+// IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.
+func (c *Container) IsObjNotFoundErr(err error) bool {
+	_, ok := err.(gophercloud.ErrDefault404)
+	return ok
+}
+
+// Upload writes the contents of the reader as an object into the container.
+func (c *Container) Upload(ctx context.Context, name string, r io.Reader) error {
+	c.opsTotal.WithLabelValues(opObjectInsert).Inc()
+
+	options := &objects.CreateOpts{Content: r}
+	res := objects.Create(c.client, c.name, name, options)
+	return res.Err
+}
+
+// Delete removes the object with the given name.
+func (c *Container) Delete(ctx context.Context, name string) error {
+	c.opsTotal.WithLabelValues(opObjectDelete).Inc()
+	return objects.Delete(c.client, c.name, name, nil).Err
+
+}
+
+func (*Container) Close() error {
+	// nothing to close
+	return nil
+}
+
+func (c *Container) CreateContainer(name string) error {
+	return containers.Create(c.client, name, nil).Err
+}
+
+func (c *Container) DeleteContainer(name string) error {
+	return containers.Delete(c.client, name).Err
+}
+
+func configFromEnv() swiftConfig {
+	c := swiftConfig{
+		AuthUrl:       os.Getenv("OS_AUTH_URL"),
+		Username:      os.Getenv("OS_USERNAME"),
+		Password:      os.Getenv("OS_PASSWORD"),
+		TenantID:      os.Getenv("OS_TENANT_ID"),
+		TenantName:    os.Getenv("OS_TENANT_NAME"),
+		RegionName:    os.Getenv("OS_REGION_NAME"),
+		ContainerName: os.Getenv("OS_CONTAINER_NAME"),
+	}
+
+	return c
+}
+
+// ValidateForTests checks to see the config options for tests are set.
+func ValidateForTests(conf swiftConfig) error {
+	if conf.AuthUrl == "" ||
+		conf.Username == "" ||
+		conf.Password == "" ||
+		(conf.TenantName == "" && conf.TenantID == "") ||
+		conf.RegionName == "" {
+		return errors.New("insufficient swift test configuration information")
+	}
+	return nil
+}
+
+// NewTestContainer creates test bkt client that before returning creates temporary container.
+// In a close function it empties and deletes the container.
+func NewTestContainer(t testing.TB) (objstore.Bucket, func(), error) {
+	config := configFromEnv()
+	if err := ValidateForTests(config); err != nil {
+		return nil, nil, err
+	}
+	containerConfig, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c, err := NewContainer(log.NewNopLogger(), containerConfig, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if config.ContainerName != "" {
+		if os.Getenv("THANOS_ALLOW_EXISTING_BUCKET_USE") == "" {
+			return nil, nil, errors.New("OS_CONTAINER_NAME is defined. Normally this tests will create temporary container " +
+				"and delete it after test. Unset OS_CONTAINER_NAME env variable to use default logic. If you really want to run " +
+				"tests against provided (NOT USED!) container, set THANOS_ALLOW_EXISTING_BUCKET_USE=true. WARNING: That container " +
+				"needs to be manually cleared. This means that it is only useful to run one test in a time. This is due " +
+				"to safety (accidentally pointing prod container for test) as well as swift not being fully strong consistent.")
+		}
+
+		if err := c.Iter(context.Background(), "", func(f string) error {
+			return errors.Errorf("container %s is not empty", config.ContainerName)
+		}); err != nil {
+			return nil, nil, errors.Wrapf(err, "swift check container %s", config.ContainerName)
+		}
+
+		t.Log("WARNING. Reusing", config.ContainerName, "container for Swift tests. Manual cleanup afterwards is required")
+		return c, func() {}, nil
+	}
+
+	src := rand.NewSource(time.Now().UnixNano())
+
+	tmpContainerName := fmt.Sprintf("test_%s_%x", strings.ToLower(t.Name()), src.Int63())
+	if len(tmpContainerName) >= 63 {
+		tmpContainerName = tmpContainerName[:63]
+	}
+
+	if err := c.CreateContainer(tmpContainerName); err != nil {
+		return nil, nil, err
+	}
+
+	c.name = tmpContainerName
+	t.Log("created temporary container for swift tests with name", tmpContainerName)
+
+	return c, func() {
+		objstore.EmptyBucket(t, context.Background(), c)
+		if err := c.DeleteContainer(tmpContainerName); err != nil {
+			t.Logf("deleting container %s failed: %s", tmpContainerName, err)
+		}
+	}, nil
+}


### PR DESCRIPTION
This commit adds support for OpenStack swift storage.

## Changes

- OpenStack Swift is a highly available, distributed object/blob store. This commit adds support to persist the metric data on Swift.

## Verification

- Ensured `TestObjStore_AcceptanceTest_e2e` works for the swift storage. Verified that the test objects are getting created by going directly to swift while the tests were running.
- Tested with a local OpenStack swift installation.
