### PR TITLE
Added shipper capability to sync compacted blocks once.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -529,6 +529,7 @@
     "fileutil",
     "index",
     "labels",
+    "testutil",
     "wal",
   ]
   pruneopts = ""
@@ -859,6 +860,7 @@
     "github.com/prometheus/tsdb/fileutil",
     "github.com/prometheus/tsdb/index",
     "github.com/prometheus/tsdb/labels",
+    "github.com/prometheus/tsdb/testutil",
     "golang.org/x/net/context",
     "golang.org/x/sync/errgroup",
     "golang.org/x/text/language",

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -50,7 +50,6 @@ func registerBucket(m map[string]setupFunc, app *kingpin.Application, name strin
 	cmd := app.Command(name, "Bucket utility commands")
 
 	objStoreConfig := regCommonObjStoreFlags(cmd, "", true)
-
 	registerBucketVerify(m, cmd, name, objStoreConfig)
 	registerBucketLs(m, cmd, name, objStoreConfig)
 	registerBucketInspect(m, cmd, name, objStoreConfig)

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -617,7 +617,9 @@ func runRule(
 			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
 			return runutil.Repeat(30*time.Second, ctx.Done(), func() error {
-				s.Sync(ctx)
+				if _, err := s.Sync(ctx); err != nil {
+					level.Warn(logger).Log("err", err)
+				}
 
 				minTime, _, err := s.Timestamps()
 				if err != nil {

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -67,7 +67,7 @@ func ExternalLabels(ctx context.Context, logger log.Logger, base *url.URL) (labe
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, errors.Errorf("got non-200 response code: %v, response: %v", resp.StatusCode, string(b))
+		return nil, errors.Errorf("is 'web.enable-admin-api' flag enabled? got non-200 response code: %v, response: %v", resp.StatusCode, string(b))
 	}
 
 	var d struct {
@@ -161,7 +161,7 @@ func (m *modelBool) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// ConfiguredFlags some configured flags from /api/v1/status/flags Prometheus endpoint.
+// ConfiguredFlags returns configured flags from /api/v1/status/flags Prometheus endpoint.
 // Added to Prometheus from v2.2.
 func ConfiguredFlags(ctx context.Context, logger log.Logger, base *url.URL) (Flags, error) {
 	u := *base

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -7,32 +7,38 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"math"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
-
-	"github.com/improbable-eng/thanos/pkg/block/metadata"
+	"sort"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/block"
+	"github.com/improbable-eng/thanos/pkg/block/metadata"
 	"github.com/improbable-eng/thanos/pkg/objstore"
+	"github.com/improbable-eng/thanos/pkg/promclient"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/tsdb"
 	"github.com/prometheus/tsdb/fileutil"
 	"github.com/prometheus/tsdb/labels"
 )
 
 type metrics struct {
-	dirSyncs        prometheus.Counter
-	dirSyncFailures prometheus.Counter
-	uploads         prometheus.Counter
-	uploadFailures  prometheus.Counter
+	dirSyncs          prometheus.Counter
+	dirSyncFailures   prometheus.Counter
+	uploads           prometheus.Counter
+	uploadFailures    prometheus.Counter
+	uploadedCompacted prometheus.Gauge
 }
 
-func newMetrics(r prometheus.Registerer) *metrics {
+func newMetrics(r prometheus.Registerer, uploadCompacted bool) *metrics {
 	var m metrics
 
 	m.dirSyncs = prometheus.NewCounter(prometheus.CounterOpts{
@@ -51,6 +57,10 @@ func newMetrics(r prometheus.Registerer) *metrics {
 		Name: "thanos_shipper_upload_failures_total",
 		Help: "Total number of failed object uploads",
 	})
+	m.uploadedCompacted = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "thanos_shipper_upload_compacted_done",
+		Help: "If 1 it means shipper uploaded all compacted blocks from the filesystem.",
+	})
 
 	if r != nil {
 		r.MustRegister(
@@ -59,6 +69,9 @@ func newMetrics(r prometheus.Registerer) *metrics {
 			m.uploads,
 			m.uploadFailures,
 		)
+		if uploadCompacted {
+			r.MustRegister(m.uploadedCompacted)
+		}
 	}
 	return &m
 }
@@ -66,16 +79,18 @@ func newMetrics(r prometheus.Registerer) *metrics {
 // Shipper watches a directory for matching files and directories and uploads
 // them to a remote data store.
 type Shipper struct {
-	logger  log.Logger
-	dir     string
-	metrics *metrics
-	bucket  objstore.Bucket
-	labels  func() labels.Labels
-	source  metadata.SourceType
+	logger          log.Logger
+	dir             string
+	workDir         string
+	metrics         *metrics
+	bucket          objstore.Bucket
+	labels          func() labels.Labels
+	source          metadata.SourceType
+	uploadCompacted bool
 }
 
 // New creates a new shipper that detects new TSDB blocks in dir and uploads them
-// to remote if necessary. It attaches the return value of the labels getter to uploaded data.
+// to remote if necessary. It attaches the Thanos metadata section in each meta JSON file.
 func New(
 	logger log.Logger,
 	r prometheus.Registerer,
@@ -90,14 +105,56 @@ func New(
 	if lbls == nil {
 		lbls = func() labels.Labels { return nil }
 	}
+
 	return &Shipper{
 		logger:  logger,
 		dir:     dir,
 		bucket:  bucket,
 		labels:  lbls,
-		metrics: newMetrics(r),
+		metrics: newMetrics(r, false),
 		source:  source,
 	}
+}
+
+// NewWithCompacted creates a new shipper that detects new TSDB blocks in dir and uploads them
+// to remote if necessary, including compacted blocks which are already in filesystem.
+// It attaches the Thanos metadata section in each meta JSON file.
+func NewWithCompacted(
+	ctx context.Context,
+	logger log.Logger,
+	r prometheus.Registerer,
+	dir string,
+	bucket objstore.Bucket,
+	lbls func() labels.Labels,
+	source metadata.SourceType,
+	prometheusURL *url.URL,
+) (*Shipper, error) {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+	if lbls == nil {
+		lbls = func() labels.Labels { return nil }
+	}
+
+	flags, err := promclient.ConfiguredFlags(ctx, logger, prometheusURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "configured flags; failed to check if compaction is disabled")
+	}
+
+	if flags.TSDBMinTime != model.Duration(2*time.Hour) || flags.TSDBMaxTime != model.Duration(2*time.Hour) {
+		return nil, errors.Errorf("Found that TSDB Max time is %s and Min time is %s. To use shipper with upload compacted option, "+
+			"compaction needs to be disabled (storage.tsdb.min-block-duration = storage.tsdb.max-block-duration = 2h", flags.TSDBMinTime, flags.TSDBMaxTime)
+	}
+
+	return &Shipper{
+		logger:          logger,
+		dir:             dir,
+		bucket:          bucket,
+		labels:          lbls,
+		metrics:         newMetrics(r, true),
+		source:          source,
+		uploadCompacted: true,
+	}, nil
 }
 
 // Timestamps returns the minimum timestamp for which data is available and the highest timestamp
@@ -136,70 +193,176 @@ func (s *Shipper) Timestamps() (minTime, maxSyncTime int64, err error) {
 	return minTime, maxSyncTime, nil
 }
 
-// Sync performs a single synchronization, which ensures all local blocks have been uploaded
+type lazyOverlapChecker struct {
+	synced bool
+	logger log.Logger
+	bucket objstore.Bucket
+	labels func() labels.Labels
+
+	metas       []tsdb.BlockMeta
+	lookupMetas map[ulid.ULID]struct{}
+}
+
+func newLazyOverlapChecker(logger log.Logger, bucket objstore.Bucket, labels func() labels.Labels) *lazyOverlapChecker {
+	return &lazyOverlapChecker{
+		logger: logger,
+		bucket: bucket,
+		labels: labels,
+
+		lookupMetas: map[ulid.ULID]struct{}{},
+	}
+}
+
+func (c *lazyOverlapChecker) sync(ctx context.Context) error {
+	level.Info(c.logger).Log("msg", "gathering all existing blocks from the remote bucket")
+	if err := c.bucket.Iter(ctx, "", func(path string) error {
+		id, ok := block.IsBlockDir(path)
+		if !ok {
+			return nil
+		}
+
+		m, err := block.DownloadMeta(ctx, c.logger, c.bucket, id)
+		if err != nil {
+			return err
+		}
+
+		if !labels.FromMap(m.Thanos.Labels).Equals(c.labels()) {
+			return nil
+		}
+
+		c.metas = append(c.metas, m.BlockMeta)
+		c.lookupMetas[m.ULID] = struct{}{}
+		return nil
+
+	}); err != nil {
+		return errors.Wrap(err, "get all block meta.")
+	}
+
+	c.synced = true
+	return nil
+}
+
+func (c *lazyOverlapChecker) IsOverlapping(ctx context.Context, newMeta tsdb.BlockMeta) error {
+	if !c.synced {
+		if err := c.sync(ctx); err != nil {
+			return err
+		}
+	}
+
+	// TODO(bwplotka) so confusing! we need to sort it first. Add comment to TSDB code.
+	metas := append([]tsdb.BlockMeta{newMeta}, c.metas...)
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].MinTime < metas[j].MinTime
+	})
+	if o := tsdb.OverlappingBlocks(metas); len(o) > 0 {
+		// TODO(bwplotka): Consider checking if overlaps relates to block in concern?
+		return errors.Errorf("shipping compacted block %s is blocked; overlap spotted: %s", newMeta.ULID, o.String())
+	}
+	return nil
+}
+
+// Sync performs a single synchronization, which ensures all non-compacted local blocks have been uploaded
 // to the object bucket once.
-// It is not concurrency-safe.
-func (s *Shipper) Sync(ctx context.Context) {
+//
+// If updload
+//
+// It is not concurrency-safe, however it is compactor-safe (running concurrently with compactor is ok)
+func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 	meta, err := ReadMetaFile(s.dir)
 	if err != nil {
 		// If we encounter any error, proceed with an empty meta file and overwrite it later.
 		// The meta file is only used to deduplicate uploads, which are properly handled
 		// by the system if their occur anyway.
 		if !os.IsNotExist(err) {
-			level.Warn(s.logger).Log("msg", "reading meta file failed, removing it", "err", err)
+			level.Warn(s.logger).Log("msg", "reading meta file failed, will override it", "err", err)
 		}
 		meta = &Meta{Version: 1}
 	}
+
 	// Build a map of blocks we already uploaded.
 	hasUploaded := make(map[ulid.ULID]struct{}, len(meta.Uploaded))
 	for _, id := range meta.Uploaded {
 		hasUploaded[id] = struct{}{}
 	}
+
 	// Reset the uploaded slice so we can rebuild it only with blocks that still exist locally.
 	meta.Uploaded = nil
 
-	// TODO(bplotka): If there are no blocks in the system check for WAL dir to ensure we have actually
-	// access to real TSDB dir (!).
-	if err = s.iterBlockMetas(func(m *metadata.Meta) error {
-		// Do not sync a block if we already uploaded it. If it is no longer found in the bucket,
+	var (
+		checker    = newLazyOverlapChecker(s.logger, s.bucket, s.labels)
+		uploadErrs int
+	)
+	// Sync non compacted blocks first.
+	if err := s.iterBlockMetas(func(m *metadata.Meta) error {
+		// Do not sync a block if we already uploaded or ignored it. If it's no longer found in the bucket,
 		// it was generally removed by the compaction process.
-		if _, ok := hasUploaded[m.ULID]; !ok {
-			if err := s.sync(ctx, m); err != nil {
-				level.Error(s.logger).Log("msg", "shipping failed", "block", m.ULID, "err", err)
-				// No error returned, just log line. This is because we want other blocks to be uploaded even
-				// though this one failed. It will be retried on second Sync iteration.
+		if _, uploaded := hasUploaded[m.ULID]; uploaded {
+			meta.Uploaded = append(meta.Uploaded, m.ULID)
+			return nil
+		}
+
+		if m.Stats.NumSamples == 0 {
+			// Ignore empty blocks.
+			level.Debug(s.logger).Log("msg", "ignoring empty block", "block", m.ULID)
+			return nil
+		}
+
+		// We only ship of the first compacted block level as normal flow.
+		if m.Compaction.Level > 1 {
+			if !s.uploadCompacted {
+				return nil
+			}
+
+			if err := checker.IsOverlapping(ctx, m.BlockMeta); err != nil {
+				level.Error(s.logger).Log("msg", "found overlap or error during sync, cannot upload compacted block", "err", err)
+				uploadErrs++
 				return nil
 			}
 		}
+
+		// Check against bucket if the meta file for this block exists.
+		ok, err := s.bucket.Exists(ctx, path.Join(m.ULID.String(), block.MetaFilename))
+		if err != nil {
+			return errors.Wrap(err, "check exists")
+		}
+		if ok {
+			return nil
+		}
+
+		if err := s.upload(ctx, m); err != nil {
+			level.Error(s.logger).Log("msg", "shipping failed", "block", m.ULID, "err", err)
+			// No error returned, just log line. This is because we want other blocks to be uploaded even
+			// though this one failed. It will be retried on second Sync iteration.
+			uploadErrs++
+			return nil
+		}
 		meta.Uploaded = append(meta.Uploaded, m.ULID)
+
+		uploaded++
+		s.metrics.uploads.Inc()
 		return nil
 	}); err != nil {
-		level.Error(s.logger).Log("msg", "iter block metas failed", "err", err)
-		return
+		s.metrics.dirSyncFailures.Inc()
+		return uploaded, errors.Wrap(err, "iter local block metas")
 	}
+
 	if err := WriteMetaFile(s.logger, s.dir, meta); err != nil {
 		level.Warn(s.logger).Log("msg", "updating meta file failed", "err", err)
 	}
+
+	s.metrics.dirSyncs.Inc()
+
+	if uploadErrs > 0 {
+		s.metrics.uploadFailures.Add(float64(uploadErrs))
+		return uploaded, errors.Errorf("failed to sync %v blocks", uploadErrs)
+	} else if s.uploadCompacted {
+		s.metrics.uploadedCompacted.Set(1)
+	}
+	return uploaded, nil
 }
 
-func (s *Shipper) sync(ctx context.Context, meta *metadata.Meta) (err error) {
-	dir := filepath.Join(s.dir, meta.ULID.String())
-
-	// We only ship of the first compacted block level.
-	// TODO(bplotka): https://github.com/improbable-eng/thanos/issues/206
-	if meta.Compaction.Level > 1 {
-		return nil
-	}
-
-	// Check against bucket if the meta file for this block exists.
-	ok, err := s.bucket.Exists(ctx, path.Join(meta.ULID.String(), block.MetaFilename))
-	if err != nil {
-		return errors.Wrap(err, "check exists")
-	}
-	if ok {
-		return nil
-	}
-
+// sync uploads the block if not exists in remote storage.
+func (s *Shipper) upload(ctx context.Context, meta *metadata.Meta) error {
 	level.Info(s.logger).Log("msg", "upload new block", "id", meta.ULID)
 
 	// We hard-link the files into a temporary upload directory so we are not affected
@@ -219,6 +382,7 @@ func (s *Shipper) sync(ctx context.Context, meta *metadata.Meta) (err error) {
 		}
 	}()
 
+	dir := filepath.Join(s.dir, meta.ULID.String())
 	if err := hardlinkBlock(dir, updir); err != nil {
 		return errors.Wrap(err, "hard link block")
 	}

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -6,11 +6,14 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"math/rand"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/improbable-eng/thanos/pkg/objstore/inmem"
 
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/block"
@@ -24,7 +27,7 @@ import (
 	"github.com/prometheus/tsdb/labels"
 )
 
-func TestShipper_UploadBlocks_e2e(t *testing.T) {
+func TestShipper_SyncBlocks_e2e(t *testing.T) {
 	objtesting.ForeachStore(t, func(t testing.TB, bkt objstore.Bucket) {
 		dir, err := ioutil.TempDir("", "shipper-e2e-test")
 		testutil.Ok(t, err)
@@ -38,17 +41,17 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		// Create 10 new blocks that should actually be uploaded.
+		// Create 10 new blocks. 9 of them (non compacted) should be actually uploaded.
 		var (
-			expBlocks = map[ulid.ULID]struct{}{}
-			expFiles  = map[string][]byte{}
-			randr     = rand.New(rand.NewSource(0))
-			now       = time.Now()
-			ids       []ulid.ULID
+			expBlocks    = map[ulid.ULID]struct{}{}
+			expFiles     = map[string][]byte{}
+			randr        = rand.New(rand.NewSource(0))
+			now          = time.Now()
+			ids          = []ulid.ULID{}
+			maxSyncSoFar int64
 		)
 		for i := 0; i < 10; i++ {
 			id := ulid.MustNew(uint64(i), randr)
-			ids = append(ids, id)
 
 			bdir := filepath.Join(dir, id.String())
 			tmp := bdir + ".tmp"
@@ -56,14 +59,29 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 			testutil.Ok(t, os.Mkdir(tmp, 0777))
 
 			meta := metadata.Meta{
+				Version: 1,
 				BlockMeta: tsdb.BlockMeta{
+					Version: 1,
+					ULID:    id,
+					Stats: tsdb.BlockStats{
+						NumSamples: 1,
+					},
 					MinTime: timestamp.FromTime(now.Add(time.Duration(i) * time.Hour)),
 					MaxTime: timestamp.FromTime(now.Add((time.Duration(i) * time.Hour) + 1)),
+
+					Compaction: tsdb.BlockMetaCompaction{
+						Level: 1,
+					},
+				},
+				Thanos: metadata.Thanos{
+					Source: metadata.TestSource,
 				},
 			}
-			meta.Version = 1
-			meta.ULID = id
-			meta.Thanos.Source = metadata.TestSource
+
+			// Sixth block is compacted one.
+			if i == 5 {
+				meta.Compaction.Level = 2
+			}
 
 			metab, err := json.Marshal(&meta)
 			testutil.Ok(t, err)
@@ -72,14 +90,16 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 			testutil.Ok(t, ioutil.WriteFile(tmp+"/index", []byte("indexcontents"), 0666))
 
 			// Running shipper while a block is being written to temp dir should not trigger uploads.
-			shipper.Sync(ctx)
+			b, err := shipper.Sync(ctx)
+			testutil.Ok(t, err)
+			testutil.Equals(t, 0, b)
 
 			shipMeta, err := ReadMetaFile(dir)
 			testutil.Ok(t, err)
 			if len(shipMeta.Uploaded) == 0 {
 				shipMeta.Uploaded = []ulid.ULID{}
 			}
-			testutil.Equals(t, &Meta{Version: 1, Uploaded: ids[:i]}, shipMeta)
+			testutil.Equals(t, &Meta{Version: 1, Uploaded: ids}, shipMeta)
 
 			testutil.Ok(t, os.MkdirAll(tmp+"/chunks", 0777))
 			testutil.Ok(t, ioutil.WriteFile(tmp+"/chunks/0001", []byte("chunkcontents1"), 0666))
@@ -88,7 +108,178 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 			testutil.Ok(t, os.Rename(tmp, bdir))
 
 			// After rename sync should upload the block.
-			shipper.Sync(ctx)
+			b, err = shipper.Sync(ctx)
+			testutil.Ok(t, err)
+			if i != 5 {
+				ids = append(ids, id)
+				maxSyncSoFar = meta.MaxTime
+				testutil.Equals(t, 1, b)
+			} else {
+				testutil.Equals(t, 0, b)
+			}
+
+			// The external labels must be attached to the meta file on upload.
+			meta.Thanos.Labels = extLset.Map()
+
+			var buf bytes.Buffer
+			enc := json.NewEncoder(&buf)
+			enc.SetIndent("", "\t")
+
+			testutil.Ok(t, enc.Encode(&meta))
+
+			// We will delete the fifth block and do not expect it to be re-uploaded later
+			if i != 4 && i != 5 {
+				expBlocks[id] = struct{}{}
+
+				expFiles[id.String()+"/meta.json"] = buf.Bytes()
+				expFiles[id.String()+"/index"] = []byte("indexcontents")
+				expFiles[id.String()+"/chunks/0001"] = []byte("chunkcontents1")
+				expFiles[id.String()+"/chunks/0002"] = []byte("chunkcontents2")
+			}
+			if i == 4 {
+				testutil.Ok(t, block.Delete(ctx, bkt, ids[4]))
+			}
+			// The shipper meta file should show all blocks as uploaded except the compacted one.
+			shipMeta, err = ReadMetaFile(dir)
+			testutil.Ok(t, err)
+			testutil.Equals(t, &Meta{Version: 1, Uploaded: ids}, shipMeta)
+
+			// Verify timestamps were updated correctly.
+			minTotal, maxSync, err := shipper.Timestamps()
+			testutil.Ok(t, err)
+			testutil.Equals(t, timestamp.FromTime(now), minTotal)
+			testutil.Equals(t, maxSyncSoFar, maxSync)
+		}
+
+		for id := range expBlocks {
+			ok, _ := bkt.Exists(ctx, path.Join(id.String(), block.MetaFilename))
+			testutil.Assert(t, ok, "block %s was not uploaded", id)
+		}
+		for fn, exp := range expFiles {
+			rc, err := bkt.Get(ctx, fn)
+			testutil.Ok(t, err)
+			act, err := ioutil.ReadAll(rc)
+			testutil.Ok(t, err)
+			testutil.Ok(t, rc.Close())
+			testutil.Equals(t, string(exp), string(act))
+		}
+		// Verify the fifth block is still deleted by the end.
+		ok, err := bkt.Exists(ctx, ids[4].String()+"/meta.json")
+		testutil.Ok(t, err)
+		testutil.Assert(t, ok == false, "fifth block was reuploaded")
+	})
+}
+
+func TestShipper_SyncBlocksWithMigrating_e2e(t *testing.T) {
+	testutil.ForeachPrometheus(t, func(t testing.TB, p *testutil.Prometheus) {
+		dir, err := ioutil.TempDir("", "shipper-e2e-test")
+		testutil.Ok(t, err)
+		defer func() {
+			testutil.Ok(t, os.RemoveAll(dir))
+		}()
+
+		bkt := inmem.NewBucket()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		extLset := labels.FromStrings("prometheus", "prom-1")
+
+		testutil.Ok(t, p.Start())
+
+		upctx, upcancel := context.WithTimeout(ctx, 10*time.Second)
+		defer upcancel()
+		testutil.Ok(t, p.WaitPrometheusUp(upctx))
+
+		addr, err := url.Parse(p.Addr())
+		testutil.Ok(t, err)
+
+		shipper, err := NewWithCompacted(ctx, log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, addr)
+		testutil.NotOk(t, err) // Compaction not disabled!
+
+		p.DisableCompaction()
+		testutil.Ok(t, p.Restart())
+
+		upctx2, upcancel2 := context.WithTimeout(ctx, 10*time.Second)
+		defer upcancel2()
+		testutil.Ok(t, p.WaitPrometheusUp(upctx2))
+
+		addr, err = url.Parse("http://" + p.Addr())
+		testutil.Ok(t, err)
+
+		shipper, err = NewWithCompacted(ctx, log.NewLogfmtLogger(os.Stderr), nil, dir, bkt, func() labels.Labels { return extLset }, metadata.TestSource, addr)
+		testutil.Ok(t, err)
+
+		// Create 10 new blocks. 9 of them (non compacted) should be actually uploaded.
+		var (
+			expBlocks = map[ulid.ULID]struct{}{}
+			expFiles  = map[string][]byte{}
+			randr     = rand.New(rand.NewSource(0))
+			now       = time.Now()
+			ids       = []ulid.ULID{}
+		)
+		for i := 0; i < 10; i++ {
+			id := ulid.MustNew(uint64(i), randr)
+
+			bdir := filepath.Join(dir, id.String())
+			tmp := bdir + ".tmp"
+
+			testutil.Ok(t, os.Mkdir(tmp, 0777))
+
+			meta := metadata.Meta{
+				Version: 1,
+				BlockMeta: tsdb.BlockMeta{
+					Version: 1,
+					ULID:    id,
+					Stats: tsdb.BlockStats{
+						NumSamples: 1,
+					},
+					MinTime: timestamp.FromTime(now.Add(time.Duration(i) * time.Hour)),
+					MaxTime: timestamp.FromTime(now.Add((time.Duration(i) * time.Hour) + 1)),
+
+					Compaction: tsdb.BlockMetaCompaction{
+						Level: 1,
+					},
+				},
+				Thanos: metadata.Thanos{
+					Source: metadata.TestSource,
+				},
+			}
+
+			// Fifth block is compacted one.
+			if i == 4 {
+				meta.Compaction.Level = 2
+			}
+
+			metab, err := json.Marshal(&meta)
+			testutil.Ok(t, err)
+
+			testutil.Ok(t, ioutil.WriteFile(tmp+"/meta.json", metab, 0666))
+			testutil.Ok(t, ioutil.WriteFile(tmp+"/index", []byte("indexcontents"), 0666))
+
+			// Running shipper while a block is being written to temp dir should not trigger uploads.
+			b, err := shipper.Sync(ctx)
+			testutil.Ok(t, err)
+			testutil.Equals(t, 0, b)
+
+			shipMeta, err := ReadMetaFile(dir)
+			testutil.Ok(t, err)
+			if len(shipMeta.Uploaded) == 0 {
+				shipMeta.Uploaded = []ulid.ULID{}
+			}
+			testutil.Equals(t, &Meta{Version: 1, Uploaded: ids}, shipMeta)
+
+			testutil.Ok(t, os.MkdirAll(tmp+"/chunks", 0777))
+			testutil.Ok(t, ioutil.WriteFile(tmp+"/chunks/0001", []byte("chunkcontents1"), 0666))
+			testutil.Ok(t, ioutil.WriteFile(tmp+"/chunks/0002", []byte("chunkcontents2"), 0666))
+
+			testutil.Ok(t, os.Rename(tmp, bdir))
+
+			// After rename sync should upload the block.
+			b, err = shipper.Sync(ctx)
+			testutil.Ok(t, err)
+			testutil.Equals(t, 1, b)
+			ids = append(ids, id)
 
 			// The external labels must be attached to the meta file on upload.
 			meta.Thanos.Labels = extLset.Map()
@@ -107,13 +298,14 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 				expFiles[id.String()+"/index"] = []byte("indexcontents")
 				expFiles[id.String()+"/chunks/0001"] = []byte("chunkcontents1")
 				expFiles[id.String()+"/chunks/0002"] = []byte("chunkcontents2")
-			} else {
+			}
+			if i == 4 {
 				testutil.Ok(t, block.Delete(ctx, bkt, ids[4]))
 			}
-			// The shipper meta file should show all blocks as uploaded.
+			// The shipper meta file should show all blocks as uploaded except the compacted one.
 			shipMeta, err = ReadMetaFile(dir)
 			testutil.Ok(t, err)
-			testutil.Equals(t, &Meta{Version: 1, Uploaded: ids[:i+1]}, shipMeta)
+			testutil.Equals(t, &Meta{Version: 1, Uploaded: ids}, shipMeta)
 
 			// Verify timestamps were updated correctly.
 			minTotal, maxSync, err := shipper.Timestamps()


### PR DESCRIPTION
Added shipper capability to sync compacted blocks once.

Changes:
* Use shipper metrics properly.
* Do not add compacted blocks to `uploaded` arr in thanos shipper meta if they are not uploaded.
* Added flag for syncing compacted blocks once.
* Enable working on different work dir.
* Enable using snapshot API to avoid race conditions.
* Ignore empty blocks.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>