### PR TITLE
reloader: add support for watching symlinked directories of rules

### DIFF
--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -207,20 +207,10 @@ func (r *Reloader) apply(ctx context.Context) error {
 
 	h := sha256.New()
 	for _, ruleDir := range r.ruleDirs {
-		walkDir := ruleDir
-		// check if ruleDir is a symlink
-		ruleDirInfo, err := os.Lstat(ruleDir)
+		walkDir, err := filepath.EvalSymlinks(ruleDir)
 		if err != nil {
-			return errors.Wrap(err, "rules stat")
+			return errors.Wrap(err, "ruleDir symlink eval")
 		}
-		if ruleDirInfo.Mode()&os.ModeSymlink != 0 {
-			// symlink resolution is necessary.
-			walkDir, err = os.Readlink(ruleDir)
-			if err != nil {
-				return errors.Wrap(err, "rules symlink resolution")
-			}
-		}
-
 		err = filepath.Walk(walkDir, func(path string, f os.FileInfo, err error) error {
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Fixes #760 

## Changes
 - add test to verify behavior difference between watches of symlinked files versus symlinked directories
 - add symlink resolution to rule directories if necessary

## Verification
 - `go test`

<!-- How you tested it? How do you know it works? -->