### PR TITLE
fix rule: Fixed scalar result handling in rule node (#598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 
 ### Fixed
 - [#566](https://github.com/improbable-eng/thanos/issues/566) - Fixed issue whereby the Proxy Store could end up in a deadlock if there were more than 9 stores being queried and all returned an error.
+- [#598](https://github.com/improbable-eng/thanos/issues/598) - Fixed handling of scalar result in rule node evaluating rules.
 
 
 ## [v0.1.0](https://github.com/improbable-eng/thanos/releases/tag/v0.1.0) - 2018.09.14
@@ -68,4 +69,3 @@ Initial version to have a stable reference before [gossip protocol removal](http
 - Bucket commands.
 - Downsampling support for UI.
 - Grafana dashboards for Thanos components.
-

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/prometheus/common/model"
+)
+
+func TestRule_UnmarshalScalarResponse(t *testing.T) {
+	var (
+		scalarJSONResult              = []byte(`[1541196373.677,"1"]`)
+		invalidLengthScalarJSONResult = []byte(`[1541196373.677,"1", "nonsence"]`)
+		invalidDataScalarJSONResult   = []byte(`["foo","bar"]`)
+
+		vectorResult   model.Vector
+		expectedVector = model.Vector{&model.Sample{
+			Metric:    model.Metric{},
+			Value:     1,
+			Timestamp: model.Time(1541196373677)}}
+	)
+	// Test valid input.
+	vectorResult, err := convertScalarJSONToVector(scalarJSONResult)
+	testutil.Ok(t, err)
+	testutil.Equals(t, vectorResult.String(), expectedVector.String())
+
+	// Test invalid length of scalar data structure.
+	vectorResult, err = convertScalarJSONToVector(invalidLengthScalarJSONResult)
+	testutil.NotOk(t, err)
+
+	// Test invalid format of scalar data.
+	vectorResult, err = convertScalarJSONToVector(invalidDataScalarJSONResult)
+	testutil.NotOk(t, err)
+}


### PR DESCRIPTION
Signed-off-by: Martin Chodur <m.chodur@seznam.cz>

## Changes
fixes https://github.com/improbable-eng/thanos/issues/598

1. Added handling of scalar result or query node response when evaluating rules

## Verification
I verified that it works with test rules loaded to the new version of rule node:
```yaml
groups:
- name: test
  rules:
  - record: scalar_rule
    expr: 1
    labels:
        type: SCALAR

  - record: vector_rule
    expr: sum(topk(1,up)) by (instance)
    labels:
        type: VECTOR
```

and result from connected query node is:
![screenshot-20181102214005-613x385](https://user-images.githubusercontent.com/6112562/47939519-eaa08480-dee7-11e8-8b7f-4e60242271e1.png)

I also added simple test to verify ability to decode scalar response.
