### PR TITLE
prometheus service account and thanos version fix

### DIFF
--- a/kube/manifests/prometheus-gcs.yaml
+++ b/kube/manifests/prometheus-gcs.yaml
@@ -52,7 +52,7 @@ spec:
           mountPath: /var/prometheus
       - name: thanos-sidecar
         # Always use explicit image tags (release or master-<date>-sha) instead of ambigous `latest` or `master`.
-        image: improbable/thanos:v0.1.0
+        image: improbable/thanos:v0.2.1
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /creds/gcs-credentials.json

--- a/kube/manifests/prometheus-gcs.yaml
+++ b/kube/manifests/prometheus-gcs.yaml
@@ -63,7 +63,7 @@ spec:
         - "--prometheus.url=http://127.0.0.1:9090"
         - "--cluster.peers=thanos-peers.default.svc.cluster.local:10900"
        # NOTE: This is required to be added in GCS prior startup of this.
-        - "--gcs.bucket=<bucket-name>"
+        - "--objstore.config=<bucket.config-yaml>"
         - "--reloader.config-file=/etc/prometheus/prometheus.yml.tmpl"
         - "--reloader.config-envsubst-file=/etc/prometheus-shared/prometheus.yml"
         ports:

--- a/kube/manifests/prometheus.yaml
+++ b/kube/manifests/prometheus.yaml
@@ -1,3 +1,40 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: default
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -21,6 +58,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10902"
     spec:
+      serviceAccountName: prometheus
 ## Commented out because Minikube has only one node, should be commented in for any production setup
 #      affinity:
 #        podAntiAffinity:
@@ -52,7 +90,7 @@ spec:
           mountPath: /var/prometheus
       - name: thanos-sidecar
         # Always use explicit image tags (release or master-<date>-sha) instead of ambigous `latest` or `master`.
-        image: improbable/thanos:v0.1.0
+        image: improbable/thanos:v0.2.1
         args:
         - "sidecar"
         - "--log.level=debug"

--- a/kube/manifests/thanos-query.yaml
+++ b/kube/manifests/thanos-query.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: thanos-query
         # Always use explicit image tags (release or master-<date>-sha) instead of ambigous `latest` or `master`.
-        image: improbable/thanos:v0.1.0
+        image: improbable/thanos:v0.2.1
         args:
         - "query"
         - "--log.level=debug"

--- a/kube/manifests/thanos-store.yaml
+++ b/kube/manifests/thanos-store.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: thanos-store
         # Always use explicit image tags (release or master-<date>-sha) instead of ambigous `latest` or `master`.
-        image: improbable/thanos:v0.1.0
+        image: improbable/thanos:v0.2.1
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /creds/gcs-credentials.json

--- a/kube/manifests/thanos-store.yaml
+++ b/kube/manifests/thanos-store.yaml
@@ -31,7 +31,7 @@ spec:
         - "--data-dir=/var/thanos/store"
         - "--cluster.peers=thanos-peers.default.svc.cluster.local:10900"
         # NOTE: This is required to be added in GCS prior startup of this.
-        - "--gcs.bucket=<bucket-name>"
+        - "--objstore.config=<bucket.config-yaml>"
         ports:
         - name: http
           containerPort: 10902


### PR DESCRIPTION
Fix for #706 

## Changes

Added service account for prometheus. 
Changed the thanos version.

## Verification

Prometheus is able to scrape the metrics. 
Thanos query is not crashing anymore. 

~~~
kubectl get pod
NAME                            READY     STATUS    RESTARTS   AGE
prometheus-0                    2/2       Running   1          16m
prometheus-1                    2/2       Running   1          16m
thanos-query-7c6f6f5f77-dzbtp   1/1       Running   0          12m
thanos-query-7c6f6f5f77-kztfx   1/1       Running   0          12m

kubectl logs prometheus-0 prometheus
level=info ts=2019-01-03T16:28:53.110868076Z caller=main.go:215 msg="Starting Prometheus" version="(version=2.0.0, branch=HEAD, revision=0a74f98628a0463dddc90528220c94de5032d1a0)"
level=info ts=2019-01-03T16:28:53.110930676Z caller=main.go:216 build_context="(go=go1.9.2, user=root@615b82cb36b6, date=20171108-07:11:59)"
level=info ts=2019-01-03T16:28:53.110948405Z caller=main.go:217 host_details="(Linux 4.15.0 #1 SMP Fri Oct 5 20:44:14 UTC 2018 x86_64 prometheus-0 (none))"
level=info ts=2019-01-03T16:28:53.115101444Z caller=web.go:380 component=web msg="Start listening for connections" address=0.0.0.0:9090
level=info ts=2019-01-03T16:28:53.11551796Z caller=main.go:314 msg="Starting TSDB"
level=info ts=2019-01-03T16:28:53.115655397Z caller=targetmanager.go:71 component="target manager" msg="Starting target manager..."
level=info ts=2019-01-03T16:28:53.128927406Z caller=main.go:326 msg="TSDB started"
level=info ts=2019-01-03T16:28:53.129169639Z caller=main.go:394 msg="Loading configuration file" filename=/etc/prometheus-shared/prometheus.yml
level=info ts=2019-01-03T16:28:53.130903619Z caller=kubernetes.go:100 component="target manager" discovery=k8s msg="Using pod service account via in-cluster config"
level=info ts=2019-01-03T16:28:53.132063611Z caller=kubernetes.go:100 component="target manager" discovery=k8s msg="Using pod service account via in-cluster config"
level=info ts=2019-01-03T16:28:53.133559881Z caller=kubernetes.go:100 component="target manager" discovery=k8s msg="Using pod service account via in-cluster config"
level=info ts=2019-01-03T16:28:53.134529662Z caller=main.go:371 msg="Server is ready to receive requests."
level=info ts=2019-01-03T16:28:57.225478678Z caller=main.go:394 msg="Loading configuration file" filename=/etc/prometheus-shared/prometheus.yml
level=info ts=2019-01-03T16:28:57.226657904Z caller=kubernetes.go:100 component="target manager" discovery=k8s msg="Using pod service account via in-cluster config"
level=info ts=2019-01-03T16:28:57.228459391Z caller=kubernetes.go:100 component="target manager" discovery=k8s msg="Using pod service account via in-cluster config"
level=info ts=2019-01-03T16:28:57.231852963Z caller=kubernetes.go:100 component="target manager" discovery=k8s msg="Using pod service account via in-cluster config"
~~~
