### PR TITLE
Upgraded Prometheus and TSDB deps.

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,7 +37,8 @@ ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
   name = "github.com/prometheus/common"
 
 [[constraint]]
-  version = "v2.3.2"
+  # TODO(bwplotka): Move to released version once our recent fixes will be released (v2.7.0)
+  revision = "3bd41cc92c7800cc6072171bd4237406126fa169"
   name = "github.com/prometheus/prometheus"
 
 [[override]]
@@ -46,7 +47,7 @@ ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
 
 [[constraint]]
   name = "github.com/prometheus/tsdb"
-  revision = "bd832fc8274e8fe63999ac749daaaff9d881241f"
+  version = "v0.4.0"
 
 [[constraint]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,9 @@ PROTOC_VERSION    ?= 3.4.0
 
 # E2e test deps.
 # Referenced by github.com/improbable-eng/thanos/blob/master/docs/getting_started.md#prometheus
-SUPPORTED_PROM_VERSIONS ?=v2.0.0 v2.2.1 v2.3.2 v2.4.3 v2.5.0
+
+# Limitied prom version, because testing was not possibe. This should fix it: https://github.com/improbable-eng/thanos/issues/758
+SUPPORTED_PROM_VERSIONS ?=v2.4.3 v2.5.0
 ALERTMANAGER_VERSION    ?=v0.15.2
 MINIO_SERVER_VERSION    ?=RELEASE.2018-10-06T00-15-16Z
 

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -10,10 +10,9 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/prometheus/tsdb/labels"
-
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
 	"github.com/improbable-eng/thanos/pkg/objstore/client"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/verifier"
@@ -23,6 +22,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/tsdb/labels"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -254,7 +254,7 @@ func registerBucket(m map[string]setupFunc, app *kingpin.Application, name strin
 		defer cancel()
 
 		// Getting Metas.
-		var blockMetas []*block.Meta
+		var blockMetas []*metadata.Meta
 		if err = bkt.Iter(ctx, "", func(name string) error {
 			id, ok := block.IsBlockDir(name)
 			if !ok {
@@ -277,7 +277,7 @@ func registerBucket(m map[string]setupFunc, app *kingpin.Application, name strin
 	}
 }
 
-func printTable(blockMetas []*block.Meta, selectorLabels labels.Labels, sortBy []string) error {
+func printTable(blockMetas []*metadata.Meta, selectorLabels labels.Labels, sortBy []string) error {
 	header := inspectColumns
 
 	var lines [][]string
@@ -355,7 +355,7 @@ func getKeysAlphabetically(labels map[string]string) []string {
 
 // matchesSelector checks if blockMeta contains every label from
 // the selector with the correct value
-func matchesSelector(blockMeta *block.Meta, selectorLabels labels.Labels) bool {
+func matchesSelector(blockMeta *metadata.Meta, selectorLabels labels.Labels) bool {
 	for _, l := range selectorLabels {
 		if v, ok := blockMeta.Thanos.Labels[l.Name]; !ok || v != l.Value {
 			return false

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -296,7 +296,16 @@ func runQuery(
 			return stores.Get(), nil
 		}, selectorLset)
 		queryableCreator = query.NewQueryableCreator(logger, proxy, replicaLabel)
-		engine           = promql.NewEngine(logger, reg, maxConcurrentQueries, queryTimeout)
+		engine           = promql.NewEngine(
+			promql.EngineOpts{
+				Logger:        logger,
+				Reg:           reg,
+				MaxConcurrent: maxConcurrentQueries,
+				// TODO(bwplotka): Expose this as a flag: https://github.com/improbable-eng/thanos/issues/703
+				MaxSamples: math.MaxInt32,
+				Timeout:    queryTimeout,
+			},
+		)
 	)
 	// Periodically update the store set with the addresses we see in our cluster.
 	{

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -5,10 +5,11 @@ package block
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
+
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
 
 	"fmt"
 
@@ -17,8 +18,6 @@ import (
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
-	"github.com/prometheus/tsdb"
-	"github.com/prometheus/tsdb/fileutil"
 )
 
 const (
@@ -32,103 +31,6 @@ const (
 	// DebugMetas is a directory for debug meta files that happen in the past. Useful for debugging.
 	DebugMetas = "debug/metas"
 )
-
-type SourceType string
-
-const (
-	UnknownSource         SourceType = ""
-	SidecarSource         SourceType = "sidecar"
-	CompactorSource       SourceType = "compactor"
-	CompactorRepairSource SourceType = "compactor.repair"
-	RulerSource           SourceType = "ruler"
-	BucketRepairSource    SourceType = "bucket.repair"
-	TestSource            SourceType = "test"
-)
-
-// Meta describes the a block's meta. It wraps the known TSDB meta structure and
-// extends it by Thanos-specific fields.
-type Meta struct {
-	Version int `json:"version"`
-
-	tsdb.BlockMeta
-
-	Thanos ThanosMeta `json:"thanos"`
-}
-
-// ThanosMeta holds block meta information specific to Thanos.
-type ThanosMeta struct {
-	Labels     map[string]string    `json:"labels"`
-	Downsample ThanosDownsampleMeta `json:"downsample"`
-
-	// Source is a real upload source of the block.
-	Source SourceType `json:"source"`
-}
-
-type ThanosDownsampleMeta struct {
-	Resolution int64 `json:"resolution"`
-}
-
-// WriteMetaFile writes the given meta into <dir>/meta.json.
-func WriteMetaFile(logger log.Logger, dir string, meta *Meta) error {
-	// Make any changes to the file appear atomic.
-	path := filepath.Join(dir, MetaFilename)
-	tmp := path + ".tmp"
-
-	f, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "\t")
-
-	if err := enc.Encode(meta); err != nil {
-		runutil.CloseWithLogOnErr(logger, f, "close meta")
-		return err
-	}
-	if err := f.Close(); err != nil {
-		return err
-	}
-	return renameFile(logger, tmp, path)
-}
-
-// ReadMetaFile reads the given meta from <dir>/meta.json.
-func ReadMetaFile(dir string) (*Meta, error) {
-	b, err := ioutil.ReadFile(filepath.Join(dir, MetaFilename))
-	if err != nil {
-		return nil, err
-	}
-	var m Meta
-
-	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, err
-	}
-	if m.Version != 1 {
-		return nil, errors.Errorf("unexpected meta file version %d", m.Version)
-	}
-	return &m, nil
-}
-
-func renameFile(logger log.Logger, from, to string) error {
-	if err := os.RemoveAll(to); err != nil {
-		return err
-	}
-	if err := os.Rename(from, to); err != nil {
-		return err
-	}
-
-	// Directory was renamed; sync parent dir to persist rename.
-	pdir, err := fileutil.OpenDir(filepath.Dir(to))
-	if err != nil {
-		return err
-	}
-
-	if err = fileutil.Fsync(pdir); err != nil {
-		runutil.CloseWithLogOnErr(logger, pdir, "close dir")
-		return err
-	}
-	return pdir.Close()
-}
 
 // Download downloads directory that is mean to be block directory.
 func Download(ctx context.Context, logger log.Logger, bucket objstore.Bucket, id ulid.ULID, dst string) error {
@@ -169,7 +71,7 @@ func Upload(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bdir st
 		return errors.Wrap(err, "not a block dir")
 	}
 
-	meta, err := ReadMetaFile(bdir)
+	meta, err := metadata.Read(bdir)
 	if err != nil {
 		// No meta or broken meta file.
 		return errors.Wrap(err, "read meta")
@@ -216,16 +118,16 @@ func Delete(ctx context.Context, bucket objstore.Bucket, id ulid.ULID) error {
 }
 
 // DownloadMeta downloads only meta file from bucket by block ID.
-func DownloadMeta(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID) (Meta, error) {
+func DownloadMeta(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID) (metadata.Meta, error) {
 	rc, err := bkt.Get(ctx, path.Join(id.String(), MetaFilename))
 	if err != nil {
-		return Meta{}, errors.Wrapf(err, "meta.json bkt get for %s", id.String())
+		return metadata.Meta{}, errors.Wrapf(err, "meta.json bkt get for %s", id.String())
 	}
 	defer runutil.CloseWithLogOnErr(logger, rc, "download meta bucket client")
 
-	var m Meta
+	var m metadata.Meta
 	if err := json.NewDecoder(rc).Decode(&m); err != nil {
-		return Meta{}, errors.Wrapf(err, "decode meta.json for block %s", id.String())
+		return metadata.Meta{}, errors.Wrapf(err, "decode meta.json for block %s", id.String())
 	}
 	return m, nil
 }
@@ -233,25 +135,4 @@ func DownloadMeta(ctx context.Context, logger log.Logger, bkt objstore.Bucket, i
 func IsBlockDir(path string) (id ulid.ULID, ok bool) {
 	id, err := ulid.Parse(filepath.Base(path))
 	return id, err == nil
-}
-
-// InjectThanosMeta sets Thanos meta to the block meta JSON and saves it to the disk.
-// NOTE: It should be used after writing any block by any Thanos component, otherwise we will miss crucial metadata.
-func InjectThanosMeta(logger log.Logger, bdir string, meta ThanosMeta, downsampledMeta *tsdb.BlockMeta) (*Meta, error) {
-	newMeta, err := ReadMetaFile(bdir)
-	if err != nil {
-		return nil, errors.Wrap(err, "read new meta")
-	}
-	newMeta.Thanos = meta
-
-	// While downsampling we need to copy original compaction.
-	if downsampledMeta != nil {
-		newMeta.Compaction = downsampledMeta.Compaction
-	}
-
-	if err := WriteMetaFile(logger, bdir, newMeta); err != nil {
-		return nil, errors.Wrap(err, "write new meta")
-	}
-
-	return newMeta, nil
 }

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -11,6 +11,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
+
+	"github.com/prometheus/tsdb/fileutil"
+
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/oklog/ulid"
@@ -36,23 +40,84 @@ type indexCache struct {
 	Postings    []postingsRange
 }
 
+type realByteSlice []byte
+
+func (b realByteSlice) Len() int {
+	return len(b)
+}
+
+func (b realByteSlice) Range(start, end int) []byte {
+	return b[start:end]
+}
+
+func (b realByteSlice) Sub(start, end int) index.ByteSlice {
+	return b[start:end]
+}
+
+func getSymbolTable(b index.ByteSlice) (map[uint32]string, error) {
+	version := int(b.Range(4, 5)[0])
+
+	if version != 1 && version != 2 {
+		return nil, errors.Errorf("unknown index file version %d", version)
+	}
+
+	toc, err := index.NewTOCFromByteSlice(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "read TOC")
+	}
+
+	symbolsV2, symbolsV1, err := index.ReadSymbols(b, version, int(toc.Symbols))
+	if err != nil {
+		return nil, errors.Wrap(err, "read symbols")
+	}
+
+	symbolsTable := make(map[uint32]string, len(symbolsV1)+len(symbolsV2))
+	for o, s := range symbolsV1 {
+		symbolsTable[o] = s
+	}
+	for o, s := range symbolsV2 {
+		symbolsTable[uint32(o)] = s
+	}
+
+	return symbolsTable, nil
+}
+
 // WriteIndexCache writes a cache file containing the first lookup stages
 // for an index file.
-func WriteIndexCache(logger log.Logger, fn string, r *index.Reader) error {
+func WriteIndexCache(logger log.Logger, indexFn string, fn string) error {
+	indexFile, err := fileutil.OpenMmapFile(indexFn)
+	if err != nil {
+		return errors.Wrapf(err, "open mmap index file %s", indexFn)
+	}
+	defer runutil.CloseWithLogOnErr(logger, indexFile, "close index cache mmap file from %s", indexFn)
+
+	b := realByteSlice(indexFile.Bytes())
+	indexr, err := index.NewReader(b)
+	if err != nil {
+		return errors.Wrap(err, "open index reader")
+	}
+	defer runutil.CloseWithLogOnErr(logger, indexr, "load index cache reader")
+
+	// We assume reader verified index already.
+	symbols, err := getSymbolTable(b)
+	if err != nil {
+		return err
+	}
+
 	f, err := os.Create(fn)
 	if err != nil {
-		return errors.Wrap(err, "create file")
+		return errors.Wrap(err, "create index cache file")
 	}
 	defer runutil.CloseWithLogOnErr(logger, f, "index cache writer")
 
 	v := indexCache{
-		Version:     r.Version(),
-		Symbols:     r.SymbolTable(),
+		Version:     indexr.Version(),
+		Symbols:     symbols,
 		LabelValues: map[string][]string{},
 	}
 
 	// Extract label value indices.
-	lnames, err := r.LabelIndices()
+	lnames, err := indexr.LabelIndices()
 	if err != nil {
 		return errors.Wrap(err, "read label indices")
 	}
@@ -62,7 +127,7 @@ func WriteIndexCache(logger log.Logger, fn string, r *index.Reader) error {
 		}
 		ln := lns[0]
 
-		tpls, err := r.LabelValues(ln)
+		tpls, err := indexr.LabelValues(ln)
 		if err != nil {
 			return errors.Wrap(err, "get label values")
 		}
@@ -82,7 +147,7 @@ func WriteIndexCache(logger log.Logger, fn string, r *index.Reader) error {
 	}
 
 	// Extract postings ranges.
-	pranges, err := r.PostingsRanges()
+	pranges, err := indexr.PostingsRanges()
 	if err != nil {
 		return errors.Wrap(err, "read postings ranges")
 	}
@@ -346,7 +411,7 @@ type ignoreFnType func(mint, maxt int64, prev *chunks.Meta, curr *chunks.Meta) (
 // - removes all near "complete" outside chunks introduced by https://github.com/prometheus/tsdb/issues/347.
 // Fixable inconsistencies are resolved in the new block.
 // TODO(bplotka): https://github.com/improbable-eng/thanos/issues/378
-func Repair(logger log.Logger, dir string, id ulid.ULID, source SourceType, ignoreChkFns ...ignoreFnType) (resid ulid.ULID, err error) {
+func Repair(logger log.Logger, dir string, id ulid.ULID, source metadata.SourceType, ignoreChkFns ...ignoreFnType) (resid ulid.ULID, err error) {
 	if len(ignoreChkFns) == 0 {
 		return resid, errors.New("no ignore chunk function specified")
 	}
@@ -355,7 +420,7 @@ func Repair(logger log.Logger, dir string, id ulid.ULID, source SourceType, igno
 	entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
 	resid = ulid.MustNew(ulid.Now(), entropy)
 
-	meta, err := ReadMetaFile(bdir)
+	meta, err := metadata.Read(bdir)
 	if err != nil {
 		return resid, errors.Wrap(err, "read meta file")
 	}
@@ -363,7 +428,7 @@ func Repair(logger log.Logger, dir string, id ulid.ULID, source SourceType, igno
 		return resid, errors.New("cannot repair downsampled block")
 	}
 
-	b, err := tsdb.OpenBlock(bdir, nil)
+	b, err := tsdb.OpenBlock(logger, bdir, nil)
 	if err != nil {
 		return resid, errors.Wrap(err, "open block")
 	}
@@ -405,7 +470,7 @@ func Repair(logger log.Logger, dir string, id ulid.ULID, source SourceType, igno
 	if err := rewrite(indexr, chunkr, indexw, chunkw, &resmeta, ignoreChkFns); err != nil {
 		return resid, errors.Wrap(err, "rewrite block")
 	}
-	if err := WriteMetaFile(logger, resdir, &resmeta); err != nil {
+	if err := metadata.Write(logger, resdir, &resmeta); err != nil {
 		return resid, err
 	}
 	return resid, nil
@@ -494,7 +559,7 @@ OUTER:
 func rewrite(
 	indexr tsdb.IndexReader, chunkr tsdb.ChunkReader,
 	indexw tsdb.IndexWriter, chunkw tsdb.ChunkWriter,
-	meta *Meta,
+	meta *metadata.Meta,
 	ignoreChkFns []ignoreFnType,
 ) error {
 	symbols, err := indexr.Symbols()

--- a/pkg/block/index_test.go
+++ b/pkg/block/index_test.go
@@ -1,0 +1,46 @@
+package block
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/prometheus/tsdb/labels"
+)
+
+func TestWriteReadIndexCache(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test-compact-prepare")
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	b, err := testutil.CreateBlock(tmpDir, []labels.Labels{
+		{{Name: "a", Value: "1"}},
+		{{Name: "a", Value: "2"}},
+		{{Name: "a", Value: "3"}},
+		{{Name: "a", Value: "4"}},
+		{{Name: "b", Value: "1"}},
+	}, 100, 0, 1000, nil, 124)
+	testutil.Ok(t, err)
+
+	fn := filepath.Join(tmpDir, "index.cache.json")
+	testutil.Ok(t, WriteIndexCache(log.NewNopLogger(), filepath.Join(tmpDir, b.String(), "index"), fn))
+
+	version, symbols, lvals, postings, err := ReadIndexCache(log.NewNopLogger(), fn)
+	testutil.Ok(t, err)
+
+	testutil.Equals(t, 2, version)
+	testutil.Equals(t, 6, len(symbols))
+	testutil.Equals(t, 2, len(lvals))
+
+	vals, ok := lvals["a"]
+	testutil.Assert(t, ok, "")
+	testutil.Equals(t, []string{"1", "2", "3", "4"}, vals)
+
+	vals, ok = lvals["b"]
+	testutil.Assert(t, ok, "")
+	testutil.Equals(t, []string{"1"}, vals)
+	testutil.Equals(t, 6, len(postings))
+}

--- a/pkg/block/metadata/meta.go
+++ b/pkg/block/metadata/meta.go
@@ -1,0 +1,142 @@
+package metadata
+
+// metadata package implements writing and reading wrapped meta.json where Thanos puts its metadata.
+// Those metadata contains external labels, downsampling resolution and source type.
+// This package is minimal and separated because it used by testutils which limits test helpers we can use in
+// this package.
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/go-kit/kit/log"
+	"github.com/improbable-eng/thanos/pkg/runutil"
+	"github.com/pkg/errors"
+	"github.com/prometheus/tsdb"
+	"github.com/prometheus/tsdb/fileutil"
+)
+
+type SourceType string
+
+const (
+	UnknownSource         SourceType = ""
+	SidecarSource         SourceType = "sidecar"
+	CompactorSource       SourceType = "compactor"
+	CompactorRepairSource SourceType = "compactor.repair"
+	RulerSource           SourceType = "ruler"
+	BucketRepairSource    SourceType = "bucket.repair"
+	TestSource            SourceType = "test"
+)
+
+const (
+	// MetaFilename is the known JSON filename for meta information.
+	MetaFilename = "meta.json"
+)
+
+// Meta describes the a block's meta. It wraps the known TSDB meta structure and
+// extends it by Thanos-specific fields.
+type Meta struct {
+	Version int `json:"version"`
+
+	tsdb.BlockMeta
+
+	Thanos Thanos `json:"thanos"`
+}
+
+// Thanos holds block meta information specific to Thanos.
+type Thanos struct {
+	Labels     map[string]string `json:"labels"`
+	Downsample ThanosDownsample  `json:"downsample"`
+
+	// Source is a real upload source of the block.
+	Source SourceType `json:"source"`
+}
+
+type ThanosDownsample struct {
+	Resolution int64 `json:"resolution"`
+}
+
+// InjectThanos sets Thanos meta to the block meta JSON and saves it to the disk.
+// NOTE: It should be used after writing any block by any Thanos component, otherwise we will miss crucial metadata.
+func InjectThanos(logger log.Logger, bdir string, meta Thanos, downsampledMeta *tsdb.BlockMeta) (*Meta, error) {
+	newMeta, err := Read(bdir)
+	if err != nil {
+		return nil, errors.Wrap(err, "read new meta")
+	}
+	newMeta.Thanos = meta
+
+	// While downsampling we need to copy original compaction.
+	if downsampledMeta != nil {
+		newMeta.Compaction = downsampledMeta.Compaction
+	}
+
+	if err := Write(logger, bdir, newMeta); err != nil {
+		return nil, errors.Wrap(err, "write new meta")
+	}
+
+	return newMeta, nil
+}
+
+// Write writes the given meta into <dir>/meta.json.
+func Write(logger log.Logger, dir string, meta *Meta) error {
+	// Make any changes to the file appear atomic.
+	path := filepath.Join(dir, MetaFilename)
+	tmp := path + ".tmp"
+
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "\t")
+
+	if err := enc.Encode(meta); err != nil {
+		runutil.CloseWithLogOnErr(logger, f, "close meta")
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return renameFile(logger, tmp, path)
+}
+
+func renameFile(logger log.Logger, from, to string) error {
+	if err := os.RemoveAll(to); err != nil {
+		return err
+	}
+	if err := os.Rename(from, to); err != nil {
+		return err
+	}
+
+	// Directory was renamed; sync parent dir to persist rename.
+	pdir, err := fileutil.OpenDir(filepath.Dir(to))
+	if err != nil {
+		return err
+	}
+
+	if err = fileutil.Fsync(pdir); err != nil {
+		runutil.CloseWithLogOnErr(logger, pdir, "close dir")
+		return err
+	}
+	return pdir.Close()
+}
+
+// Read reads the given meta from <dir>/meta.json.
+func Read(dir string) (*Meta, error) {
+	b, err := ioutil.ReadFile(filepath.Join(dir, MetaFilename))
+	if err != nil {
+		return nil, err
+	}
+	var m Meta
+
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	if m.Version != 1 {
+		return nil, errors.Errorf("unexpected meta file version %d", m.Version)
+	}
+	return &m, nil
+}

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -15,12 +16,14 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
 	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/objtesting"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb"
+	"github.com/prometheus/tsdb/index"
 	"github.com/prometheus/tsdb/labels"
 )
 
@@ -37,13 +40,13 @@ func TestSyncer_SyncMetas_e2e(t *testing.T) {
 		// After the first synchronization the first 5 should be dropped and the
 		// last 5 be loaded from the bucket.
 		var ids []ulid.ULID
-		var metas []*block.Meta
+		var metas []*metadata.Meta
 
 		for i := 0; i < 15; i++ {
 			id, err := ulid.New(uint64(i), nil)
 			testutil.Ok(t, err)
 
-			var meta block.Meta
+			var meta metadata.Meta
 			meta.Version = 1
 			meta.ULID = id
 
@@ -56,7 +59,7 @@ func TestSyncer_SyncMetas_e2e(t *testing.T) {
 		for _, m := range metas[5:] {
 			var buf bytes.Buffer
 			testutil.Ok(t, json.NewEncoder(&buf).Encode(&m))
-			testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), block.MetaFilename), &buf))
+			testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), metadata.MetaFilename), &buf))
 		}
 
 		groups, err := sy.Groups()
@@ -79,11 +82,11 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 
 		// Generate 10 source block metas and construct higher level blocks
 		// that are higher compactions of them.
-		var metas []*block.Meta
+		var metas []*metadata.Meta
 		var ids []ulid.ULID
 
 		for i := 0; i < 10; i++ {
-			var m block.Meta
+			var m metadata.Meta
 
 			m.Version = 1
 			m.ULID = ulid.MustNew(uint64(i), nil)
@@ -94,28 +97,28 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 			metas = append(metas, &m)
 		}
 
-		var m1 block.Meta
+		var m1 metadata.Meta
 		m1.Version = 1
 		m1.ULID = ulid.MustNew(100, nil)
 		m1.Compaction.Level = 2
 		m1.Compaction.Sources = ids[:4]
 		m1.Thanos.Downsample.Resolution = 0
 
-		var m2 block.Meta
+		var m2 metadata.Meta
 		m2.Version = 1
 		m2.ULID = ulid.MustNew(200, nil)
 		m2.Compaction.Level = 2
 		m2.Compaction.Sources = ids[4:8] // last two source IDs is not part of a level 2 block.
 		m2.Thanos.Downsample.Resolution = 0
 
-		var m3 block.Meta
+		var m3 metadata.Meta
 		m3.Version = 1
 		m3.ULID = ulid.MustNew(300, nil)
 		m3.Compaction.Level = 3
 		m3.Compaction.Sources = ids[:9] // last source ID is not part of level 3 block.
 		m3.Thanos.Downsample.Resolution = 0
 
-		var m4 block.Meta
+		var m4 metadata.Meta
 		m4.Version = 14
 		m4.ULID = ulid.MustNew(400, nil)
 		m4.Compaction.Level = 2
@@ -127,7 +130,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 			fmt.Println("create", m.ULID)
 			var buf bytes.Buffer
 			testutil.Ok(t, json.NewEncoder(&buf).Encode(&m))
-			testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), block.MetaFilename), &buf))
+			testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), metadata.MetaFilename), &buf))
 		}
 
 		// Do one initial synchronization with the bucket.
@@ -173,7 +176,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
-		var metas []*block.Meta
+		var metas []*metadata.Meta
 		extLset := labels.Labels{{Name: "e1", Value: "1"}}
 		b1, err := testutil.CreateBlock(prepareDir, []labels.Labels{
 			{{Name: "a", Value: "1"}},
@@ -183,7 +186,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		}, 100, 0, 1000, extLset, 124)
 		testutil.Ok(t, err)
 
-		meta, err := block.ReadMetaFile(filepath.Join(prepareDir, b1.String()))
+		meta, err := metadata.Read(filepath.Join(prepareDir, b1.String()))
 		testutil.Ok(t, err)
 		metas = append(metas, meta)
 
@@ -196,15 +199,18 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		testutil.Ok(t, err)
 
 		// Mix order to make sure compact is able to deduct min time / max time.
-		meta, err = block.ReadMetaFile(filepath.Join(prepareDir, b3.String()))
+		meta, err = metadata.Read(filepath.Join(prepareDir, b3.String()))
 		testutil.Ok(t, err)
 		metas = append(metas, meta)
 
-		// Empty block. This can happen when TSDB does not have any samples for min-block-size time.
-		b2, err := testutil.CreateBlock(prepareDir, []labels.Labels{}, 100, 1001, 2000, extLset, 124)
+		// Currently TSDB does not produces empty blocks (see: https://github.com/prometheus/tsdb/pull/374). However before v2.7.0 it was
+		// so we still want to mimick this case as close as possible.
+		b2, err := createEmptyBlock(prepareDir, 1001, 2000, extLset, 124)
 		testutil.Ok(t, err)
 
-		meta, err = block.ReadMetaFile(filepath.Join(prepareDir, b2.String()))
+		// blocks" count=3 mint=0 maxt=3000 ulid=01D1RQCRRJM77KQQ4GYDSC50GM sources="[01D1RQCRMNZBVHBPGRPG2M3NZQ 01D1RQCRPJMYN45T65YA1PRWB7 01D1RQCRNMTWJKTN5QQXFNKKH8]"
+
+		meta, err = metadata.Read(filepath.Join(prepareDir, b2.String()))
 		testutil.Ok(t, err)
 		metas = append(metas, meta)
 
@@ -217,7 +223,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		}, 100, 3001, 4000, extLset, 124)
 		testutil.Ok(t, err)
 
-		meta, err = block.ReadMetaFile(filepath.Join(prepareDir, freshB.String()))
+		meta, err = metadata.Read(filepath.Join(prepareDir, freshB.String()))
 		testutil.Ok(t, err)
 		metas = append(metas, meta)
 
@@ -263,7 +269,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		resDir := filepath.Join(dir, id.String())
 		testutil.Ok(t, block.Download(ctx, log.NewNopLogger(), bkt, id, resDir))
 
-		meta, err = block.ReadMetaFile(resDir)
+		meta, err = metadata.Read(resDir)
 		testutil.Ok(t, err)
 
 		testutil.Equals(t, int64(0), meta.MinTime)
@@ -293,4 +299,57 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		})
 		testutil.Ok(t, err)
 	})
+}
+
+// createEmptyBlock produces empty block like it was the case before fix: https://github.com/prometheus/tsdb/pull/374.
+// (Prometheus pre v2.7.0)
+func createEmptyBlock(dir string, mint int64, maxt int64, extLset labels.Labels, resolution int64) (ulid.ULID, error) {
+	entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
+	uid := ulid.MustNew(ulid.Now(), entropy)
+
+	if err := os.Mkdir(path.Join(dir, uid.String()), os.ModePerm); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "close index")
+	}
+
+	if err := os.Mkdir(path.Join(dir, uid.String(), "chunks"), os.ModePerm); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "close index")
+	}
+
+	w, err := index.NewWriter(path.Join(dir, uid.String(), "index"))
+	if err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "new index")
+	}
+
+	if err := w.Close(); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "close index")
+	}
+
+	m := tsdb.BlockMeta{
+		Version: 1,
+		ULID:    uid,
+		MinTime: mint,
+		MaxTime: maxt,
+		Compaction: tsdb.BlockMetaCompaction{
+			Level:   1,
+			Sources: []ulid.ULID{uid},
+		},
+	}
+	b, err := json.Marshal(&m)
+	if err != nil {
+		return ulid.ULID{}, err
+	}
+
+	if err := ioutil.WriteFile(path.Join(dir, uid.String(), "meta.json"), b, os.ModePerm); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "saving meta.json")
+	}
+
+	if _, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(dir, uid.String()), metadata.Thanos{
+		Labels:     extLset.Map(),
+		Downsample: metadata.ThanosDownsample{Resolution: resolution},
+		Source:     metadata.TestSource,
+	}, nil); err != nil {
+		return ulid.ULID{}, errors.Wrap(err, "finalize block")
+	}
+
+	return uid, nil
 }

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -1,11 +1,14 @@
 package downsample
 
 import (
+	"github.com/prometheus/tsdb"
 	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
 
 	"github.com/prometheus/prometheus/pkg/value"
 
@@ -59,7 +62,7 @@ func TestDownsampleRaw(t *testing.T) {
 			},
 		},
 	}
-	testDownsample(t, input, &block.Meta{}, 100)
+	testDownsample(t, input, &metadata.Meta{BlockMeta: tsdb.BlockMeta{MinTime: 0, MaxTime: 250}}, 100)
 }
 
 func TestDownsampleAggr(t *testing.T) {
@@ -96,8 +99,9 @@ func TestDownsampleAggr(t *testing.T) {
 			},
 		},
 	}
-	var meta block.Meta
+	var meta metadata.Meta
 	meta.Thanos.Downsample.Resolution = 10
+	meta.BlockMeta = tsdb.BlockMeta{MinTime: 99, MaxTime: 1300}
 
 	testDownsample(t, input, &meta, 500)
 }
@@ -123,7 +127,7 @@ type downsampleTestSet struct {
 
 // testDownsample inserts the input into a block and invokes the downsampler with the given resolution.
 // The chunk ranges within the input block are aligned at 500 time units.
-func testDownsample(t *testing.T, data []*downsampleTestSet, meta *block.Meta, resolution int64) {
+func testDownsample(t *testing.T, data []*downsampleTestSet, meta *metadata.Meta, resolution int64) {
 	t.Helper()
 
 	dir, err := ioutil.TempDir("", "downsample-raw")

--- a/pkg/compact/downsample/pool.go
+++ b/pkg/compact/downsample/pool.go
@@ -6,14 +6,14 @@ import (
 	"github.com/prometheus/tsdb/chunkenc"
 )
 
-// Pool is a memory pool of chunk objects, supporting Thanos aggr chunk encoding.
+// Pool is a memory pool of chunk objects, supporting Thanos aggregated chunk encoding.
 // It maintains separate pools for xor and aggr chunks.
 type pool struct {
 	wrapped chunkenc.Pool
 	aggr    sync.Pool
 }
 
-// TODO(bplotka): Add reasonable limits to our sync pools them to detect OOMs early.
+// TODO(bwplotka): Add reasonable limits to our sync pooling them to detect OOMs early.
 func NewPool() chunkenc.Pool {
 	return &pool{
 		wrapped: chunkenc.NewPool(),
@@ -51,6 +51,7 @@ func (p *pool) Put(c chunkenc.Chunk) error {
 		// Clear []byte.
 		*ac = AggrChunk(nil)
 		p.aggr.Put(ac)
+		return nil
 	}
 
 	return p.wrapped.Put(c)

--- a/pkg/compact/retention_test.go
+++ b/pkg/compact/retention_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
 	"github.com/improbable-eng/thanos/pkg/compact"
 	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/inmem"
@@ -253,15 +253,15 @@ func TestApplyRetentionPolicyByResolution(t *testing.T) {
 
 func uploadMockBlock(t *testing.T, bkt objstore.Bucket, id string, minTime, maxTime time.Time, resolutionLevel int64) {
 	t.Helper()
-	meta1 := block.Meta{
+	meta1 := metadata.Meta{
 		Version: 1,
 		BlockMeta: tsdb.BlockMeta{
 			ULID:    ulid.MustParse(id),
 			MinTime: minTime.Unix() * 1000,
 			MaxTime: maxTime.Unix() * 1000,
 		},
-		Thanos: block.ThanosMeta{
-			Downsample: block.ThanosDownsampleMeta{
+		Thanos: metadata.Thanos{
+			Downsample: metadata.ThanosDownsample{
 				Resolution: resolutionLevel,
 			},
 		},

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -527,15 +527,16 @@ func (api *API) series(r *http.Request) (interface{}, []error, *apiError) {
 
 	var sets []storage.SeriesSet
 	for _, mset := range matcherSets {
-		s, err := q.Select(&storage.SelectParams{}, mset...)
+		s, _, err := q.Select(&storage.SelectParams{}, mset...)
 		if err != nil {
 			return nil, nil, &apiError{errorExec, err}
 		}
 		sets = append(sets, s)
 	}
 
-	set := storage.NewMergeSeriesSet(sets)
-	metrics := []labels.Labels{}
+	set := storage.NewMergeSeriesSet(sets, nil)
+
+	var metrics []labels.Labels
 	for set.Next() {
 		metrics = append(metrics, set.At().Labels())
 	}

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -333,7 +333,7 @@ func TestEndpoints(t *testing.T) {
 				"start":   []string{"-2"},
 				"end":     []string{"-1"},
 			},
-			response: []labels.Labels{},
+			response: []labels.Labels(nil),
 		},
 		// Start and end after series ends.
 		{
@@ -343,7 +343,7 @@ func TestEndpoints(t *testing.T) {
 				"start":   []string{"100000"},
 				"end":     []string{"100001"},
 			},
-			response: []labels.Labels{},
+			response: []labels.Labels(nil),
 		},
 		// Start before series starts, end after series ends.
 		{
@@ -409,33 +409,38 @@ func TestEndpoints(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		// Build a context with the correct request params.
-		ctx := context.Background()
-		for p, v := range test.params {
-			ctx = route.WithParam(ctx, p, v)
-		}
-		t.Logf("run query %q", test.query.Encode())
+		if ok := t.Run(test.query.Encode(), func(t *testing.T) {
+			// Build a context with the correct request params.
+			ctx := context.Background()
+			for p, v := range test.params {
+				ctx = route.WithParam(ctx, p, v)
+			}
 
-		req, err := http.NewRequest("ANY", fmt.Sprintf("http://example.com?%s", test.query.Encode()), nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, _, apiErr := test.endpoint(req.WithContext(ctx))
-		if apiErr != nil {
-			if test.errType == errorNone {
-				t.Fatalf("Unexpected error: %s", apiErr)
+			req, err := http.NewRequest("ANY", fmt.Sprintf("http://example.com?%s", test.query.Encode()), nil)
+			if err != nil {
+				t.Fatal(err)
 			}
-			if test.errType != apiErr.typ {
-				t.Fatalf("Expected error of type %q but got type %q", test.errType, apiErr.typ)
+			resp, _, apiErr := test.endpoint(req.WithContext(ctx))
+			if apiErr != nil {
+				if test.errType == errorNone {
+					t.Fatalf("Unexpected error: %s", apiErr)
+				}
+				if test.errType != apiErr.typ {
+					t.Fatalf("Expected error of type %q but got type %q", test.errType, apiErr.typ)
+				}
+				return
 			}
-			continue
+			if apiErr == nil && test.errType != errorNone {
+				t.Fatalf("Expected error of type %q but got none", test.errType)
+			}
+
+			if !reflect.DeepEqual(resp, test.response) {
+				t.Fatalf("Response does not match, expected:\n%+v\ngot:\n%+v", test.response, resp)
+			}
+		}); !ok {
+			return
 		}
-		if apiErr == nil && test.errType != errorNone {
-			t.Fatalf("Expected error of type %q but got none", test.errType)
-		}
-		if !reflect.DeepEqual(resp, test.response) {
-			t.Fatalf("Response does not match, expected:\n%+v\ngot:\n%+v", test.response, resp)
-		}
+
 	}
 }
 

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -36,7 +36,7 @@ func TestQuerier_Series(t *testing.T) {
 	q := newQuerier(context.Background(), nil, 1, 300, "", testProxy, false, 0, true, nil)
 	defer func() { testutil.Ok(t, q.Close()) }()
 
-	res, err := q.Select(&storage.SelectParams{})
+	res, _, err := q.Select(&storage.SelectParams{})
 	testutil.Ok(t, err)
 
 	expected := []struct {

--- a/pkg/query/test_print.go
+++ b/pkg/query/test_print.go
@@ -1,0 +1,34 @@
+package query
+
+import (
+	"fmt"
+
+	"github.com/prometheus/prometheus/storage"
+)
+
+type printSeriesSet struct {
+	set storage.SeriesSet
+}
+
+func newPrintSeriesSet(set storage.SeriesSet) storage.SeriesSet {
+	return &printSeriesSet{set: set}
+}
+
+func (s *printSeriesSet) Next() bool {
+	return s.set.Next()
+}
+
+func (s *printSeriesSet) At() storage.Series {
+	at := s.set.At()
+	fmt.Println("Series", at.Labels())
+
+	i := at.Iterator()
+	for i.Next() {
+		fmt.Println(i.At())
+	}
+	return at
+}
+
+func (s *printSeriesSet) Err() error {
+	return s.set.Err()
+}

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
 	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/objtesting"
 	"github.com/improbable-eng/thanos/pkg/testutil"
@@ -32,7 +33,7 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 		}()
 
 		extLset := labels.FromStrings("prometheus", "prom-1")
-		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, block.TestSource)
+		shipper := New(log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -54,7 +55,7 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 
 			testutil.Ok(t, os.Mkdir(tmp, 0777))
 
-			meta := block.Meta{
+			meta := metadata.Meta{
 				BlockMeta: tsdb.BlockMeta{
 					MinTime: timestamp.FromTime(now.Add(time.Duration(i) * time.Hour)),
 					MaxTime: timestamp.FromTime(now.Add((time.Duration(i) * time.Hour) + 1)),
@@ -62,7 +63,7 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 			}
 			meta.Version = 1
 			meta.ULID = id
-			meta.Thanos.Source = block.TestSource
+			meta.Thanos.Source = metadata.TestSource
 
 			metab, err := json.Marshal(&meta)
 			testutil.Ok(t, err)

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -2,15 +2,13 @@ package shipper
 
 import (
 	"io/ioutil"
+	"math"
 	"os"
+	"path"
 	"testing"
 
-	"math"
-
-	"path"
-
 	"github.com/go-kit/kit/log"
-	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/oklog/ulid"
 	"github.com/prometheus/tsdb"
@@ -23,7 +21,7 @@ func TestShipperTimestamps(t *testing.T) {
 		testutil.Ok(t, os.RemoveAll(dir))
 	}()
 
-	s := New(nil, nil, dir, nil, nil, block.TestSource)
+	s := New(nil, nil, dir, nil, nil, metadata.TestSource)
 
 	// Missing thanos meta file.
 	_, _, err = s.Timestamps()
@@ -41,7 +39,7 @@ func TestShipperTimestamps(t *testing.T) {
 
 	id1 := ulid.MustNew(1, nil)
 	testutil.Ok(t, os.Mkdir(path.Join(dir, id1.String()), os.ModePerm))
-	testutil.Ok(t, block.WriteMetaFile(log.NewNopLogger(), path.Join(dir, id1.String()), &block.Meta{
+	testutil.Ok(t, metadata.Write(log.NewNopLogger(), path.Join(dir, id1.String()), &metadata.Meta{
 		Version: 1,
 		BlockMeta: tsdb.BlockMeta{
 			ULID:    id1,
@@ -56,7 +54,7 @@ func TestShipperTimestamps(t *testing.T) {
 
 	id2 := ulid.MustNew(2, nil)
 	testutil.Ok(t, os.Mkdir(path.Join(dir, id2.String()), os.ModePerm))
-	testutil.Ok(t, block.WriteMetaFile(log.NewNopLogger(), path.Join(dir, id2.String()), &block.Meta{
+	testutil.Ok(t, metadata.Write(log.NewNopLogger(), path.Join(dir, id2.String()), &metadata.Meta{
 		Version: 1,
 		BlockMeta: tsdb.BlockMeta{
 			ULID:    id2,

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
 	"github.com/improbable-eng/thanos/pkg/objstore"
 	"github.com/improbable-eng/thanos/pkg/objstore/objtesting"
 	"github.com/improbable-eng/thanos/pkg/runutil"
@@ -59,10 +60,10 @@ func prepareStoreWithTestBlocks(t testing.TB, ctx context.Context, dir string, b
 		dir1, dir2 := filepath.Join(dir, id1.String()), filepath.Join(dir, id2.String())
 
 		// Add labels to the meta of the second block.
-		meta, err := block.ReadMetaFile(dir2)
+		meta, err := metadata.Read(dir2)
 		testutil.Ok(t, err)
 		meta.Thanos.Labels = map[string]string{"ext2": "value2"}
-		testutil.Ok(t, block.WriteMetaFile(log.NewNopLogger(), dir2, meta))
+		testutil.Ok(t, metadata.Write(log.NewNopLogger(), dir2, meta))
 
 		testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, dir1))
 		testutil.Ok(t, block.Upload(ctx, log.NewNopLogger(), bkt, dir2))
@@ -72,7 +73,7 @@ func prepareStoreWithTestBlocks(t testing.TB, ctx context.Context, dir string, b
 		testutil.Ok(t, os.RemoveAll(dir2))
 	}
 
-	store, err := NewBucketStore(nil, nil, bkt, dir, 100, 0, false)
+	store, err := NewBucketStore(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, 100, 0, false)
 	testutil.Ok(t, err)
 
 	go func() {

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -4,13 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/oklog/ulid"
-
-	"github.com/improbable-eng/thanos/pkg/compact/downsample"
-
 	"github.com/fortytw2/leaktest"
-	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
+	"github.com/improbable-eng/thanos/pkg/compact/downsample"
 	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/oklog/ulid"
 	"github.com/prometheus/tsdb/labels"
 )
 
@@ -41,7 +39,7 @@ func TestBucketBlockSet_addGet(t *testing.T) {
 	}
 
 	for _, in := range input {
-		var m block.Meta
+		var m metadata.Meta
 		m.Thanos.Downsample.Resolution = in.window
 		m.MinTime = in.mint
 		m.MaxTime = in.maxt
@@ -102,7 +100,7 @@ func TestBucketBlockSet_addGet(t *testing.T) {
 
 		var exp []*bucketBlock
 		for _, b := range c.res {
-			var m block.Meta
+			var m metadata.Meta
 			m.Thanos.Downsample.Resolution = b.window
 			m.MinTime = b.mint
 			m.MaxTime = b.maxt
@@ -129,7 +127,7 @@ func TestBucketBlockSet_remove(t *testing.T) {
 	}
 
 	for _, in := range input {
-		var m block.Meta
+		var m metadata.Meta
 		m.ULID = in.id
 		m.MinTime = in.mint
 		m.MaxTime = in.maxt

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -122,6 +122,7 @@ func TestPrometheusStore_LabelValues_e2e(t *testing.T) {
 	_, err = a.Add(labels.FromStrings("a", "c"), 0, 1)
 	testutil.Ok(t, err)
 	_, err = a.Add(labels.FromStrings("a", "a"), 0, 1)
+	testutil.Ok(t, err)
 	testutil.Ok(t, a.Commit())
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/testutil/prometheus.go
+++ b/pkg/testutil/prometheus.go
@@ -12,8 +12,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
+
 	"github.com/go-kit/kit/log"
-	"github.com/improbable-eng/thanos/pkg/block"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
@@ -157,7 +158,7 @@ func (p *Prometheus) SetConfig(s string) (err error) {
 // Stop terminates Prometheus and clean up its data directory.
 func (p *Prometheus) Stop() error {
 	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-		return errors.Wrapf(err, "failed to Prometheus. Kill it manually and cleanr %s dir", p.db.Dir())
+		return errors.Wrapf(err, "failed to Prometheus. Kill it manually and clean %s dir", p.db.Dir())
 	}
 
 	time.Sleep(time.Second / 2)
@@ -188,7 +189,7 @@ func CreateBlock(
 	extLset labels.Labels,
 	resolution int64,
 ) (id ulid.ULID, err error) {
-	h, err := tsdb.NewHead(nil, nil, tsdb.NopWAL(), 10000000000)
+	h, err := tsdb.NewHead(nil, nil, nil, 10000000000)
 	if err != nil {
 		return id, errors.Wrap(err, "create head block")
 	}
@@ -238,15 +239,15 @@ func CreateBlock(
 		return id, errors.Wrap(err, "create compactor")
 	}
 
-	id, err = c.Write(dir, h, mint, maxt)
+	id, err = c.Write(dir, h, mint, maxt, nil)
 	if err != nil {
 		return id, errors.Wrap(err, "write block")
 	}
 
-	if _, err = block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(dir, id.String()), block.ThanosMeta{
+	if _, err = metadata.InjectThanos(log.NewNopLogger(), filepath.Join(dir, id.String()), metadata.Thanos{
 		Labels:     extLset.Map(),
-		Downsample: block.ThanosDownsampleMeta{Resolution: resolution},
-		Source:     block.TestSource,
+		Downsample: metadata.ThanosDownsample{Resolution: resolution},
+		Source:     metadata.TestSource,
 	}, nil); err != nil {
 		return id, errors.Wrap(err, "finalize block")
 	}

--- a/pkg/verifier/index_issue.go
+++ b/pkg/verifier/index_issue.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/block"
@@ -94,7 +96,7 @@ func IndexIssue(ctx context.Context, logger log.Logger, bkt objstore.Bucket, bac
 			logger,
 			tmpdir,
 			id,
-			block.BucketRepairSource,
+			metadata.BucketRepairSource,
 			block.IgnoreCompleteOutsideChunk,
 			block.IgnoreDuplicateOutsideChunk,
 			block.IgnoreIssue347OutsideChunk,


### PR DESCRIPTION
This PR does not add anything, however by upgrading Prometheus from 2.3.2 to master tip and same for TSDB it may affects few things.
Bigger packages we use and changes I found manually:
* prometheus/prometheus/discovery/file
  * [ENHANCEMENT] Discovery: Improve performance of previously slow updates of changes of targets. #4526 ?? cc @ivan-valkov
  * [BUGFIX] Wait for service discovery to stop before exiting #4508 ??
* prometheus/prometheus/promql:
  * [BUGFIX] PromQL: Fix a goroutine leak in the lexer/parser. #4858
  * [BUGFIX] Change max/min over_time to handle NaNs properly. #438
  * [BUGFIX] Check label name for `count_values` PromQL function. #4585
  * [BUGFIX] Ensure that vectors and matrices do not contain identical label-sets. #4589
  * [ENHANCEMENT] Optimize PromQL aggregations #4248
  * [BUGFIX] Only add LookbackDelta to vector selectors #4399
  * [BUGFIX] Reduce floating point errors in stddev and related functions #4533
* prometheus/prometheus/rules:
  * New metrics exposed! (prometheus evaluation!)
  * [ENHANCEMENT] Rules: Error out at load time for invalid templates, rather than at evaluation time. #4537

* prometheus/tsdb/index: Index reader optimizations.

There are things/fixes we may reuse in next PRs (TODO create gh issues for those):
* api changes (warnings support on Prometheus UI and Query API)
* UI fixes:
  * [ENHANCEMENT] Web UI: Support console queries at specific times. #4764
  * [ENHANCEMENT] Web UI: Avoid browser spell-checking in expression field. #472
* Use notifier package once https://github.com/prometheus/prometheus/pull/5025 is merged.
* Ruler UI fixes:
 * [ENHANCEMENT] Show rule evaluation errors in UI #4457

Follopw up issues we can fix in further PRs:
* QueryAPI has now api/v1/labels that Thanos does not yet support. Created issue with details: https://github.com/improbable-eng/thanos/issues/702
* https://github.com/improbable-eng/thanos/issues/703

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>
