### PR TITLE
Update documentation to use objstore.config-file

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -53,7 +53,7 @@ All data is uploaded as it is created by the Prometheus server/storage engine. T
                   │                                │           │
                 Blocks                           Blocks      Blocks
                   │                                │           │
-                  v                                v           v 
+                  v                                v           v
               ┌──────────────────────────────────────────────────┐
               │                   Object Storage                 │
               └──────────────────────────────────────────────────┘

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -38,13 +38,13 @@ The following configures the Sidecar to only backup Prometheus data into a Googl
 
 ```
 thanos sidecar \
-    --tsdb.path         /var/prometheus \           # Data directory of Prometheus
-    --gcs.bucket        example-bucket \            # Bucket to upload data to
+    --tsdb.path                /var/prometheus \           # Data directory of Prometheus
+    --objstore.config-file     "bucket.yml"    \           # Bucket config file to send data to
 ```
 
 Rolling this out has little to zero impact on the running Prometheus instance. It is a good start to ensure you are backing up your data while figuring out the other pieces of Thanos.
 
-If you are not interested in backing up any data, the `--gcs.bucket` flag can simply be omitted.
+If you are not interested in backing up any data, the `--objstore.config-file` flag can simply be omitted.
 
 * _[Example Kubernetes manifest](../kube/manifests/prometheus.yaml)_
 * _[Example Kubernetes manifest with GCS upload](../kube/manifests/prometheus-gcs.yaml)_
@@ -59,7 +59,7 @@ Let's extend the Sidecar in the previous section to connect to a Prometheus serv
 ```
 thanos sidecar \
     --tsdb.path                 /var/prometheus \
-    --gcs.bucket                example-bucket \
+    --objstore.config-file     "bucket.yml"    \           # Bucket config file to send data to
     --prometheus.url            http://localhost:9090 \    # Location of the Prometheus HTTP server
     --http-address              0.0.0.0:19191 \            # HTTP endpoint for collecting metrics on the Sidecar
     --cluster.peers             127.0.0.1:19391 \          # Static list of peers where the node will get info about the cluster
@@ -146,7 +146,7 @@ Given a sidecar we can have it join a gossip cluster by advertising itself to ot
 thanos sidecar \
     --prometheus.url            http://localhost:9090 \
     --tsdb.path                 /var/prometheus \
-    --gcs.bucket                example-bucket \
+    --objstore.config-file     "bucket.yml"    \           # Bucket config file to send data to
     --grpc-address              0.0.0.0:19091 \            # gRPC endpoint for Store API (will be used to perform PromQL queries)
     --http-address              0.0.0.0:19191 \            # HTTP endpoint for collecting metrics on Thanos sidecar
     --cluster.address           0.0.0.0:19391 \            # Endpoint used to meta data about the current node
@@ -212,7 +212,7 @@ Just like sidecars and query nodes, the store gateway joins the gossip cluster a
 ```
 thanos store \
     --data-dir                  /var/thanos/store \     # Disk space for local caches
-    --gcs.bucket                example-bucket \        # Bucket to fetch data from
+    --objstore.config-file     "bucket.yml"    \        # Bucket config file to fetch data from
     --cluster.address           0.0.0.0:19891 \
     --cluster.advertise-address 127.0.0.1:19891 \
     --cluster.peers             127.0.0.1:19391 \
@@ -230,8 +230,8 @@ The compactor component simple scans the object storage and processes compaction
 
 ```
 thanos compact \
-    --data-dir /var/thanos/compact \  # Temporary workspace for data processing
-    --gcs-bucket example-bucket
+    --data-dir                 /var/thanos/compact \  # Temporary workspace for data processing
+    --objstore.config-file     "bucket.yml"    \      # Bucket config file to send data to
 ```
 
 The compactor is not in the critical path of querying or data backup. It can either be run as a periodic batch job or be left running to always compact data as soon as possible. It is recommended to provide 100-300GB of local disk space for data processing.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -46,7 +46,8 @@ Set the flags `--objstore.config-file` to reference to the configuration file.
 
 AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
 
-Make sure you use a correct signature version to set `signature-version2: true`, otherwise, you will get Access Denied error.
+Make sure you use a correct signature version.
+Currently AWS require signature v4, so it needs `signature-version2: false`, otherwise, you will get Access Denied error, but several other S3 compatible use `signature-version2: true`
 
 For debug purposes you can set `insecure: true` to switch to plain insecure HTTP instead of HTTPS
 

--- a/docs/thanos_service_discovery.md
+++ b/docs/thanos_service_discovery.md
@@ -1,7 +1,7 @@
 # Thanos Service Discovery
 
-Service discovery has a vital place in Thanos components that allows them to perform some logic against given set of APIs. 
-Currently there are 2 places like this: 
+Service discovery has a vital place in Thanos components that allows them to perform some logic against given set of APIs.
+Currently there are 2 places like this:
 * `Thanos Query` needs to know about [StoreAPI](https://github.com/improbable-eng/thanos/blob/d3fb337da94d11c78151504b1fccb1d7e036f394/pkg/store/storepb/rpc.proto#L14) servers in order to query metrics from them.
 * `Thanos Rule` needs to know about `QueryAPI` servers in order to evaluate recording and alerting rules.
 
@@ -12,17 +12,17 @@ Currently there are several ways to configure this and they are described below.
 The simplest way to tell a component about a peer is to use a static flag.
 
 ### Thanos Query
-The repeatable flag `--store=<store>` can be used to specify a `StoreAPI` that `Thanos Query` should use. 
+The repeatable flag `--store=<store>` can be used to specify a `StoreAPI` that `Thanos Query` should use.
 
 ### Thanos Rule
 
-The repeatable flag `--query=<query>` can be used to specify a `QueryAPI` that `Thanos Rule` should use. 
+The repeatable flag `--query=<query>` can be used to specify a `QueryAPI` that `Thanos Rule` should use.
 
 ## File Service Discovery
 
-File Service Discovery is another mechanism for configuring components. With File SD, a 
-list of files can be watched for updates, and the new configuration will be dynamically loaded when a change occurs.   
-The list of files to watch is passed to a component via a flag shown in the component specific sections below. 
+File Service Discovery is another mechanism for configuring components. With File SD, a
+list of files can be watched for updates, and the new configuration will be dynamically loaded when a change occurs.
+The list of files to watch is passed to a component via a flag shown in the component specific sections below.
 
 The format of the configuration file is the same as the one used in [Prometheus' File SD](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config).
 Both YAML and JSON files can be used. The format of the files is this:
@@ -47,25 +47,25 @@ The default value for all File SD re-read intervals is 5 minutes.
 ### Thanos Query
 
 The repeatable flag `--store.sd-files=<path>` can be used to specify the path to files that contain addresses of `StoreAPI` servers.
-The `<path>` can be a glob pattern so you can specify several files using a single flag. 
+The `<path>` can be a glob pattern so you can specify several files using a single flag.
 
 The flag `--store.sd-interval=<5m>` can be used to change the fallback re-read interval from the default 5 minutes.
 
 ### Thanos Rule
 
 The repeatable flag `--query.sd-files=<path>` can be used to specify the path to files that contain addresses of `QueryAPI` servers.
-Again, the `<path>` can be a glob pattern. 
+Again, the `<path>` can be a glob pattern.
 
 The flag `--query.sd-interval=<5m>` can be used to change the fallback re-read interval.
 
 ## DNS Service Discovery
 
-DNS Service Discovery is another mechanism for finding components that can be used in conjunction with Static Flags or File SD. 
+DNS Service Discovery is another mechanism for finding components that can be used in conjunction with Static Flags or File SD.
 With DNS SD, a domain name can be specified and it will be periodically queried to discover a list of IPs.
 
 To use DNS SD, just add one of the following prefixes to the domain name in your configuration:
 
-* `dns+` - the domain name after this prefix will be looked up as an A/AAAA query. *A port is required for this query type*. 
+* `dns+` - the domain name after this prefix will be looked up as an A/AAAA query. *A port is required for this query type*.
 An example using this lookup with a static flag:
 ```
 --store=dns+stores.thanos.mycompany.org:9090
@@ -77,10 +77,10 @@ one from the query results will be used. An example:
 --store=dnssrv+_thanosstores._tcp.mycompany.org
 ```
 
-The default interval between DNS lookups is 30s. You can change it using the `store.sd-dns-interval` flag for `StoreAPI` 
+The default interval between DNS lookups is 30s. You can change it using the `store.sd-dns-interval` flag for `StoreAPI`
 configuration in `Thanos Query`, or `query.sd-dns-interval` for `QueryAPI` configuration in `Thanos Rule`.
 
 ## Other
 
-Currently, there are no plans of adding other Service Discovery mechanisms like Consul SD, kube SD, etc. However, we welcome 
+Currently, there are no plans of adding other Service Discovery mechanisms like Consul SD, kube SD, etc. However, we welcome
 people implementing their preferred Service Discovery by writing the results to File SD which will propagate them to the different Thanos components.

--- a/examples/alerts/alerts.md
+++ b/examples/alerts/alerts.md
@@ -12,7 +12,7 @@ Here are some example alerts configured for Kubernetes environment.
     team: TEAM
   annotations:
     summary: Thanos compaction has failed to run and now is halted
-    impact: Long term storage queries will be slower 
+    impact: Long term storage queries will be slower
     action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
     dashboard: COMPACTION_URL
 - alert: ThanosCompactCompactionsFailed
@@ -21,7 +21,7 @@ Here are some example alerts configured for Kubernetes environment.
     team: TEAM
   annotations:
     summary: Thanos Compact is failing compaction
-    impact: Long term storage queries will be slower 
+    impact: Long term storage queries will be slower
     action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
     dashboard: COMPACTION_URL
 - alert: ThanosCompactBucketOperationsFailed
@@ -30,7 +30,7 @@ Here are some example alerts configured for Kubernetes environment.
     team: TEAM
   annotations:
     summary: Thanos Compact bucket operations are failing
-    impact: Long term storage queries will be slower 
+    impact: Long term storage queries will be slower
     action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
     dashboard: COMPACTION_URL
 - alert: ThanosCompactNotRunIn24Hours
@@ -39,7 +39,7 @@ Here are some example alerts configured for Kubernetes environment.
     team: TEAM
   annotations:
     summary: Thanos Compaction has not been run in 24 hours
-    impact: Long term storage queries will be slower 
+    impact: Long term storage queries will be slower
     action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
     dashboard: COMPACTION_URL
 - alert: ThanosComactionIsNotRunning
@@ -49,7 +49,7 @@ Here are some example alerts configured for Kubernetes environment.
     team: TEAM
   annotations:
     summary: Thanos Compaction is not running
-    impact: Long term storage queries will be slower 
+    impact: Long term storage queries will be slower
     action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
     dashboard: COMPACTION_URL
 - alert: ThanosComactionMultipleCompactionsAreRunning
@@ -111,7 +111,7 @@ For Thanos ruler we run some alerts in local Prometheus, to make sure that Thano
   labels:
     team: TEAM
   annotations:
-    summary: Thanos Store is returning Internal/Unavailable errors 
+    summary: Thanos Store is returning Internal/Unavailable errors
     impact: Long Term Storage Prometheus queries are failing
     action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
     dashboard: GATEWAY_URL
@@ -156,7 +156,7 @@ For Thanos ruler we run some alerts in local Prometheus, to make sure that Thano
   labels:
     team: TEAM
   annotations:
-    summary: Thanos Sidecar is returning Internal/Unavailable errors 
+    summary: Thanos Sidecar is returning Internal/Unavailable errors
     impact: Prometheus queries are failing
     action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
     dashboard: SIDECAR_URL
@@ -171,7 +171,7 @@ For Thanos ruler we run some alerts in local Prometheus, to make sure that Thano
   labels:
     team: TEAM
   annotations:
-    summary: Thanos Query is returning Internal/Unavailable errors 
+    summary: Thanos Query is returning Internal/Unavailable errors
     impact: Grafana is not showing metrics
     action: Check {{ $labels.kubernetes_pod_name }} pod logs in {{ $labels.kubernetes_namespace}} namespace
     dashboard: QUERY_URL

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -19,6 +19,7 @@ then
   export S3_BUCKET=${MINIO_BUCKET}
   export S3_ENDPOINT=${MINIO_ENDPOINT}
   export S3_INSECURE="true"
+  export S3_V2_SIGNATURE="true"
   rm -rf data/minio
   mkdir -p data/minio
 
@@ -29,6 +30,17 @@ then
   mc config host add tmp http://${MINIO_ENDPOINT} THANOS ITSTHANOSTIME
   mc mb tmp/${MINIO_BUCKET}
   mc config host rm tmp
+
+  cat <<EOF > data/bucket.yml
+type: S3
+config:
+  bucket: $S3_BUCKET
+  endpoint: $S3_ENDPOINT
+  insecure: $S3_INSECURE
+  signature_version2: $S3_V2_SIGANTURE
+  access_key: $S3_ACCESS_KEY
+  secret_key: $S3_SECRET_KEY
+EOF
 fi
 
 # Start three Prometheus servers monitoring themselves.
@@ -86,7 +98,7 @@ do
     --http-address              0.0.0.0:1919${i} \
     --prometheus.url            http://localhost:909${i} \
     --tsdb.path                 data/prom${i} \
-    --gcs.bucket                "${GCS_BUCKET}" \
+    --objstore.config-file      data/bucket.yml \
     --cluster.address           0.0.0.0:1939${i} \
     --cluster.advertise-address 127.0.0.1:1939${i} \
     --cluster.peers             127.0.0.1:19391 &
@@ -100,11 +112,11 @@ if [ -n "${GCS_BUCKET}" -o -n "${S3_ENDPOINT}" ]
 then
   ./thanos store \
     --debug.name                store \
-    --log.level debug \
+    --log.level                 debug \
     --grpc-address              0.0.0.0:19691 \
     --http-address              0.0.0.0:19791 \
     --data-dir                  data/store \
-    --gcs.bucket                "${GCS_BUCKET}" \
+    --objstore.config-file      data/bucket.yml \
     --cluster.address           0.0.0.0:19891 \
     --cluster.advertise-address 127.0.0.1:19891 \
     --cluster.peers             127.0.0.1:19391 &

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -37,7 +37,7 @@ config:
   bucket: $S3_BUCKET
   endpoint: $S3_ENDPOINT
   insecure: $S3_INSECURE
-  signature_version2: $S3_V2_SIGANTURE
+  signature_version2: $S3_V2_SIGNATURE
   access_key: $S3_ACCESS_KEY
   secret_key: $S3_SECRET_KEY
 EOF


### PR DESCRIPTION
## Changes
Updated documentation and example script to use `--objstore.config-file`
Update S3 signature, reporting that AWS now require `signature-version2: false`
Cleanup some whitespace in the end of line
## Verification
Documentation mostly
the script, i did check with https://www.shellcheck.net/