### PR TITLE
sidecar: fix reloader to reload prometheus, when it shouldn't

### DIFF
--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -170,7 +170,9 @@ func (r *Reloader) apply(ctx context.Context) error {
 			return errors.Wrap(err, "build hash")
 		}
 	}
-	ruleHash = h.Sum(nil)
+	if len(r.ruleDirs) > 0 {
+		ruleHash = h.Sum(nil)
+	}
 
 	if bytes.Equal(r.lastCfgHash, cfgHash) && bytes.Equal(r.lastRuleHash, ruleHash) {
 		// Nothing to do.


### PR DESCRIPTION
SHA256 calculate sum even on empty input:
[227 176 196 66 152 252 28 20 154 ....]

in this case, even if ruleDirs hasn't been specified, it tries to reload prometheus.
For the case the --web.enable-lifecycle isn't enabled, the reloader gets into the infinity loop.

fixes: https://github.com/improbable-eng/thanos/pull/476

cc @bwplotka 