### PR TITLE
add correct app selector for prometheus traffic

### DIFF
--- a/kube/manifests/prometheus-gcs.yaml
+++ b/kube/manifests/prometheus-gcs.yaml
@@ -162,8 +162,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: prometheus
-  name: prometheus
+    app: prometheus-gcs
+  name: prometheus-gcs
 spec:
   externalTrafficPolicy: Cluster
   ports:
@@ -176,7 +176,7 @@ spec:
     targetPort: sidecar-http
     name: http-sidecar-metrics
   selector:
-    app: prometheus
+    app: prometheus-gcs
   sessionAffinity: None
   type: NodePort
 status:


### PR DESCRIPTION
and for consistency add -gcs suffix to service as well.

Without this the selector would point to non-existent prometheus pods
