### PR TITLE
rule: add verification for labels provided via --label

### DIFF
--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -38,6 +38,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/discovery/file"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
@@ -717,6 +718,9 @@ func parseFlagLabels(s []string) (labels.Labels, error) {
 		parts := strings.SplitN(l, "=", 2)
 		if len(parts) != 2 {
 			return nil, errors.Errorf("unrecognized label %q", l)
+		}
+		if !model.LabelName.IsValid(model.LabelName(string(parts[0]))) {
+			return nil, errors.Errorf("unsupported format for label %s", l)
 		}
 		val, err := strconv.Unquote(parts[1])
 		if err != nil {

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -12,41 +12,41 @@ import (
 
 func Test_parseFlagLabels(t *testing.T) {
 	var tData = []struct {
-		s   []string
-		err error
+		s         []string
+		expectErr bool
 	}{
 		{
-			s:   []string{`labelName="LabelVal"`, `_label_Name="LabelVal"`, `label_name="LabelVal"`, `LAb_el_Name="LabelValue"`, `lab3l_Nam3="LabelValue"`}, // Valid
-			err: nil,
+			s:         []string{`labelName="LabelVal"`, `_label_Name="LabelVal"`, `label_name="LabelVal"`, `LAb_el_Name="LabelValue"`, `lab3l_Nam3="LabelValue"`},
+			expectErr: false,
 		},
 		{
-			s:   []string{`label-Name="LabelVal"`}, //Unsupported labelname
-			err: errors.New(""),
+			s:         []string{`label-Name="LabelVal"`}, //Unsupported labelname
+			expectErr: true,
 		},
 		{
-			s:   []string{`label:Name="LabelVal"`}, //Unsupported labelname
-			err: errors.New(""),
+			s:         []string{`label:Name="LabelVal"`}, //Unsupported labelname
+			expectErr: true,
 		},
 		{
-			s:   []string{`1abelName="LabelVal"`}, //Unsupported labelname
-			err: errors.New(""),
+			s:         []string{`1abelName="LabelVal"`}, //Unsupported labelname
+			expectErr: true,
 		},
 		{
-			s:   []string{`label_Name"LabelVal"`}, //Missing "=" seprator
-			err: errors.New(""),
+			s:         []string{`label_Name"LabelVal"`}, //Missing "=" seprator
+			expectErr: true,
 		},
 		{
-			s:   []string{`label_Name= "LabelVal"`}, //whitespace invalid syntax
-			err: errors.New(""),
+			s:         []string{`label_Name= "LabelVal"`}, //Whitespace invalid syntax
+			expectErr: true,
 		},
 		{
-			s:   []string{`label_name=LabelVal`}, //Missing quotes invalid syntax
-			err: errors.New(""),
+			s:         []string{`label_name=LabelVal`}, //Missing quotes invalid syntax
+			expectErr: true,
 		},
 	}
 	for _, td := range tData {
 		_, err := parseFlagLabels(td.s)
-		testutil.Equals(t, err == nil, td.err == nil)
+		testutil.Equals(t, err != nil, td.expectErr)
 	}
 }
 

--- a/cmd/thanos/rule_test.go
+++ b/cmd/thanos/rule_test.go
@@ -10,6 +10,46 @@ import (
 	"github.com/pkg/errors"
 )
 
+func Test_parseFlagLabels(t *testing.T) {
+	var tData = []struct {
+		s   []string
+		err error
+	}{
+		{
+			s:   []string{`labelName="LabelVal"`, `_label_Name="LabelVal"`, `label_name="LabelVal"`, `LAb_el_Name="LabelValue"`, `lab3l_Nam3="LabelValue"`}, // Valid
+			err: nil,
+		},
+		{
+			s:   []string{`label-Name="LabelVal"`}, //Unsupported labelname
+			err: errors.New(""),
+		},
+		{
+			s:   []string{`label:Name="LabelVal"`}, //Unsupported labelname
+			err: errors.New(""),
+		},
+		{
+			s:   []string{`1abelName="LabelVal"`}, //Unsupported labelname
+			err: errors.New(""),
+		},
+		{
+			s:   []string{`label_Name"LabelVal"`}, //Missing "=" seprator
+			err: errors.New(""),
+		},
+		{
+			s:   []string{`label_Name= "LabelVal"`}, //whitespace invalid syntax
+			err: errors.New(""),
+		},
+		{
+			s:   []string{`label_name=LabelVal`}, //Missing quotes invalid syntax
+			err: errors.New(""),
+		},
+	}
+	for _, td := range tData {
+		_, err := parseFlagLabels(td.s)
+		testutil.Equals(t, err == nil, td.err == nil)
+	}
+}
+
 func TestRule_AlertmanagerResolveWithoutPort(t *testing.T) {
 	mockResolver := mockResolver{
 		resultIPs: map[string][]string{


### PR DESCRIPTION
Fixes #800 
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
Uses prometheus' LabelName verification to check if labels provided via `--label` fit the guidelines
<!-- Enumerate changes you made -->

## Verification
`make test` and tested various unsupported label names like `-`. 
<!-- How you tested it? How do you know it works? -->