### PR TITLE
Remove bucket operator metrics

### DIFF
--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -50,9 +50,9 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg *prometheus.Regist
 	var bucket objstore.Bucket
 	switch strings.ToUpper(string(bucketConf.Type)) {
 	case string(GCS):
-		bucket, err = gcs.NewBucket(context.Background(), logger, config, reg, component)
+		bucket, err = gcs.NewBucket(context.Background(), logger, config, component)
 	case string(S3):
-		bucket, err = s3.NewBucket(logger, config, reg, component)
+		bucket, err = s3.NewBucket(logger, config, component)
 	default:
 		return nil, errors.Errorf("bucket with type %s is not supported", bucketConf.Type)
 	}

--- a/test/e2e/store_gateway_test.go
+++ b/test/e2e/store_gateway_test.go
@@ -77,7 +77,7 @@ func TestStoreGatewayQuery(t *testing.T) {
 
 	l := log.NewLogfmtLogger(os.Stdout)
 
-	bkt, err := s3.NewBucketWithConfig(l, s3Config, nil, "test-feed")
+	bkt, err := s3.NewBucketWithConfig(l, s3Config, "test-feed")
 	testutil.Ok(t, err)
 
 	testutil.Ok(t, objstore.UploadDir(ctx, l, bkt, path.Join(dir, id1.String()), id1.String()))


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
Related comments: [#467](https://github.com/improbable-eng/thanos/pull/467#discussion_r228696300)

The bucket operator metrics in each bucket are unnecessary, because we wrap the instance of bucket in the `metricBucket`, those seem to be duplicated. Let's remove the metrics and we can add again when support multiple buckets.

## Verification

<!-- How you tested it? How do you know it works? -->
In Thanos Query UI, we can just find the `thanos_objstore_bucket_operations_total`, no `thanos_objstore_s3_bucket_operations_total` or `thanos_objstore_gcs_bucket_operations_total` etc.. 