### PR TITLE
s3: Moved bucket-owner-full-control to be optional behind the flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Fixed
 
 - [#649](https://github.com/improbable-eng/thanos/issues/649) - Fixed store label values api to add also external label values.
+- [#708](https://github.com/improbable-eng/thanos/issues/708) - `"X-Amz-Acl": "bucket-owner-full-control"` metadata for s3 upload operation is no longer set by default which was breaking some providers handled by minio client.
 
+### Changed
+
+- S3 provider:
+  - Added `put_user_metadata` option to config.
+  
 ## [v0.2.1](https://github.com/improbable-eng/thanos/releases/tag/v0.2.1) - 2018.12.27
 
 ### Added

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -47,6 +47,7 @@ config:
   signature_version2: false
   encrypt_sse: false
   secret_key: ""
+  put_user_metadata: {}
   http_config:
     idle_conn_timeout: 0s
 ```

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -41,6 +41,23 @@ http_config:
   idle_conn_timeout: 0s`)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
-
 	testutil.Ok(t, validate(cfg))
+	testutil.Assert(t, cfg.PutUserMetadata != nil, "map should not be nil")
+
+	input2 := []byte(`bucket: "bucket-name"
+endpoint: "s3-endpoint"
+access_key: "access_key"
+insecure: false
+signature_version2: false
+encrypt_sse: false
+secret_key: "secret_key"
+put_user_metadata: 
+  "X-Amz-Acl": "bucket-owner-full-control"
+http_config:
+  idle_conn_timeout: 0s`)
+	cfg2, err := parseConfig(input2)
+	testutil.Ok(t, err)
+	testutil.Ok(t, validate(cfg2))
+
+	testutil.Equals(t, "bucket-owner-full-control", cfg2.PutUserMetadata["X-Amz-Acl"])
 }


### PR DESCRIPTION
Fixes https://github.com/improbable-eng/thanos/issues/708
Fixed potential nil pointer panic - fixed wrong casting handling.

CC @druss17

CC @improbable-ludwik @ianbillett