### PR TITLE
Fixed store label values api to add also external label values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+### Fixed
+
+- [#649](https://github.com/improbable-eng/thanos/issues/649) - Fixed store label values api to add also external label values.
+
 ## [v0.2.1](https://github.com/improbable-eng/thanos/releases/tag/v0.2.1) - 2018.12.27
 
 ### Added
@@ -30,7 +34,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ## [v0.2.0](https://github.com/improbable-eng/thanos/releases/tag/v0.2.0) - 2018.12.10
 
 Next Thanos release adding support to new discovery method, gRPC mTLS and two new object store providers (Swift and Azure).
- 
+
 Note lots of necessary breaking changes in flags that relates to bucket configuration.
 
 ### Deprecated
@@ -56,7 +60,7 @@ Note lots of necessary breaking changes in flags that relates to bucket configur
 ### Changed
 
 - *breaking*: Added `thanos_` prefix to memberlist (gossip) metrics. Make sure to update your dashboards and rules.
-- S3 provider: 
+- S3 provider:
   - Set `"X-Amz-Acl": "bucket-owner-full-control"` metadata for s3 upload operation.
 
 ### Added
@@ -70,7 +74,7 @@ Note lots of necessary breaking changes in flags that relates to bucket configur
 - In `thanos query`, file based discovery of store nodes using `--store.file-sd-config.files`
 - `/-/healthy` endpoint to Querier.
 - DNS service discovery to static and file based configurations using the `dns+` and `dnssrv+` prefixes for the respective lookup. Details [here](/docs/service_discovery.md)
-- `--cluster.disable` flag to disable gossip functionality completely. 
+- `--cluster.disable` flag to disable gossip functionality completely.
 - Hidden flag to configure max compaction level.
 - Azure Storage.
 - OpenStack Swift support.

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -312,39 +312,15 @@ func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesR
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-func deduplicateAndSortStringSlice(srtings []string) []string {
-	sort.Strings(srtings)
-	j := 0
-	for i := 1; i < len(srtings); i++ {
-		if srtings[j] == srtings[i] {
-			continue
-		}
-		j++
-		srtings[i], srtings[j] = srtings[j], srtings[i]
-	}
-	return srtings[:j+1]
-}
-
-// extendSortAndDeduplicateLabelValues adds values of matching label name from external labels.
-func (p *PrometheusStore) extendSortAndDeduplicateLabelValues(labelName string, labelValues []string) []string {
-	externalLabels := p.externalLabels()
-	finalLabels := make([]string, 0, len(labelValues)+len(externalLabels))
-	for _, l := range labelValues {
-		finalLabels = append(finalLabels, l)
-	}
-	for _, l := range externalLabels {
-		if l.Name == labelName {
-			finalLabels = append(finalLabels, l.Value)
-		}
-	}
-	// Additional external labels values can be duplicit so we need to deduplicate them.
-	return deduplicateAndSortStringSlice(finalLabels)
-}
-
 // LabelValues returns all known label values for a given label name.
-func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequest) (
-	*storepb.LabelValuesResponse, error,
-) {
+func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequest) (*storepb.LabelValuesResponse, error) {
+	externalLset := p.externalLabels()
+
+	// First check for matching external label which has priority.
+	if l := externalLset.Get(r.Label); l != "" {
+		return &storepb.LabelValuesResponse{Values: []string{l}}, nil
+	}
+
 	u := *p.base
 	u.Path = path.Join(u.Path, "/api/v1/label/", r.Label, "/values")
 
@@ -368,9 +344,7 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
+	sort.Strings(m.Data)
 
-	// We need to add also possible matching external labels.
-	extendedLabels := p.extendSortAndDeduplicateLabelValues(r.Label, m.Data)
-
-	return &storepb.LabelValuesResponse{Values: extendedLabels}, nil
+	return &storepb.LabelValuesResponse{Values: m.Data}, nil
 }


### PR DESCRIPTION
Signed-off-by: Martin Chodur <m.chodur@seznam.cz>
Fixes https://github.com/improbable-eng/thanos/issues/649

This fixes missing external label values in query HTTP API endpoit `/api/v1/label/<label_name/values>`.
Till now it only added label values returned from Prometheus instance and did not add it's own external labels.

@bwplotka If you could please take a look I'm not sure if Store node and Rule node uses the same code I verified it works only for Sidecar. Thanks in advance!

## Changes

1. Store adds it's values of matching external label by name
1. De-duplicates resulting values because external labels can have same value as Prometheus labels.
1. Tests for external labels  

## Verification

Tests are passing and it was tested on real-world Prometheus instance with sidecar and query pointing to it. All worked as expected.  Did not test with Store node and Rule node.