### PR TITLE
grafana: remove rate from non-counter metrics

### DIFF
--- a/examples/grafana/thanos-query.json
+++ b/examples/grafana/thanos-query.json
@@ -478,7 +478,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(prometheus_engine_queries{$labelselector=\"$labelvalue\",kubernetes_pod_name=~\"$pod\"}[$interval])",
+          "expr": "prometheus_engine_queries{$labelselector=\"$labelvalue\",kubernetes_pod_name=~\"$pod\"}",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,

--- a/examples/grafana/thanos-query.json
+++ b/examples/grafana/thanos-query.json
@@ -396,7 +396,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(prometheus_engine_query_duration_seconds{$labelselector=\"$labelvalue\",kubernetes_pod_name=~\"$pod\",quantile=\"0.99\"}[$interval])",
+          "expr": "prometheus_engine_query_duration_seconds{$labelselector=\"$labelvalue\",kubernetes_pod_name=~\"$pod\",quantile=\"0.99\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{kubernetes_pod_name}} {{slice}}",
@@ -406,7 +406,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Prometheus Query 99 Quantile [$interval]",
+      "title": "Prometheus Query 99 Quantile",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
## Changes

Some queries were incorrectly using rate() on non-counter metrics, this function was removed from the query

## Verification

Deployed to Grafana instance