### PR TITLE
kubernetes-demo: manifests to use improbable/thanos:v0.3.0

### DIFF
--- a/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml
+++ b/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml
@@ -115,7 +115,7 @@ spec:
           - name: prometheus
             mountPath: /var/prometheus
       - name: thanos
-        image: improbable/thanos:v0.3.0-rc.0
+        image: improbable/thanos:v0.3.0
         args:
           - sidecar
           - --log.level=debug

--- a/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml
+++ b/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml
@@ -110,7 +110,7 @@ spec:
           - name: prometheus
             mountPath: /var/prometheus
       - name: thanos
-        image: improbable/thanos:v0.3.0-rc.0
+        image: improbable/thanos:v0.3.0
         args:
           - sidecar
           - --log.level=debug

--- a/tutorials/kubernetes-demo/manifests/thanos-compactor.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-compactor.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: thanos
-          image: improbable/thanos:v0.3.0-rc.0
+          image: improbable/thanos:v0.3.0
           args:
             - compact
             - --log.level=debug

--- a/tutorials/kubernetes-demo/manifests/thanos-gateway.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-gateway.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: thanos
-        image: improbable/thanos:v0.3.0-rc.0
+        image: improbable/thanos:v0.3.0
         args:
         - store
         - --log.level=debug

--- a/tutorials/kubernetes-demo/manifests/thanos-querier-no-us1.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-querier-no-us1.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: thanos
-        image: improbable/thanos:v0.3.0-rc.0
+        image: improbable/thanos:v0.3.0
         args:
         - query
         - --log.level=debug

--- a/tutorials/kubernetes-demo/manifests/thanos-querier.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-querier.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: thanos
-        image: improbable/thanos:v0.3.0-rc.0
+        image: improbable/thanos:v0.3.0
         args:
         - query
         - --log.level=debug

--- a/tutorials/kubernetes-demo/manifests/thanos-ruler.yaml
+++ b/tutorials/kubernetes-demo/manifests/thanos-ruler.yaml
@@ -45,7 +45,7 @@ spec:
     spec:
       containers:
         - name: thanos
-          image: improbable/thanos:v0.3.0-rc.0
+          image: improbable/thanos:v0.3.0
           args:
             - rule
             - --log.level=debug


### PR DESCRIPTION
Signed-off-by: David Calvert <davidcalvertfr@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Updated kubernetes-demo manifests to use improbable/thanos:v0.3.0 docker image instead of the rc.

## Verification

Based on image tag available here : 
https://hub.docker.com/r/improbable/thanos/tags