### PR TITLE
docs: Improve discovery file snippets

### DIFF
--- a/docs/thanos_service_discovery.md
+++ b/docs/thanos_service_discovery.md
@@ -25,16 +25,16 @@ The format of the configuration file is the same as the one used in [Prometheus'
 Both YAML and JSON files can be used. The format of the files is this:
 
 * JSON:
-```
+```json
 [
-	{
-		"targets": ["localhost:9090", "example.org:443"],
-	}
+  {
+    "targets": ["localhost:9090", "example.org:443"]
+  }
 ]
 ```
 
 * YAML:
-```
+```yaml
 - targets: ['localhost:9090', 'example.org:443']
 ```
 


### PR DESCRIPTION
## Changes

Format the markdown of JSON and YAML Discovery File snippets so they properly highlighted. In addition, there was an extra comma in after the array in the JSON sample, which would make the JSON file itself invalid.

## Verification

The snippets are properly highlighted when previewing the modified markdown.