### PR TITLE
proxy: Make sure there is no race condition between sender and recv of resp channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
+- [#745](https://github.com/improbable-eng/thanos/pull/745) - Fixed race conditions and edge cases for Thanos Querier fanout logic. 
 - [#649](https://github.com/improbable-eng/thanos/issues/649) - Fixed store label values api to add also external label values.
 - [#708](https://github.com/improbable-eng/thanos/issues/708) - `"X-Amz-Acl": "bucket-owner-full-control"` metadata for s3 upload operation is no longer set by default which was breaking some providers handled by minio client.
 

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -500,14 +500,13 @@ func TestProxyStore_Series_RegressionFillResponseChannel(t *testing.T) {
 	ctx := context.Background()
 	s := newStoreSeriesServer(ctx)
 
-	err := q.Series(
+	testutil.Ok(t, q.Series(
 		&storepb.SeriesRequest{
 			MinTime:  1,
 			MaxTime:  300,
 			Matchers: []storepb.LabelMatcher{{Name: "fed", Value: "a", Type: storepb.LabelMatcher_EQ}},
 		}, s,
-	)
-	testutil.Ok(t, err)
+	))
 	testutil.Equals(t, 0, len(s.SeriesSet))
 	testutil.Equals(t, 110, len(s.Warnings))
 }
@@ -658,6 +657,7 @@ func TestStoreMatches(t *testing.T) {
 type storeSeriesServer struct {
 	// This field just exist to pseudo-implement the unused methods of the interface.
 	storepb.Store_SeriesServer
+
 	ctx context.Context
 
 	SeriesSet []storepb.Series


### PR DESCRIPTION
This fixes potential race condition. Thanks to @jojohappy who highlighted the problem in this PR: https://github.com/improbable-eng/thanos/pull/744

Sorry for getting duplicate PR, but found other race conditions as well (what if sending stream gives err!) and this fixes CI and edge cases for users so it's quite urgent.

Particular race conditions and known issues this PR fixed:
* Start stream series set sending to buffered chamber before we are even reading. When one of store returns err and want to send warn it is blocked forever. (@jojohappy finding)
* When error happens while stream.recv on start stream we were warning only despite our partial response disable flag.
* When client stream is broken we end response channel reader loop. This means that if stores sends us data and channel is buffered we are locked forever!

@domgreen you were fixing something similar. This should fix all cases. More unittests to be added tomorrow. 

PTAL @jojohappy 

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>

