### PR TITLE
Fixed make proto

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,12 +21,15 @@ The philosophy of Thanos and our community is borrowing much from UNIX philosoph
 
 Adding large new features and components to Thanos should be done by first creating a [proposal](docs/proposals) document outlining the design decisions of the change, motivations for the change, and any alternatives that might have been considered.
 
+## Prerequisites
+
+* It is strongly recommended that you use OSX or popular Linux distributions systems e.g. Ubuntu, Redhat, or OpenSUSE for development.
+
 ## Pull Request Process
 
 1. Read [getting started docs](docs/getting_started.md) and prepare Thanos.
-2. It is strongly recommended that you use OSX or popular Linux distributions systems e.g., Ubuntu, Redhat, and OpenSUSE for development.
-3. Familiarize yourself with [Makefile](Makefile) commands like `format`, `build`, `proto` and `test`.
-4. Fork improbable-eng/thanos.git and start development from your own fork. Here are sample steps to setup your development environment:
+2. Familiarize yourself with [Makefile](Makefile) commands like `format`, `build`, `proto` and `test`.
+3. Fork improbable-eng/thanos.git and start development from your own fork. Here are sample steps to setup your development environment:
 ```console
 $ mkdir -p $GOPATH/src/github.com/improbable-eng
 $ cd $GOPATH/src/github.com/improbable-eng
@@ -38,7 +41,7 @@ $ git merge upstream/master
 $ make build
 $ ./thanos -h
 ```
-5. Keep PRs as small as possible. For each of your PR, you create one branch based on the latest master. Chain them if needed (base PR on other PRs). Here are sample steps you can follow. You can get more details about the workflow from [here](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
+4. Keep PRs as small as possible. For each of your PR, you create one branch based on the latest master. Chain them if needed (base PR on other PRs). Here are sample steps you can follow. You can get more details about the workflow from [here](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
 ```console
 $ git checkout master
 $ git remote update
@@ -48,7 +51,7 @@ $ make build
 $ <Iterate your development>
 $ git push origin <your_branch_for_new_pr>
 ```
-6. If you don't have a live object store ready add these envvars to skip tests for these:
+5. If you don't have a live object store ready add these envvars to skip tests for these:
 - THANOS_SKIP_GCS_TESTS to skip GCS tests.
 - THANOS_SKIP_S3_AWS_TESTS to skip AWS tests.
 - THANOS_SKIP_AZURE_TESTS to skip Azure tests.
@@ -58,7 +61,7 @@ $ git push origin <your_branch_for_new_pr>
 If you skip all of these, the store specific tests will be run against memory object storage only.
 CI runs GCS and inmem tests only for now. Not having these variables will produce auth errors against GCS, AWS, Azure or COS tests.
 
-7. If your change affects users (adds or removes feature) consider adding the item to [CHANGELOG](CHANGELOG.md)
-8. You may merge the Pull Request in once you have the sign-off of at least one developers with write access, or if you
+6. If your change affects users (adds or removes feature) consider adding the item to [CHANGELOG](CHANGELOG.md)
+7. You may merge the Pull Request in once you have the sign-off of at least one developers with write access, or if you
    do not have permission to do that, you may request the second reviewer to merge it for you.
-9. If you feel like your PR waits too long for a review, feel free to ping [`#thanos-dev`](https://join.slack.com/t/improbable-eng/shared_invite/enQtMzQ1ODcyMzQ5MjM4LWY5ZWZmNGM2ODc5MmViNmQ3ZTA3ZTY3NzQwOTBlMTkzZmIxZTIxODk0OWU3YjZhNWVlNDU3MDlkZGViZjhkMjc) channel on our slack for review!
+8. If you feel like your PR waits too long for a review, feel free to ping [`#thanos-dev`](https://join.slack.com/t/improbable-eng/shared_invite/enQtMzQ1ODcyMzQ5MjM4LWY5ZWZmNGM2ODc5MmViNmQ3ZTA3ZTY3NzQwOTBlMTkzZmIxZTIxODk0OWU3YjZhNWVlNDU3MDlkZGViZjhkMjc) channel on our slack for review!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,9 @@ Adding large new features and components to Thanos should be done by first creat
 ## Pull Request Process
 
 1. Read [getting started docs](docs/getting_started.md) and prepare Thanos.
-2. Familarize yourself with [Makefile](Makefile) commands like `format`, `build`, `proto` and `test`.
-3. Fork improbable-eng/thanos.git and start development from your own fork. Here are sample steps to setup your development environment:
+2. It is strongly recommended that you use OSX or popular Linux distributions systems e.g., Ubuntu, Redhat, and OpenSUSE for development.
+3. Familiarize yourself with [Makefile](Makefile) commands like `format`, `build`, `proto` and `test`.
+4. Fork improbable-eng/thanos.git and start development from your own fork. Here are sample steps to setup your development environment:
 ```console
 $ mkdir -p $GOPATH/src/github.com/improbable-eng
 $ cd $GOPATH/src/github.com/improbable-eng
@@ -37,7 +38,7 @@ $ git merge upstream/master
 $ make build
 $ ./thanos -h
 ```
-4. Keep PRs as small as possible. For each of your PR, you create one branch based on the latest master. Chain them if needed (base PR on other PRs). Here are sample steps you can follow. You can get more details about the workflow from [here](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
+5. Keep PRs as small as possible. For each of your PR, you create one branch based on the latest master. Chain them if needed (base PR on other PRs). Here are sample steps you can follow. You can get more details about the workflow from [here](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
 ```console
 $ git checkout master
 $ git remote update
@@ -47,7 +48,7 @@ $ make build
 $ <Iterate your development>
 $ git push origin <your_branch_for_new_pr>
 ```
-5. If you don't have a live object store ready add these envvars to skip tests for these:
+6. If you don't have a live object store ready add these envvars to skip tests for these:
 - THANOS_SKIP_GCS_TESTS to skip GCS tests.
 - THANOS_SKIP_S3_AWS_TESTS to skip AWS tests.
 - THANOS_SKIP_AZURE_TESTS to skip Azure tests.
@@ -57,7 +58,7 @@ $ git push origin <your_branch_for_new_pr>
 If you skip all of these, the store specific tests will be run against memory object storage only.
 CI runs GCS and inmem tests only for now. Not having these variables will produce auth errors against GCS, AWS, Azure or COS tests.
 
-6. If your change affects users (adds or removes feature) consider adding the item to [CHANGELOG](CHANGELOG.md)
-7. You may merge the Pull Request in once you have the sign-off of at least one developers with write access, or if you
+7. If your change affects users (adds or removes feature) consider adding the item to [CHANGELOG](CHANGELOG.md)
+8. You may merge the Pull Request in once you have the sign-off of at least one developers with write access, or if you
    do not have permission to do that, you may request the second reviewer to merge it for you.
-8. If you feel like your PR waits too long for a review, feel free to ping [`#thanos-dev`](https://join.slack.com/t/improbable-eng/shared_invite/enQtMzQ1ODcyMzQ5MjM4LWY5ZWZmNGM2ODc5MmViNmQ3ZTA3ZTY3NzQwOTBlMTkzZmIxZTIxODk0OWU3YjZhNWVlNDU3MDlkZGViZjhkMjc) channel on our slack for review!
+9. If you feel like your PR waits too long for a review, feel free to ping [`#thanos-dev`](https://join.slack.com/t/improbable-eng/shared_invite/enQtMzQ1ODcyMzQ5MjM4LWY5ZWZmNGM2ODc5MmViNmQ3ZTA3ZTY3NzQwOTBlMTkzZmIxZTIxODk0OWU3YjZhNWVlNDU3MDlkZGViZjhkMjc) channel on our slack for review!

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,8 @@ format: $(GOIMPORTS)
 # proto generates golang files from Thanos proto files.
 .PHONY: proto
 proto: deps $(GOIMPORTS) $(PROTOC)
-	@GOIMPORTS_BIN="$(GOIMPORTS)" PROTOC_BIN="$(PROTOC)" ./scripts/genproto.sh
+	@go install ./vendor/github.com/gogo/protobuf/protoc-gen-gogofast
+	@GOIMPORTS_BIN="$(GOIMPORTS)" PROTOC_BIN="$(PROTOC)" scripts/genproto.sh
 
 .PHONY: promu
 promu: $(PROMU)
@@ -213,4 +214,3 @@ $(PROTOC):
 	@echo ">> installing protoc@${PROTOC_VERSION}"
 	@mv -- "$(TMP_GOPATH)/bin/protoc" "$(BIN_DIR)/protoc-$(PROTOC_VERSION)"
 	@echo ">> produced $(BIN_DIR)/protoc-$(PROTOC_VERSION)"
-	@go install ./vendor/github.com/gogo/protobuf/protoc-gen-gogofast

--- a/Makefile
+++ b/Makefile
@@ -207,10 +207,8 @@ $(PROMU):
 
 $(PROTOC):
 	@echo ">> fetching protoc@${PROTOC_VERSION}"
-	@if [ ! -x '$(BIN_DIR)/protoc' ]; then \
-		curl -LSs $(PROTOC_DOWNLOAD_URL) -o $(BIN_DIR)/$(PROTOC_PACKAGE); \
-		unzip -qqj $(BIN_DIR)/$(PROTOC_PACKAGE) "bin/protoc" -d "$(BIN_DIR)"; \
-	fi
+	@curl -LSs $(PROTOC_DOWNLOAD_URL) -o $(TMP_GOPATH)/$(PROTOC_PACKAGE)
+	@unzip -qqj $(TMP_GOPATH)/$(PROTOC_PACKAGE) "bin/protoc" -d "$(TMP_GOPATH)/bin/"
 	@echo ">> installing protoc@${PROTOC_VERSION}"
-	@mv -- "$(BIN_DIR)/protoc" "$(BIN_DIR)/protoc-$(PROTOC_VERSION)"
+	@mv -- "$(TMP_GOPATH)/bin/protoc" "$(BIN_DIR)/protoc-$(PROTOC_VERSION)"
 	@echo ">> produced $(BIN_DIR)/protoc-$(PROTOC_VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,7 @@ $(PROMU):
 	$(call fetch_go_bin_version,github.com/prometheus/promu,$(PROMU_VERSION))
 
 $(PROTOC):
+	@mkdir -p $(TMP_GOPATH)
 	@echo ">> fetching protoc@${PROTOC_VERSION}"
 	@curl -LSs $(PROTOC_DOWNLOAD_URL) -o $(TMP_GOPATH)/$(PROTOC_PACKAGE)
 	@unzip -qqj $(TMP_GOPATH)/$(PROTOC_PACKAGE) "bin/protoc" -d "$(TMP_GOPATH)/bin/"

--- a/Makefile
+++ b/Makefile
@@ -16,25 +16,23 @@ BIN_DIR           ?= $(FIRST_GOPATH)/bin
 DEP_FINISHED      ?= .dep-finished
 
 # Tools.
-DEP                 ?= $(BIN_DIR)/dep-$(DEP_VERSION)
-DEP_VERSION         ?= 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
-EMBEDMD             ?= $(BIN_DIR)/embedmd-$(EMBEDMD_VERSION)
+DEP               ?= $(BIN_DIR)/dep-$(DEP_VERSION)
+DEP_VERSION       ?= 45be32ba4708aad5e2aa8c86f9432c4c4c1f8da2
+EMBEDMD           ?= $(BIN_DIR)/embedmd-$(EMBEDMD_VERSION)
 # v2.0.0
-EMBEDMD_VERSION     ?= 97c13d6e41602fc6e397eb51c45f38069371a969
-ERRCHECK            ?= $(BIN_DIR)/errcheck-$(ERRCHECK_VERSION)
+EMBEDMD_VERSION   ?= 97c13d6e41602fc6e397eb51c45f38069371a969
+ERRCHECK          ?= $(BIN_DIR)/errcheck-$(ERRCHECK_VERSION)
 # v1.2.0
-ERRCHECK_VERSION    ?= e14f8d59a22d460d56c5ee92507cd94c78fbf274
-LICHE               ?= $(BIN_DIR)/liche-$(LICHE_VERSION)
-LICHE_VERSION       ?= 2a2e6e56f6c615c17b2e116669c4cdb31b5453f3
-GOIMPORTS           ?= $(BIN_DIR)/goimports-$(GOIMPORTS_VERSION)
-GOIMPORTS_VERSION   ?= 1c3d964395ce8f04f3b03b30aaed0b096c08c3c6
-PROMU               ?= $(BIN_DIR)/promu-$(PROMU_VERSION)
+ERRCHECK_VERSION  ?= e14f8d59a22d460d56c5ee92507cd94c78fbf274
+LICHE             ?= $(BIN_DIR)/liche-$(LICHE_VERSION)
+LICHE_VERSION     ?= 2a2e6e56f6c615c17b2e116669c4cdb31b5453f3
+GOIMPORTS         ?= $(BIN_DIR)/goimports-$(GOIMPORTS_VERSION)
+GOIMPORTS_VERSION ?= 1c3d964395ce8f04f3b03b30aaed0b096c08c3c6
+PROMU             ?= $(BIN_DIR)/promu-$(PROMU_VERSION)
 # v0.2.0
-PROMU_VERSION       ?= 264dc36af9ea3103255063497636bd5713e3e9c1
-PROTOC              ?= $(BIN_DIR)/protoc-$(PROTOC_VERSION)
-PROTOC_VERSION      ?= 3.4.0
-PROTOC_PACKAGE      ?= protoc-$(PROTOC_VERSION)-linux-x86_64.zip
-PROTOC_DOWNLOAD_URL ?= https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/$(PROTOC_PACKAGE)
+PROMU_VERSION     ?= 264dc36af9ea3103255063497636bd5713e3e9c1
+PROTOC            ?= $(BIN_DIR)/protoc-$(PROTOC_VERSION)
+PROTOC_VERSION    ?= 3.4.0
 
 # E2e test deps.
 # Referenced by github.com/improbable-eng/thanos/blob/master/docs/getting_started.md#prometheus
@@ -208,8 +206,7 @@ $(PROMU):
 $(PROTOC):
 	@mkdir -p $(TMP_GOPATH)
 	@echo ">> fetching protoc@${PROTOC_VERSION}"
-	@curl -LSs $(PROTOC_DOWNLOAD_URL) -o $(TMP_GOPATH)/$(PROTOC_PACKAGE)
-	@unzip -qqj $(TMP_GOPATH)/$(PROTOC_PACKAGE) "bin/protoc" -d "$(TMP_GOPATH)/bin/"
+	@PROTOC_VERSION="$(PROTOC_VERSION)" TMP_GOPATH="$(TMP_GOPATH)" scripts/installprotoc.sh
 	@echo ">> installing protoc@${PROTOC_VERSION}"
 	@mv -- "$(TMP_GOPATH)/bin/protoc" "$(BIN_DIR)/protoc-$(PROTOC_VERSION)"
 	@echo ">> produced $(BIN_DIR)/protoc-$(PROTOC_VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -207,10 +207,10 @@ $(PROMU):
 
 $(PROTOC):
 	@echo ">> fetching protoc@${PROTOC_VERSION}"
-	@if [ ! -x '$(TMP_GOPATH)/bin/protoc' ]; then \
-		cd -- $(TMP_GOPATH) && curl -OLSs $(PROTOC_DOWNLOAD_URL); \
-		unzip -qq $(PROTOC_PACKAGE); \
+	@if [ ! -x '$(BIN_DIR)/protoc' ]; then \
+		curl -LSs $(PROTOC_DOWNLOAD_URL) -o $(BIN_DIR)/$(PROTOC_PACKAGE); \
+		unzip -qqj $(BIN_DIR)/$(PROTOC_PACKAGE) "bin/protoc" -d "$(BIN_DIR)"; \
 	fi
 	@echo ">> installing protoc@${PROTOC_VERSION}"
-	@mv -- "$(TMP_GOPATH)/bin/protoc" "$(BIN_DIR)/protoc-$(PROTOC_VERSION)"
+	@mv -- "$(BIN_DIR)/protoc" "$(BIN_DIR)/protoc-$(PROTOC_VERSION)"
 	@echo ">> produced $(BIN_DIR)/protoc-$(PROTOC_VERSION)"

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -5,12 +5,15 @@
 set -e
 set -u
 
+PROTOC_BIN=${PROTOC_BIN:-protoc}
+GOIMPORTS_BIN=${GOIMPORTS_BIN:-goimports}
+
 if ! [[ "$0" =~ "scripts/genproto.sh" ]]; then
 	echo "must be run from repository root"
 	exit 255
 fi
 
-if ! [[ $(protoc --version) =~ "3.4.0" ]]; then
+if ! [[ $(${PROTOC_BIN} --version) =~ "3.4.0" ]]; then
 	echo "could not find protoc 3.4.0, is it installed + in PATH?"
 	exit 255
 fi
@@ -24,7 +27,7 @@ DIRS="pkg/store/storepb pkg/store/prompb"
 
 for dir in ${DIRS}; do
 	pushd ${dir}
-		protoc --gogofast_out=plugins=grpc:. -I=. \
+		${PROTOC_BIN} --gogofast_out=plugins=grpc:. -I=. \
             -I="${GOGOPROTO_PATH}" \
             -I="${PROM_PATH}" \
             *.proto
@@ -32,6 +35,6 @@ for dir in ${DIRS}; do
 		sed -i.bak -E 's/import _ \"gogoproto\"//g' *.pb.go
 		sed -i.bak -E 's/import _ \"google\/protobuf\"//g' *.pb.go
 		rm -f *.bak
-		goimports -w *.pb.go
+		${GOIMPORTS_BIN} -w *.pb.go
 	popd
 done

--- a/scripts/installprotoc.sh
+++ b/scripts/installprotoc.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Install the standard protocol buffer implementation - protoc.
+set -e
+set -u
+
+PROTOC_VERSION=${PROTOC_VERSION:-3.4.0}
+TMP_GOPATH=${TMP_GOPATH:-/tmp/thanos-go}
+PROTOC_DOWNLOAD_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}"
+
+OS=$(go env GOOS)
+ARCH=$(go env GOARCH)
+PLATFORM="${OS}/${ARCH}"
+
+is_supported_platform() {
+    platform=$1
+    found=1
+    case "$platform" in
+        darwin/amd64) found=0 ;;
+        darwin/i386) found=0 ;;
+        linux/amd64) found=0 ;;
+        linux/i386) found=0 ;;
+        linux/arm64) found=0 ;;
+    esac
+    return $found
+}
+
+adjust_os() {
+    case ${OS} in
+        darwin) OS=osx ;;
+    esac
+    true
+}
+
+adjust_arch() {
+    case ${ARCH} in
+        amd64) ARCH=x86_64 ;;
+        i386) ARCH=x86_32 ;;
+        arm64) ARCH=aarch_64 ;;
+    esac
+    true
+}
+
+mkdir -p ${TMP_GOPATH}
+
+is_supported_platform "$PLATFORM"
+if [[ $? -eq 1 ]]; then
+    echo "platform $PLATFORM is not supported. See https://github.com/protocolbuffers/protobuf/releases for details"
+    exit 1
+fi
+
+adjust_os
+
+adjust_arch
+
+PACKAGE="protoc-${PROTOC_VERSION}-${OS}-${ARCH}.zip"
+PACKAGE_DOWNLOAD_URL="${PROTOC_DOWNLOAD_URL}/${PACKAGE}"
+curl -LSs ${PACKAGE_DOWNLOAD_URL} -o ${TMP_GOPATH}/${PACKAGE}
+unzip -qqj ${TMP_GOPATH}/${PACKAGE} "bin/protoc" -d "${TMP_GOPATH}/bin/"


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
We have a shortcut of `make proto` to generates golang files from Thanos proto files. But if people have not installed the standard protocol buffer implementation from https://github.com/google/protobuf, the command will be failed. 

This PR will fix the bug for downloading the `protoc` binary and pinning the version at `3.4.0` we specified.
## Verification
To run `make proto` locally.
<!-- How you tested it? How do you know it works? -->