### PR TITLE
s3: insecure skip verify option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - S3 provider:
   - Added `put_user_metadata` option to config.
-  
+  - Added `insecure_skip_verify` option to config.
+
 ## [v0.2.1](https://github.com/improbable-eng/thanos/releases/tag/v0.2.1) - 2018.12.27
 
 ### Added

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -44,7 +44,6 @@ config:
   endpoint: ""
   access_key: ""
   insecure: false
-  insecure_skip_verify: false
   signature_version2: false
   encrypt_sse: false
   secret_key: ""

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -44,6 +44,7 @@ config:
   endpoint: ""
   access_key: ""
   insecure: false
+  insecure_skip_verify: false
   signature_version2: false
   encrypt_sse: false
   secret_key: ""
@@ -57,7 +58,10 @@ AWS region to endpoint mapping can be found in this [link](https://docs.aws.amaz
 Make sure you use a correct signature version.
 Currently AWS require signature v4, so it needs `signature-version2: false`, otherwise, you will get Access Denied error, but several other S3 compatible use `signature-version2: true`
 
-For debug purposes you can set `insecure: true` to switch to plain insecure HTTP instead of HTTPS
+For debug and testing purposes you can set
+
+* `insecure: true` to switch to plain insecure HTTP instead of HTTPS
+* `insecure_skip_verify: true` to disable TLS certificate verification (if your S3 based storage is using a self-signed certificate, for example)
 
 ### Credentials
 By default Thanos will try to retrieve credentials from the following sources:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -51,6 +51,7 @@ config:
   put_user_metadata: {}
   http_config:
     idle_conn_timeout: 0s
+    insecure_skip_verify: false
 ```
 
 AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
@@ -61,7 +62,7 @@ Currently AWS require signature v4, so it needs `signature-version2: false`, oth
 For debug and testing purposes you can set
 
 * `insecure: true` to switch to plain insecure HTTP instead of HTTPS
-* `insecure_skip_verify: true` to disable TLS certificate verification (if your S3 based storage is using a self-signed certificate, for example)
+* `http_config.insecure_skip_verify: true` to disable TLS certificate verification (if your S3 based storage is using a self-signed certificate, for example)
 
 ### Credentials
 By default Thanos will try to retrieve credentials from the following sources:

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -35,21 +35,21 @@ const DirDelim = "/"
 
 // Config stores the configuration for s3 bucket.
 type Config struct {
-	Bucket             string            `yaml:"bucket"`
-	Endpoint           string            `yaml:"endpoint"`
-	AccessKey          string            `yaml:"access_key"`
-	Insecure           bool              `yaml:"insecure"`
-	InsecureSkipVerify bool              `yaml:"insecure_skip_verify"`
-	SignatureV2        bool              `yaml:"signature_version2"`
-	SSEEncryption      bool              `yaml:"encrypt_sse"`
-	SecretKey          string            `yaml:"secret_key"`
-	PutUserMetadata    map[string]string `yaml:"put_user_metadata"`
-	HTTPConfig         HTTPConfig        `yaml:"http_config"`
+	Bucket          string            `yaml:"bucket"`
+	Endpoint        string            `yaml:"endpoint"`
+	AccessKey       string            `yaml:"access_key"`
+	Insecure        bool              `yaml:"insecure"`
+	SignatureV2     bool              `yaml:"signature_version2"`
+	SSEEncryption   bool              `yaml:"encrypt_sse"`
+	SecretKey       string            `yaml:"secret_key"`
+	PutUserMetadata map[string]string `yaml:"put_user_metadata"`
+	HTTPConfig      HTTPConfig        `yaml:"http_config"`
 }
 
 // HTTPConfig stores the http.Transport configuration for the s3 minio client.
 type HTTPConfig struct {
-	IdleConnTimeout model.Duration `yaml:"idle_conn_timeout"`
+	IdleConnTimeout    model.Duration `yaml:"idle_conn_timeout"`
+	InsecureSkipVerify bool           `yaml:"insecure_skip_verify"`
 }
 
 // Bucket implements the store.Bucket interface against s3-compatible APIs.
@@ -144,7 +144,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		// Refer:
 		//    https://golang.org/src/net/http/transport.go?h=roundTrip#L1843
 		DisableCompression: true,
-		TLSClientConfig:    &tls.Config{InsecureSkipVerify: config.InsecureSkipVerify},
+		TLSClientConfig:    &tls.Config{InsecureSkipVerify: config.HTTPConfig.InsecureSkipVerify},
 	})
 
 	var sse encrypt.ServerSide
@@ -323,7 +323,7 @@ func configFromEnv() Config {
 	}
 
 	c.Insecure, _ = strconv.ParseBool(os.Getenv("S3_INSECURE"))
-	c.InsecureSkipVerify, _ = strconv.ParseBool(os.Getenv("S3_INSECURE_SKIP_VERIFY"))
+	c.HTTPConfig.InsecureSkipVerify, _ = strconv.ParseBool(os.Getenv("S3_INSECURE_SKIP_VERIFY"))
 	c.SignatureV2, _ = strconv.ParseBool(os.Getenv("S3_SIGNATURE_VERSION2"))
 	return c
 }

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -3,6 +3,7 @@ package s3
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"math/rand"
@@ -34,15 +35,16 @@ const DirDelim = "/"
 
 // Config stores the configuration for s3 bucket.
 type Config struct {
-	Bucket          string            `yaml:"bucket"`
-	Endpoint        string            `yaml:"endpoint"`
-	AccessKey       string            `yaml:"access_key"`
-	Insecure        bool              `yaml:"insecure"`
-	SignatureV2     bool              `yaml:"signature_version2"`
-	SSEEncryption   bool              `yaml:"encrypt_sse"`
-	SecretKey       string            `yaml:"secret_key"`
-	PutUserMetadata map[string]string `yaml:"put_user_metadata"`
-	HTTPConfig      HTTPConfig        `yaml:"http_config"`
+	Bucket             string            `yaml:"bucket"`
+	Endpoint           string            `yaml:"endpoint"`
+	AccessKey          string            `yaml:"access_key"`
+	Insecure           bool              `yaml:"insecure"`
+	InsecureSkipVerify bool              `yaml:"insecure_skip_verify"`
+	SignatureV2        bool              `yaml:"signature_version2"`
+	SSEEncryption      bool              `yaml:"encrypt_sse"`
+	SecretKey          string            `yaml:"secret_key"`
+	PutUserMetadata    map[string]string `yaml:"put_user_metadata"`
+	HTTPConfig         HTTPConfig        `yaml:"http_config"`
 }
 
 // HTTPConfig stores the http.Transport configuration for the s3 minio client.
@@ -142,6 +144,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		// Refer:
 		//    https://golang.org/src/net/http/transport.go?h=roundTrip#L1843
 		DisableCompression: true,
+		TLSClientConfig:    &tls.Config{InsecureSkipVerify: config.InsecureSkipVerify},
 	})
 
 	var sse encrypt.ServerSide
@@ -320,6 +323,7 @@ func configFromEnv() Config {
 	}
 
 	c.Insecure, _ = strconv.ParseBool(os.Getenv("S3_INSECURE"))
+	c.InsecureSkipVerify, _ = strconv.ParseBool(os.Getenv("S3_INSECURE_SKIP_VERIFY"))
 	c.SignatureV2, _ = strconv.ParseBool(os.Getenv("S3_SIGNATURE_VERSION2"))
 	return c
 }

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -24,10 +24,10 @@ http_config:
 	if cfg.Bucket != "abcd" {
 		t.Errorf("parsing of bucket failed: got %v, expected %v", cfg.Bucket, "abcd")
 	}
-	if cfg.Insecure != false {
+	if cfg.Insecure {
 		t.Errorf("parsing of insecure failed: got %v, expected %v", cfg.Insecure, false)
 	}
-	if cfg.HTTPConfig.InsecureSkipVerify != true {
+	if !cfg.HTTPConfig.InsecureSkipVerify {
 		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
 	}
 }
@@ -37,7 +37,6 @@ func TestValidate_OK(t *testing.T) {
 endpoint: "s3-endpoint"
 access_key: "access_key"
 insecure: false
-insecure_skip_verify: false
 signature_version2: false
 encrypt_sse: false
 secret_key: "secret_key"
@@ -53,14 +52,12 @@ http_config:
 endpoint: "s3-endpoint"
 access_key: "access_key"
 insecure: false
-insecure_skip_verify: false
 signature_version2: false
 encrypt_sse: false
 secret_key: "secret_key"
 put_user_metadata:
   "X-Amz-Acl": "bucket-owner-full-control"
 http_config:
-  insecure_skip_verify: false
   idle_conn_timeout: 0s`)
 	cfg2, err := parseConfig(input2)
 	testutil.Ok(t, err)

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -10,8 +10,8 @@ import (
 func TestParseConfig_DefaultHTTPOpts(t *testing.T) {
 	input := []byte(`bucket: abcd
 insecure: false
-insecure_skip_verify: false
 http_config:
+  insecure_skip_verify: true
   idle_conn_timeout: 50s`)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
@@ -27,8 +27,8 @@ http_config:
 	if cfg.Insecure != false {
 		t.Errorf("parsing of insecure failed: got %v, expected %v", cfg.Insecure, false)
 	}
-	if cfg.InsecureSkipVerify != false {
-		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.InsecureSkipVerify, false)
+	if cfg.HTTPConfig.InsecureSkipVerify != true {
+		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
 	}
 }
 
@@ -42,7 +42,8 @@ signature_version2: false
 encrypt_sse: false
 secret_key: "secret_key"
 http_config:
-  idle_conn_timeout: 0s`)
+  insecure_skip_verify: false
+  idle_conn_timeout: 50s`)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
 	testutil.Ok(t, validate(cfg))
@@ -56,9 +57,10 @@ insecure_skip_verify: false
 signature_version2: false
 encrypt_sse: false
 secret_key: "secret_key"
-put_user_metadata: 
+put_user_metadata:
   "X-Amz-Acl": "bucket-owner-full-control"
 http_config:
+  insecure_skip_verify: false
   idle_conn_timeout: 0s`)
 	cfg2, err := parseConfig(input2)
 	testutil.Ok(t, err)

--- a/pkg/objstore/s3/s3_test.go
+++ b/pkg/objstore/s3/s3_test.go
@@ -10,6 +10,7 @@ import (
 func TestParseConfig_DefaultHTTPOpts(t *testing.T) {
 	input := []byte(`bucket: abcd
 insecure: false
+insecure_skip_verify: false
 http_config:
   idle_conn_timeout: 50s`)
 	cfg, err := parseConfig(input)
@@ -26,7 +27,9 @@ http_config:
 	if cfg.Insecure != false {
 		t.Errorf("parsing of insecure failed: got %v, expected %v", cfg.Insecure, false)
 	}
-
+	if cfg.InsecureSkipVerify != false {
+		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.InsecureSkipVerify, false)
+	}
 }
 
 func TestValidate_OK(t *testing.T) {
@@ -34,6 +37,7 @@ func TestValidate_OK(t *testing.T) {
 endpoint: "s3-endpoint"
 access_key: "access_key"
 insecure: false
+insecure_skip_verify: false
 signature_version2: false
 encrypt_sse: false
 secret_key: "secret_key"
@@ -48,6 +52,7 @@ http_config:
 endpoint: "s3-endpoint"
 access_key: "access_key"
 insecure: false
+insecure_skip_verify: false
 signature_version2: false
 encrypt_sse: false
 secret_key: "secret_key"


### PR DESCRIPTION
## Changes

This adds a new option in the s3 object storage config that provides the ability to ignore TLS verification errors for testing and/or debugging purposes.

## Verification

We are running Thanos with this patch against our internal s3 compatible storage system (Dell EMC ECS) as well against Minio server with a self-signed certificate.

## Background

We are using Thanos with an s3 compatible storage service and, for various reasons, we are limited to a self-signed certificate in our testing environment. Plain HTTP is not an option either (so the `insecure` options does not work for us). This option allows us to proceed with our Thanos testing and evaluation.