### PR TITLE
s3: change AWS S3 authentication sequence

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -63,9 +63,9 @@ For debug purposes you can set `insecure: true` to switch to plain insecure HTTP
 By default Thanos will try to retrieve credentials from the following sources:
 
 1. From config file if BOTH `access_key` and `secret_key` are present.
-1. IAM credentials retrieved from an instance profile.
-1. From `~/.aws/credentials`
 1. From the standard AWS environment variable - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+1. From `~/.aws/credentials`
+1. IAM credentials retrieved from an instance profile.
 
 NOTE: Getting access key from config file and secret key from other method (and vice versa) is not supported. 
 

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -105,13 +105,13 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		}}
 	} else {
 		chain = []credentials.Provider{
+			&credentials.EnvAWS{},
+			&credentials.FileAWSCredentials{},			
 			&credentials.IAM{
 				Client: &http.Client{
 					Transport: http.DefaultTransport,
 				},
 			},
-			&credentials.FileAWSCredentials{},
-			&credentials.EnvAWS{},
 		}
 	}
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

authentication sequence changed to the following: 
1. config file
2. Environment variables
3. ~/.aws/credentials
4. IAM instance profile

## Verification

built it locally and used env vars for thanos store and thanos compactor. both were able to access S3 without any errors.