### PR TITLE
Fix documentation for SWIFT objectstore.

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -199,9 +199,16 @@ Below is an example configuration file for thanos to use OpenStack swift contain
 ```yaml
 type: SWIFT
 config:
-  storage_account: ""
-  storage_account_key: ""
-  container: ""
+  auth_url: ""
+  username: ""
+  user_id: ""
+  password: ""
+  domain_id: ""
+  domain_name: ""
+  tenant_id: ""
+  tenant_name: ""
+  region_name: ""
+  container_name: ""
 ```
 
 ## Other minio supported S3 object storages

--- a/pkg/objstore/swift/swift.go
+++ b/pkg/objstore/swift/swift.go
@@ -26,16 +26,16 @@ import (
 // DirDelim is the delimiter used to model a directory structure in an object store bucket.
 const DirDelim = "/"
 
-type swiftConfig struct {
+type SwiftConfig struct {
 	AuthUrl       string `yaml:"auth_url"`
-	Username      string `yaml:"username,omitempty"`
-	UserId        string `yaml:"user_id,omitempty"`
+	Username      string `yaml:"username"`
+	UserId        string `yaml:"user_id"`
 	Password      string `yaml:"password"`
-	DomainId      string `yaml:"domain_id,omitempty"`
-	DomainName    string `yaml:"domain_name,omitempty"`
-	TenantID      string `yaml:"tenant_id,omitempty"`
-	TenantName    string `yaml:"tenant_name,omitempty"`
-	RegionName    string `yaml:"region_name,omitempty"`
+	DomainId      string `yaml:"domain_id"`
+	DomainName    string `yaml:"domain_name"`
+	TenantID      string `yaml:"tenant_id"`
+	TenantName    string `yaml:"tenant_name"`
+	RegionName    string `yaml:"region_name"`
 	ContainerName string `yaml:"container_name"`
 }
 
@@ -46,7 +46,7 @@ type Container struct {
 }
 
 func NewContainer(logger log.Logger, conf []byte) (*Container, error) {
-	var sc swiftConfig
+	var sc SwiftConfig
 	if err := yaml.Unmarshal(conf, &sc); err != nil {
 		return nil, err
 	}
@@ -178,8 +178,8 @@ func (c *Container) deleteContainer(name string) error {
 	return containers.Delete(c.client, name).Err
 }
 
-func configFromEnv() swiftConfig {
-	c := swiftConfig{
+func configFromEnv() SwiftConfig {
+	c := SwiftConfig{
 		AuthUrl:       os.Getenv("OS_AUTH_URL"),
 		Username:      os.Getenv("OS_USERNAME"),
 		Password:      os.Getenv("OS_PASSWORD"),
@@ -193,7 +193,7 @@ func configFromEnv() swiftConfig {
 }
 
 // validateForTests checks to see the config options for tests are set.
-func validateForTests(conf swiftConfig) error {
+func validateForTests(conf SwiftConfig) error {
 	if conf.AuthUrl == "" ||
 		conf.Username == "" ||
 		conf.Password == "" ||

--- a/scripts/bucketcfggen/main.go
+++ b/scripts/bucketcfggen/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/objstore/cos"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
+	"github.com/improbable-eng/thanos/pkg/objstore/swift"
 	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v2"
@@ -26,7 +27,7 @@ var (
 		client.AZURE: azure.Config{},
 		client.GCS:   gcs.Config{},
 		client.S3:    s3.Config{},
-		client.SWIFT: azure.Config{},
+		client.SWIFT: swift.SwiftConfig{},
 		client.COS:   cos.Config{},
 	}
 )


### PR DESCRIPTION
This time I've created a proper fix for the SWIFT object store example in the documentation.

## Changes

Made swiftConfig public and added proper config in the helper tool.

## Verification

Executed make docs and the example is now created properly.