### PR TITLE
fix docs link for supported Prometheus versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ PROMU             ?= $(BIN_DIR)/promu-$(PROMU_VERSION)
 PROMU_VERSION     ?= 264dc36af9ea3103255063497636bd5713e3e9c1
 
 # E2e test deps.
+# Referenced by github.com/improbable-eng/thanos/blob/master/docs/getting_started.md#prometheus
 SUPPORTED_PROM_VERSIONS ?=v2.0.0 v2.2.1 v2.3.2 v2.4.3 v2.5.0
 ALERTMANAGER_VERSION    ?=v0.15.2
 MINIO_SERVER_VERSION    ?=RELEASE.2018-10-06T00-15-16Z

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -30,7 +30,7 @@ The `thanos` binary should now be in your `$PATH` and is the only thing required
 
 Thanos bases on vanilla Prometheus (v2.2.1+).
 
-For exact Prometheus version list Thanos was tested against you can find [here](../Makefile#L25)
+For exact Prometheus version list Thanos was tested against you can find [here](../Makefile#L36)
 
 ## [Sidecar](components/sidecar.md)
 


### PR DESCRIPTION
## Changes
Just a small change to fix the docs link for supported Prometheus versions after https://github.com/improbable-eng/thanos/commit/7d30beb3ac98e6ab3bdeebdee01430f6671922ad
