### PR TITLE
Fixed toml file versions; Upgraded cloud.google.com/go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:7131fa3a68e56764067bb569886cc7b03de5523fe5e81cbe0c70368932a1c622"
+  digest = "1:f19c3f0ced947e547141d155158d373336a399bc197380a519dab153f8fd4371"
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
@@ -19,7 +19,7 @@
   version = "v0.35.1"
 
 [[projects]]
-  digest = "1:5f61d4466cef935862c262f6bc00e24beb5b39b551e906f3cfb180dfac096d57"
+  digest = "1:27225d855b839ce9c20e1a2291e4447f744effb952f9eb69ef1a313bf7acb458"
   name = "contrib.go.opencensus.io/exporter/stackdriver"
   packages = ["propagation"]
   pruneopts = ""
@@ -35,7 +35,7 @@
   version = "0.1.7"
 
 [[projects]]
-  digest = "1:f0dc2e8b5f53bd286e49ba57313df9d450ec1f273c59bc7b0011fd4e99eea7db"
+  digest = "1:5da4d3b3b9949b9043d2fd36c4ff9b208f72ad5260a3dcb6f94267a769ee1899"
   name = "github.com/Azure/azure-storage-blob-go"
   packages = ["azblob"]
   pruneopts = ""
@@ -52,7 +52,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a74730e052a45a3fab1d310fdef2ec17ae3d6af16228421e238320846f2aaec8"
+  digest = "1:1399282ad03ac819f0e8a747c888407c5c98bb497d33821a7047c7bae667ede0"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
@@ -71,7 +71,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:354e62d5acb9af138e13ec842f78a846d214a8d4a9f80e578698f1f1565e2ef8"
+  digest = "1:d64110a78451e373c5a952d2625323dbbe3bfe41c67f9652ea9668a6ceb4f645"
   name = "github.com/armon/go-metrics"
   packages = [
     ".",
@@ -82,7 +82,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
+  digest = "1:fca298802a2ab834d6eb0e284788ae037ebc324c0f325ff92c5eea592d189cc5"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
   pruneopts = ""
@@ -98,7 +98,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f1a75a8e00244e5ea77ff274baa9559eb877437b240ee7b278f3fc560d9f08bf"
+  digest = "1:c367c68b4bf22ef91069ae442422025da1a3a57049b370252a7b4a895c3fdd6b"
   name = "github.com/dustin/go-humanize"
   packages = ["."]
   pruneopts = ""
@@ -121,7 +121,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
+  digest = "1:b2106f1668ea5efc1ecc480f7e922a093adb9563fd9ce58585292871f0d0f229"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   pruneopts = ""
@@ -129,7 +129,7 @@
   version = "v1.4.7"
 
 [[projects]]
-  digest = "1:cd5bab9c9e23ffa6858eaa79dc827fd84bc24bc00b0cfb0b14036e393da2b1fa"
+  digest = "1:4d5221853226d8d4be594d52d885ddde38170d2e3159b82ed92ecde4dded2304"
   name = "github.com/go-ini/ini"
   packages = ["."]
   pruneopts = ""
@@ -137,7 +137,7 @@
   version = "v1.38.2"
 
 [[projects]]
-  digest = "1:44ec1082ba97d89ce860abcc6ee3f0cf24e658d3efb8531b0f0a52f0781e4243"
+  digest = "1:8bde347c11c0df9cb474b5927a7cdab415adb841247e5e8404adbd12249efb22"
   name = "github.com/go-kit/kit"
   packages = [
     "log",
@@ -164,7 +164,7 @@
   version = "v1.8.0"
 
 [[projects]]
-  digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
+  digest = "1:673df1d02ca0c6f51458fe94bbb6fae0b05e54084a31db2288f1c4321255c2da"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -176,7 +176,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
+  digest = "1:815d45503dceeca8ffecce0081d7edeae5e75b126107ef763d1c617154d72359"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -193,7 +193,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2a5888946cdbc8aa360fd43301f9fc7869d663f60d5eedae7d4e6e5e4f06f2bf"
+  digest = "1:075128b9fc42e6d99067da1a2e6c0a634a6043b5a60abe6909c51f5ecad37b6d"
   name = "github.com/golang/snappy"
   packages = ["."]
   pruneopts = ""
@@ -208,7 +208,7 @@
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
-  digest = "1:55c1b46a80db2baf4d762c1d0b5cb4946e46125baa02b8959310abab15b54aee"
+  digest = "1:a6cddf1b063a156c043598ff714518975969b4f6badf5cb9eff016717589c0b6"
   name = "github.com/googleapis/gax-go"
   packages = [
     ".",
@@ -219,7 +219,7 @@
   version = "v2.0.3"
 
 [[projects]]
-  digest = "1:b25d3130db325eb5d01fe54bb886a979e34c056422c919617d5c7d6cf4bb11fa"
+  digest = "1:e9aa4d37933cdd1978d83938e8af418c02b4c183e1d6c936efd00ce1628fadb7"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -237,7 +237,7 @@
   revision = "0719c6b22f30132b0ae6c90b038e0d50992107b0"
 
 [[projects]]
-  digest = "1:9a0b2dd1f882668a3d7fbcd424eed269c383a16f1faa3a03d14e0dd5fba571b1"
+  digest = "1:0bf81a189b23434fc792317c9276abfe7aee4eb3f85d3c3659a2e0f21acafe97"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = [
     ".",
@@ -252,7 +252,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9d155c1c6b496391d43b4f4d17ca0d8d533b2d28e9d7ae3757682d25d30ccfa2"
+  digest = "1:ab673e7646a69f9f295248d41b54641b66644d92eb3b863dfd56fae2a2a55de6"
   name = "github.com/grpc-ecosystem/go-grpc-prometheus"
   packages = ["."]
   pruneopts = ""
@@ -276,7 +276,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6396690228a7560bf9247cb90e5ae9c797bd630b01e7d2acab430bbca9a1ecb3"
+  digest = "1:6a611e691e739173805cb54019b5c39bb9d46455526dff31e0e6fe3aaca52776"
   name = "github.com/hashicorp/go-msgpack"
   packages = ["codec"]
   pruneopts = ""
@@ -292,7 +292,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fd8ec2359315965bb6b84fd8e45cd5e8b58b80d8430dc96c8c5dfce46d30dbfc"
+  digest = "1:74f54e6ef2339f1de1e8c4b6674442118bd89e619b2fbd949ef2337330067994"
   name = "github.com/hashicorp/go-sockaddr"
   packages = ["."]
   pruneopts = ""
@@ -307,7 +307,7 @@
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:d2c45a353b65012162c7ca22c39b1b0bd06d39362fb375cf42b4e48e1104bfc6"
+  digest = "1:d7ce65372f495908f80fc1f80f4dab5d763d9a1de544abd95aa719e4262d0dd5"
   name = "github.com/hashicorp/memberlist"
   packages = ["."]
   pruneopts = ""
@@ -347,7 +347,7 @@
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
+  digest = "1:49a8b01a6cd6558d504b65608214ca40a78000e1b343ed0da5c6a9ccd83d6d30"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   pruneopts = ""
@@ -355,7 +355,7 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:4c8d8358c45ba11ab7bb15df749d4df8664ff1582daead28bae58cf8cbe49890"
+  digest = "1:f0bad0fece0fb73c6ea249c18d8e80ffbe86be0457715b04463068f04686cf39"
   name = "github.com/miekg/dns"
   packages = ["."]
   pruneopts = ""
@@ -363,7 +363,7 @@
   version = "v1.0.8"
 
 [[projects]]
-  digest = "1:619ff8becfc8080f2cc4532ea21437e804038e0431c88e171c381fde96eb06ae"
+  digest = "1:a513d21165a0cc81a2e443ba65f992bd1b0a5b2f0c0fe27a58642d915557f966"
   name = "github.com/minio/minio-go"
   packages = [
     ".",
@@ -386,7 +386,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:a7dd959cc032a7a18f1e0ec4671a5b09e7cf4f0e032d8b8d4be1de3560890e4c"
+  digest = "1:484d7b3ea990153489735f4810f74b50c63ea16ba58e2fc34ac88c2b0d80f584"
   name = "github.com/mozillazg/go-cos"
   packages = ["."]
   pruneopts = ""
@@ -400,14 +400,6 @@
   pruneopts = ""
   revision = "4e5d6424981844faafc4b0649036b2e0395bdf99"
   version = "v0.2.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:3adc46876d4d0e4d5bbcfcc44c2116b95d7a5c966e2ee92a219488547fd453f2"
-  name = "github.com/nightlyone/lockfile"
-  packages = ["."]
-  pruneopts = ""
-  revision = "0ad87eef1443f64d3d8c50da647e2b1552851124"
 
 [[projects]]
   digest = "1:94e9081cc450d2cdf4e6886fc2c06c07272f86477df2d74ee5931951fa3d2577"
@@ -426,7 +418,7 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:28a9131d18ac1b8761f41370e59b7e807148bbd24a926816233522fb64e593bf"
+  digest = "1:4e46a239a25ae3c430d31cb18479ecd0c964f02c96310003668c6a828f6e34b8"
   name = "github.com/olekukonko/tablewriter"
   packages = ["."]
   pruneopts = ""
@@ -434,7 +426,7 @@
   version = "v0.0.1"
 
 [[projects]]
-  digest = "1:401f4865a509980af0cc40716e6592b3a616b9a6fa52aab282bb963e6d3fac06"
+  digest = "1:171ac7b583c9e4f28dfd3c310fdef0802a9db6afa066ab71e2134ff2cfb646d7"
   name = "github.com/opentracing/basictracer-go"
   packages = [
     ".",
@@ -445,7 +437,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:78fb99d6011c2ae6c72f3293a83951311147b12b06a5ffa43abf750c4fab6ac5"
+  digest = "1:bba12aa4747b212f75db3e7fee73fe1b66d303cb3ff0c1984b7f2ad20e8bd2bc"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
@@ -465,7 +457,7 @@
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:37e79889eaa743256a4923e15fb6338ad14cfe413985a075322a13744fa3602b"
+  digest = "1:6b845cb63c34fc6ed0f4eb2d5ff1f5834c76f133c17b680fc36ad7c5021a8011"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -478,7 +470,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:185cf55b1f44a1bf243558901c3f06efa5c64ba62cfdcbb1bf7bbe8c3fb68561"
+  digest = "1:562d53e436b244a9bb5c1ff43bcaf4882e007575d34ec37717b15751c65cc63a"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = ""
@@ -486,7 +478,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f477ef7b65d94fb17574fc6548cef0c99a69c1634ea3b6da248b63a61ebe0498"
+  digest = "1:8a871dca636f82a927daffe10e9866fee6aa97a215905d56e97ecc73c07d5d44"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -500,7 +492,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e04aaa0e8f8da0ed3d6c0700bd77eda52a47f38510063209d72d62f0ef807d5e"
+  digest = "1:7f298639cea3d8fe88aeefe6a7af1d642bca295cd125e172d320f57064c956c2"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -512,11 +504,12 @@
   revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
-  digest = "1:2f2138db39ee627b66623fbc8aaa508383f8dc14bb1d6739cba62cc205f02fdd"
+  digest = "1:43ad0a170d6f826f8dd63244960384eb205e75423a444f7afbf145425f287227"
   name = "github.com/prometheus/prometheus"
   packages = [
     "discovery/file",
     "discovery/targetgroup",
+    "pkg/gate",
     "pkg/labels",
     "pkg/rulefmt",
     "pkg/textparse",
@@ -532,11 +525,10 @@
     "util/testutil",
   ]
   pruneopts = ""
-  revision = "71af5e29e815795e9dd14742ee7725682fa14b7b"
-  version = "v2.3.2"
+  revision = "3bd41cc92c7800cc6072171bd4237406126fa169"
 
 [[projects]]
-  digest = "1:baccfad2a001820617e141f836390a28a7940e1d8b1d2391eca8a58e07133853"
+  digest = "1:00780e2d7a870f4de3da0d854cc419170c81cf82e6f2e802a3543fcf54c1867d"
   name = "github.com/prometheus/tsdb"
   packages = [
     ".",
@@ -545,9 +537,11 @@
     "fileutil",
     "index",
     "labels",
+    "wal",
   ]
   pruneopts = ""
-  revision = "bd832fc8274e8fe63999ac749daaaff9d881241f"
+  revision = "10ba228e6baa4811818e04b1ab9b48110bb43d7b"
+  version = "v0.4.0"
 
 [[projects]]
   branch = "master"
@@ -558,7 +552,7 @@
   revision = "e2103e2c35297fb7e17febb81e49b312087a2372"
 
 [[projects]]
-  digest = "1:3fcbf733a8d810a21265a7f2fe08a3353db2407da052b233f8b204b5afc03d9b"
+  digest = "1:2c38661f5fb038bfb95197e0e5bc7a8f050d1f992c5ddaa01945e58fe2ef00de"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = ""
@@ -566,10 +560,11 @@
   version = "v1.0.6"
 
 [[projects]]
-  digest = "1:8778190ba18941ba540ea3a065bfe3e6c4126ab16aa2f8a240076ef51af9ab75"
+  digest = "1:eebd9b01fe3b4523521eeebd3d81436a392c8105bf32e1a6b95abcc0133f5309"
   name = "go.opencensus.io"
   packages = [
     ".",
+    "exemplar",
     "internal",
     "internal/tagencoding",
     "plugin/ocgrpc",
@@ -582,14 +577,15 @@
     "trace",
     "trace/internal",
     "trace/propagation",
+    "trace/tracestate",
   ]
   pruneopts = ""
-  revision = "7b558058b7cc960667590e5413ef55157b06652e"
-  version = "v0.15.0"
+  revision = "b7bf3cdb64150a8c8c53b769fdeb2ba581bd4d4b"
+  version = "v0.18.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:b2d8b39397ca07929a3de3a3fd2b6ca4c8d48e9cadaa7cf2b083e27fd9e78107"
+  digest = "1:16db3d6f4f8bbe4b7b42cb8808e68457fea4bd7aea410b77c8c9a6dc26253a60"
   name = "golang.org/x/crypto"
   packages = [
     "argon2",
@@ -603,7 +599,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1e9704e5379e68ac473c28aeb3f7e7cd4036ae8a246bf0285b5ebdbb8e0cfacf"
+  digest = "1:4381a93509c06203e7f3dd14ca61ea2af7e951eba07561bf9d85fd2d10602fb3"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -625,7 +621,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b697592485cb412be4188c08ca0beed9aab87f36b86418e21acc4a3998f63734"
+  digest = "1:ae181e046572bff397421c415715120190004207493745fec4b385925dc13f6d"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -639,7 +635,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b2ea75de0ccb2db2ac79356407f8a4cd8f798fe15d41b381c00abf3ae8e55ed1"
+  digest = "1:d84d0f563cc649de4c9a8272a0395f75b11952202d18d4d927e933cc91493062"
   name = "golang.org/x/sync"
   packages = [
     "errgroup",
@@ -650,7 +646,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:85316553c08142add4a383f8950d9c376ba8bd72456de8840d78af0c37c099c9"
+  digest = "1:54bad0d07b2d834122adaf5ecc35e4df006a4e0bb6114f2466b73e2cc6f03583"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
@@ -661,7 +657,7 @@
   revision = "ebe1bf3edb3325c393447059974de898d5133eb8"
 
 [[projects]]
-  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
+  digest = "1:af9bfca4298ef7502c52b1459df274eed401a4f5498b900e9a92d28d3d87ac5a"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -693,7 +689,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b733c0bc39e94f61e47a81faffa8eac9668b161ab97d082d823a79dcc847f88c"
+  digest = "1:7e248912e9ce5218a30a9fa1b4ed575e474430e178a24af34ecb2373dbb93752"
   name = "google.golang.org/api"
   packages = [
     "gensupport",
@@ -713,7 +709,7 @@
   revision = "0ad5a633fea1d4b64bf5e6a01e30d1fc466038e5"
 
 [[projects]]
-  digest = "1:c1771ca6060335f9768dff6558108bc5ef6c58506821ad43377ee23ff059e472"
+  digest = "1:eede11c81b63c8f6fd06ef24ba0a640dc077196ec9b7a58ecde03c82eee2f151"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -735,7 +731,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e43f1cb3f488a0c2be85939c2a594636f60b442a12a196c778bd2d6c9aca3df7"
+  digest = "1:7040eaf95eb09f6f69e1415074049a9a66236d59d8767f2d17b759b916f79fb1"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
@@ -748,7 +744,7 @@
   revision = "11092d34479b07829b72e10713b159248caf5dad"
 
 [[projects]]
-  digest = "1:ca75b3775a5d4e5d1fb48f57ef0865b4aaa8b3f00e6b52be68db991c4594e0a7"
+  digest = "1:cb1330030248de97a11d9f9664f3944fce0df947e5ed94dbbd9cb6e77068bd46"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -784,7 +780,7 @@
   version = "v1.14.0"
 
 [[projects]]
-  digest = "1:15d017551627c8bb091bde628215b2861bed128855343fdd570c62d08871f6e1"
+  digest = "1:2840683aa0e9980689f85bf48b2a56ec7a108fd089f12af8ea7d98c172819589"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
   pruneopts = ""
@@ -792,7 +788,7 @@
   version = "v2.2.6"
 
 [[projects]]
-  digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
+  digest = "1:b2106f1668ea5efc1ecc480f7e922a093adb9563fd9ce58585292871f0d0f229"
   name = "gopkg.in/fsnotify/fsnotify.v1"
   packages = ["."]
   pruneopts = ""

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -2,7 +2,7 @@ ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
 
 [[constraint]]
   name = "cloud.google.com/go"
-  version = "0.16.0"
+  version = "0.35.1"
 
 [[constraint]]
   name = "github.com/go-kit/kit"
@@ -47,7 +47,7 @@ ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
 
 [[constraint]]
   name = "github.com/prometheus/tsdb"
-  version = "v0.4.0"
+  version = "0.4.0"
 
 [[constraint]]
   branch = "master"
@@ -63,7 +63,7 @@ ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "v1.12.1"
+  version = "1.12.1"
 
 [[constraint]]
   name = "gopkg.in/alecthomas/kingpin.v2"
@@ -87,8 +87,12 @@ ignored = ["github.com/improbable-eng/thanos/benchmark/*"]
 
 [[constraint]]
   name = "github.com/fatih/structtag"
-  version = "v1.0.0"
+  version = "1.0.0"
 
 [[constraint]]
-  version = "v0.11.0"
+  version = "0.11.0"
   name = "github.com/mozillazg/go-cos"
+
+[[override]]
+  name = "go.opencensus.io"
+  version = "v0.18.0"

--- a/pkg/shipper/shipper_e2e_test.go
+++ b/pkg/shipper/shipper_e2e_test.go
@@ -123,7 +123,7 @@ func TestShipper_UploadBlocks_e2e(t *testing.T) {
 		}
 
 		for id := range expBlocks {
-			ok, _ := bkt.Exists(nil, path.Join(id.String(), block.MetaFilename))
+			ok, _ := bkt.Exists(ctx, path.Join(id.String(), block.MetaFilename))
 			testutil.Assert(t, ok, "block %s was not uploaded", id)
 		}
 		for fn, exp := range expFiles {


### PR DESCRIPTION
This will hopefully make sure dependantbot is not trolling us (: 

The problem: Go dep expects toml file `version` in `0.16.0` not `v0.16.0`... -.-  
Signed-off-by: Bartek Plotka <bwplotka@gmail.com>

