### PR TITLE
Add flag for thanos-store block sync concurrency

### DIFF
--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -112,7 +112,8 @@ Flags:
                                  Object store configuration in YAML.
       --sync-block-duration=3m   Repeat interval for syncing the blocks between
                                  local and remote view.
-      --block-sync-concurrency=20
-                                 Number of goroutines to use when syncing blocks from object storage.
+      --block-sync-concurrency=20  
+                                 Number of goroutines to use when syncing blocks
+                                 from object storage.
 
 ```

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -112,5 +112,7 @@ Flags:
                                  Object store configuration in YAML.
       --sync-block-duration=3m   Repeat interval for syncing the blocks between
                                  local and remote view.
+      --block-sync-concurrency=20
+                                 Number of goroutines to use when syncing blocks from object storage.
 
 ```

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -169,7 +169,7 @@ type BucketStore struct {
 
 	// Verbose enabled additional logging.
 	debugLogging bool
-	// Number of goroutines to use when syncing blocks from object storage
+	// Number of goroutines to use when syncing blocks from object storage.
 	blockSyncConcurrency int
 }
 

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -73,7 +73,7 @@ func prepareStoreWithTestBlocks(t testing.TB, ctx context.Context, dir string, b
 		testutil.Ok(t, os.RemoveAll(dir2))
 	}
 
-	store, err := NewBucketStore(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, 100, 0, false)
+	store, err := NewBucketStore(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, 100, 0, false, 20)
 	testutil.Ok(t, err)
 
 	go func() {


### PR DESCRIPTION
## Changes

Added a command-line argument to thanos store for the number of goroutines to use when syncing blocks from a store.  This should limit the amount of memory used at peak when starting up the process, especially the first time when there won't be `index.cache.json` files on disk already.

## Verification
Added debug statements to validate number of goroutines created during development and blocks being loaded. 