### PR TITLE
feat tests: Added newer versions of Prometheus and Minio to e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ EMBEDMD           ?= $(BIN_DIR)/embedmd
 DEP               ?= $(BIN_DIR)/dep-$(DEP_VERSION)
 
 DEP_VERSION             ?=45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
-# TODO(bplotka): Add more recent version after https://github.com/prometheus/prometheus/issues/4551 is fixed.
-SUPPORTED_PROM_VERSIONS ?=v2.0.0 v2.2.1
+SUPPORTED_PROM_VERSIONS ?=v2.0.0 v2.2.1 v2.3.2 v2.4.3
 ALERTMANAGER_VERSION    ?=v0.15.2
 MINIO_SERVER_VERSION    ?=RELEASE.2018-10-06T00-15-16Z
 
@@ -140,7 +139,7 @@ tarballs-release: $(PROMU)
 # test runs all Thanos golang tests against each supported version of Prometheus.
 .PHONY: test
 test: test-deps
-	@echo ">> running all tests. Do export THANOS_SKIP_GCS_TESTS='true' or/and  export THANOS_SKIP_S3_AWS_TESTS='true' or/and THANOS_SKIP_AZURE_TESTS='true' if you want to skip e2e tests against real store buckets"
+	@echo ">> running all tests. Do export THANOS_SKIP_GCS_TESTS='true' or/and  export THANOS_SKIP_S3_AWS_TESTS='true' or/and export THANOS_SKIP_AZURE_TESTS='true' if you want to skip e2e tests against real store buckets"
 	@for ver in $(SUPPORTED_PROM_VERSIONS); do \
 		THANOS_TEST_PROMETHEUS_PATH="prometheus-$$ver" THANOS_TEST_ALERTMANAGER_PATH="alertmanager-$(ALERTMANAGER_VERSION)" go test $(shell go list ./... | grep -v /vendor/ | grep -v /benchmark/); \
 	done


### PR DESCRIPTION
## Changes

I added `v2.3.2` and `v2.4.3`. 

Possible enhancement could be automatically getting latest stable version of Prometheus so we don't have to add new versions manually.   

## Verification

Tests are passing for all versions.