### PR TITLE
S3 SignatureV4 Without Config File Credentials

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,3 +91,7 @@ ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
 [[constraint]]
   version = "v0.11.0"
   name = "github.com/mozillazg/go-cos"
+
+[[constraint]]
+  version = "v4.0.0"
+  name = "k8s.io/client-go"

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -90,12 +90,13 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	if err := validate(config); err != nil {
 		return nil, err
 	}
-	if config.AccessKey != "" {
-		signature := credentials.SignatureV4
-		if config.SignatureV2 {
-			signature = credentials.SignatureV2
-		}
 
+	signature := credentials.SignatureV4
+	if config.SignatureV2 {
+		signature = credentials.SignatureV2
+	}
+
+	if config.AccessKey != "" {
 		chain = []credentials.Provider{&credentials.Static{
 			Value: credentials.Value{
 				AccessKeyID:     config.AccessKey,
@@ -106,7 +107,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	} else {
 		chain = []credentials.Provider{
 			&credentials.EnvAWS{},
-			&credentials.FileAWSCredentials{},			
+			&credentials.FileAWSCredentials{},
 			&credentials.IAM{
 				Client: &http.Client{
 					Transport: http.DefaultTransport,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

This PR fixes a bug in s3 config implementation, which allows the use of `SignatureV4` without requiring s3 `access_key` or `secret_key` to be in storage object config. This allows the use of environment variables, aws credentials file, etc.

## Verification

I tested this change by building locally and verifying SignatureV4 was used if config.SignatureV2 was `false`.