### PR TITLE
ruler: require either --query or --query.sd-files when gossip is disabled

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -138,6 +138,10 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			fileSD = file.NewDiscovery(conf, logger)
 		}
 
+		if len(*queries) < 1 && peer.Name() == "no gossip" && fileSD == nil {
+			return errors.Errorf("Gossip is disabled and no --query parameter was given.")
+		}
+
 		return runRule(g,
 			logger,
 			reg,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Fixes #799 
## Changes
This checks if either `--query` or `--query.sd-files` flag has been given, when `--cluster.disable` flag is set.
<!-- Enumerate changes you made -->

## Verification
Tested with different combinations of above mentioned flags. Also `make test`
<!-- How you tested it? How do you know it works? -->