### PR TITLE
Fix thanos rule alertmanager dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
+- Thanos Rule Alertmanager DNS SD bug
 - DNS SD bug when having SRV results with different ports.
 
 ## [v0.2.0](https://github.com/improbable-eng/thanos/releases/tag/v0.2.0) - 2018.12.10

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -758,7 +758,7 @@ func (s *alertmanagerSet) update(ctx context.Context) error {
 		host := u.Host
 		if qtype != "" {
 			if qtype == dns.A {
-				_, _, err = net.SplitHostPort(name)
+				_, _, err = net.SplitHostPort(host)
 				if err != nil {
 					// The host could be missing a port. Append the defaultAlertmanagerPort.
 					host = host + ":" + strconv.Itoa(defaultAlertmanagerPort)

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
+	"net/url"
 	"testing"
 
+	"github.com/improbable-eng/thanos/pkg/discovery/dns"
 	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 )
 
@@ -31,4 +35,63 @@ func TestRule_UnmarshalScalarResponse(t *testing.T) {
 	// Test invalid format of scalar data.
 	vectorResult, err = convertScalarJSONToVector(invalidDataScalarJSONResult)
 	testutil.NotOk(t, err)
+}
+
+func TestRule_AlertmanagerResolveWithoutPort(t *testing.T) {
+	mockResolver := mockResolver{
+		resultIPs: map[string][]string{
+			"alertmanager.com:9093": []string{"1.1.1.1:9300"},
+		},
+	}
+	am := alertmanagerSet{resolver: mockResolver, addrs: []string{"dns+http://alertmanager.com"}}
+
+	ctx := context.TODO()
+	err := am.update(ctx)
+	testutil.Ok(t, err)
+
+	expected := []*url.URL{
+		{
+			Scheme: "http",
+			Host:   "1.1.1.1:9300",
+		},
+	}
+	gotURLs := am.get()
+	testutil.Equals(t, expected, gotURLs)
+}
+
+func TestRule_AlertmanagerResolveWithPort(t *testing.T) {
+	mockResolver := mockResolver{
+		resultIPs: map[string][]string{
+			"alertmanager.com:19093": []string{"1.1.1.1:9300"},
+		},
+	}
+	am := alertmanagerSet{resolver: mockResolver, addrs: []string{"dns+http://alertmanager.com:19093"}}
+
+	ctx := context.TODO()
+	err := am.update(ctx)
+	testutil.Ok(t, err)
+
+	expected := []*url.URL{
+		{
+			Scheme: "http",
+			Host:   "1.1.1.1:9300",
+		},
+	}
+	gotURLs := am.get()
+	testutil.Equals(t, expected, gotURLs)
+}
+
+type mockResolver struct {
+	resultIPs map[string][]string
+	err       error
+}
+
+func (m mockResolver) Resolve(ctx context.Context, name string, qtype dns.QType) ([]string, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if res, ok := m.resultIPs[name]; ok {
+		return res, nil
+	}
+	return nil, errors.Errorf("mockResolver not found response for name: %s", name)
 }


### PR DESCRIPTION
## Changes

Fixes https://github.com/improbable-eng/thanos/issues/680

## Verification

Tested this code with docker image:
```
povilasv/thanos:fix-thanos-rule-alertmanager-dns-2018-12-13-99b00b0
```
