### PR TITLE
LRU cache ensureFits() tweaks WRT deadlocking

### DIFF
--- a/pkg/store/cache.go
+++ b/pkg/store/cache.go
@@ -116,6 +116,9 @@ func newIndexCache(reg prometheus.Registerer, maxBytes uint64) (*indexCache, err
 }
 
 func (c *indexCache) ensureFits(b []byte) {
+	if uint64(len(b)) > c.maxSize {
+		return
+	}
 	for c.curSize+uint64(len(b)) > c.maxSize {
 		c.lru.RemoveOldest()
 	}

--- a/pkg/store/cache.go
+++ b/pkg/store/cache.go
@@ -139,8 +139,7 @@ func (c *indexCache) setPostings(b ulid.ULID, l labels.Label, v []byte) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	fits := c.ensureFits(v)
-	if !fits {
+	if !c.ensureFits(v) {
 		c.overflow.WithLabelValues(cacheTypePostings).Add(1)
 		return
 	}
@@ -174,8 +173,7 @@ func (c *indexCache) setSeries(b ulid.ULID, id uint64, v []byte) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	fits := c.ensureFits(v)
-	if !fits {
+	if !c.ensureFits(v) {
 		c.overflow.WithLabelValues(cacheTypeSeries).Add(1)
 		return
 	}

--- a/pkg/store/cache.go
+++ b/pkg/store/cache.go
@@ -140,7 +140,7 @@ func (c *indexCache) setPostings(b ulid.ULID, l labels.Label, v []byte) {
 	defer c.mtx.Unlock()
 
 	if !c.ensureFits(v) {
-		c.overflow.WithLabelValues(cacheTypePostings).Add(1)
+		c.overflow.WithLabelValues(cacheTypePostings).Inc()
 		return
 	}
 
@@ -174,7 +174,7 @@ func (c *indexCache) setSeries(b ulid.ULID, id uint64, v []byte) {
 	defer c.mtx.Unlock()
 
 	if !c.ensureFits(v) {
-		c.overflow.WithLabelValues(cacheTypeSeries).Add(1)
+		c.overflow.WithLabelValues(cacheTypeSeries).Inc()
 		return
 	}
 

--- a/pkg/store/cache_test.go
+++ b/pkg/store/cache_test.go
@@ -1,4 +1,4 @@
-// Tests out the edge cases of the index cache.
+// Tests out the index cache implementation.
 package store
 
 import (
@@ -8,7 +8,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func test_index_edge(t *testing.T) {
+// TestIndexCacheEdge tests the index cache edge cases.
+func TestIndexCacheEdge(t *testing.T) {
 	metrics := prometheus.NewRegistry()
 	cache, err := newIndexCache(metrics, 1)
 	testutil.Ok(t, err)

--- a/pkg/store/cache_test.go
+++ b/pkg/store/cache_test.go
@@ -1,0 +1,21 @@
+// Tests out the edge cases of the index cache.
+package store
+
+import (
+	"testing"
+
+	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func test_index_edge(t *testing.T) {
+	metrics := prometheus.NewRegistry()
+	cache, err := newIndexCache(metrics, 1)
+	testutil.Ok(t, err)
+
+	fits := cache.ensureFits([]byte{42, 24})
+	testutil.Equals(t, fits, false)
+
+	fits = cache.ensureFits([]byte{42})
+	testutil.Equals(t, fits, true)
+}


### PR DESCRIPTION
Related to #651. An initial attempt to fix this because I am always nervous that some person could unintentionally make our Thanos Store instance hang even if the index cache is quite big :( 

## Changes

`thanos_store_index_cache_items_overflowed_total` metric added which shows how many times we have tried to add an item to the cache which was simply too big according to the `--index-cache-size` parameter. `ensureFits()` now returns false when we cannot possibly ensure that the passed slice could fit into the cache. The original problem still exists in some form that `setPostings` or `setSeries` could block for a longer time if there are a lot of small items in the cache however at least it shouldn't dead-lock.

## Verification

Wrote unit tests for it and they pass. It is kind of hard to reproduce this unfortunately in a live environment with the changes but I will see what I can do.