### PR TITLE
S3 object store: set bucket-owner-full-control acl on upload

### DIFF
--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -234,7 +234,7 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 // Upload the contents of the reader as an object into the bucket.
 func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
 	_, err := b.client.PutObjectWithContext(ctx, b.name, name, r, -1,
-		minio.PutObjectOptions{ServerSideEncryption: b.sse},
+		minio.PutObjectOptions{ServerSideEncryption: b.sse, UserMetadata: map[string]string{"X-Amz-Acl": "bucket-owner-full-control"}},
 	)
 
 	return errors.Wrap(err, "upload s3 object")


### PR DESCRIPTION
S3 object store: set bucket-owner-full-control acl on upload

This is needed in environments where the sidecar is deployed in
one AWS account while the store bucket is owned by a different account
Without this ACL the storer cannot access data written

## Changes
 - set bucket-owner-full-control canned acl on S3 Upload

## Verification

 - Local test with multiple accounts