### PR TITLE
Added shipper capability to sync compacted blocks once; Added sync command.

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -587,7 +587,9 @@ func runRule(
 			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
-				s.Sync(ctx)
+				if _, err := s.SyncNonCompacted(ctx); err != nil {
+					level.Warn(logger).Log("err", err)
+				}
 
 				minTime, _, err := s.Timestamps()
 				if err != nil {

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -264,7 +264,9 @@ func runSidecar(
 			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
-				s.Sync(ctx)
+				if _, err := s.SyncNonCompacted(ctx); err != nil {
+					level.Warn(logger).Log("err", err)
+				}
 
 				minTime, _, err := s.Timestamps()
 				if err != nil {

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -71,7 +71,9 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 			testutil.Ok(t, ioutil.WriteFile(tmp+"/index", []byte("indexcontents"), 0666))
 
 			// Running shipper while a block is being written to temp dir should not trigger uploads.
-			shipper.Sync(ctx)
+			b, err := shipper.SyncNonCompacted(ctx)
+			testutil.Ok(t, err)
+			testutil.Equals(t, 0, b)
 
 			shipMeta, err := ReadMetaFile(dir)
 			testutil.Ok(t, err)
@@ -87,7 +89,9 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 			testutil.Ok(t, os.Rename(tmp, bdir))
 
 			// After rename sync should upload the block.
-			shipper.Sync(ctx)
+			b, err = shipper.SyncNonCompacted(ctx)
+			testutil.Ok(t, err)
+			testutil.Equals(t, 1, b)
 
 			// The external labels must be attached to the meta file on upload.
 			meta.Thanos.Labels = extLset.Map()


### PR DESCRIPTION
Fixes: https://github.com/improbable-eng/thanos/issues/348

Changes:
* Use shipper metrics properly.
* Do not add compacted blocks to `uploaded` arr in thanos shipper meta, as they are not uploaded.
* Added sync command
* Enable working on different work dir
* Enable using snapshot API to avoid race conditions.

NOTE: There is a clear race condition and lack of support for eventual consistency when uploading old blocks (created long ago).
I will update read-write ops proposal with potential fix (using object meta data for creation time, or append creation time to meta.json).

For now turning off compactor is REQUIRED. Explicitly stated that.