### PR TITLE
compactor: change GatherIndexIssueStats validation logic on sorted labels

### DIFF
--- a/pkg/block/index_test.go
+++ b/pkg/block/index_test.go
@@ -1,10 +1,14 @@
 package block
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/prometheus/tsdb/index"
+	"github.com/prometheus/tsdb/tsdbutil"
 
 	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/thanos/pkg/testutil"
@@ -43,4 +47,155 @@ func TestWriteReadIndexCache(t *testing.T) {
 	testutil.Assert(t, ok, "")
 	testutil.Equals(t, []string{"1"}, vals)
 	testutil.Equals(t, 6, len(postings))
+}
+
+func TestGatherIndexIssueStats(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test-gather-stats")
+	testutil.Ok(t, err)
+	// Cleans up all temp files
+	defer func() { testutil.Ok(t, os.RemoveAll(tmpDir)) }()
+
+	l := log.NewNopLogger()
+
+	// Non existent file
+	_, err = GatherIndexIssueStats(l, "", 0, 0)
+	testutil.NotOk(t, err)
+
+	// Real but empty file
+	tmpfile, err := ioutil.TempFile(tmpDir, "empty-file")
+	testutil.Ok(t, err)
+	_, err = GatherIndexIssueStats(l, tmpfile.Name(), 0, 0)
+	testutil.NotOk(t, err)
+
+	// Working test cases
+	testCases := []struct {
+		name       string
+		lsets      []labels.Labels
+		expected   Stats
+		startTime  int64
+		endTime    int64
+		numSamples int
+	}{
+		{
+			name: "empty case",
+		},
+		{
+			name: "1 labelset name only",
+			lsets: []labels.Labels{
+				{
+					{Name: "__name__", Value: "metric_name"},
+				},
+			},
+			expected: Stats{TotalSeries: 1},
+		},
+		{
+			name: "2 labelsets name only",
+			lsets: []labels.Labels{
+				{
+					{Name: "__name__", Value: "metric_name"},
+				}, {
+					{Name: "__name__", Value: "metric_name_2"},
+				},
+			},
+			expected: Stats{TotalSeries: 2},
+		},
+		{
+			name: "2 labelsets with adtl labels",
+			lsets: []labels.Labels{
+				{
+					{Name: "__name__", Value: "metric_name"},
+					{Name: "label", Value: "value1"},
+				}, {
+					{Name: "__name__", Value: "metric_name"},
+					{Name: "label", Value: "value2"},
+				},
+			},
+			expected: Stats{TotalSeries: 2},
+		},
+		{
+			name: "1 labelset with lots of labels",
+			lsets: []labels.Labels{
+				{
+					{Name: "__name__", Value: "metric_name"},
+					{Name: "a", Value: "1"},
+					{Name: "b", Value: "2"},
+					{Name: "c", Value: "3"},
+					{Name: "d", Value: "4"},
+					{Name: "e", Value: "5"},
+				},
+			},
+			expected: Stats{TotalSeries: 1},
+		},
+		{
+			// Name always comes first and prometheus doesn't sort it.
+			// https://github.com/prometheus/prometheus/blob/9f903fb3f7841f55d1b634d5fb02986a8bfc5e0c/pkg/textparse/promparse.go#L230
+			name: "1 labelset with capitalized label",
+			lsets: []labels.Labels{
+				{
+					{Name: "__name__", Value: "metric_name"},
+					{Name: "CapitalizedLabel", Value: "1"},
+					{Name: "CapitalizedLabel2", Value: "2"},
+					{Name: "more_common_label", Value: "3"},
+				},
+			},
+			expected: Stats{TotalSeries: 1},
+		},
+	}
+
+	for caseNum, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpfile, err := ioutil.TempFile(tmpDir, fmt.Sprintf("test-case-%d", caseNum))
+			testutil.Ok(t, err)
+
+			testutil.Ok(t, writeTestIndex(tmpfile.Name(), tc.startTime, tc.numSamples, tc.lsets...))
+
+			stats, err := GatherIndexIssueStats(l, tmpfile.Name(), tc.startTime, tc.endTime)
+
+			testutil.Ok(t, err)
+			// == works for now since the struct is only ints (no pointers or nested values)
+			testutil.Assert(t, tc.expected == stats,
+				"index stats did not have an expected value. \nExpected: %+v \nActual:   %+v", tc.expected, stats)
+		})
+	}
+
+}
+
+// writeTestIndex is a helper function that creates an index file with dummy data for testing
+func writeTestIndex(filename string, startTime int64, numSamples int, lsets ...labels.Labels) error {
+	chunks := tsdbutil.PopulatedChunk(numSamples, startTime)
+
+	symbols := make(map[string]struct{})
+	for _, lset := range lsets {
+		for _, l := range lset {
+			symbols[l.Name] = struct{}{}
+			symbols[l.Value] = struct{}{}
+		}
+	}
+
+	memPostings := index.NewMemPostings()
+	for i, lset := range lsets {
+		memPostings.Add(uint64(i), lset)
+	}
+
+	w, err := index.NewWriter(filename)
+	if err != nil {
+		return err
+	}
+
+	if err = w.AddSymbols(symbols); err != nil {
+		return err
+	}
+
+	for i, lset := range lsets {
+		if err = w.AddSeries(uint64(i), lset, chunks); err != nil {
+			return err
+		}
+	}
+
+	pKey, pVal := index.AllPostingsKey()
+	if err = w.WritePostings(pKey, pVal, memPostings.All()); err != nil {
+		return err
+	}
+
+	return w.Close()
 }


### PR DESCRIPTION

Deliberately exclude the first element when checking that a label set is in sorted order.

The first element is always `__name__` for prometheus and while `_` is lexicographically before all lowercase letters, it does not precede upper case letters. This made compaction fail on valid metrics such as `up{Z="one", a="two"}` since the expected order was `[Z, __name__, a]`.

This change brings the validation more in line with what prometheus is using in [promparse](https://github.com/prometheus/prometheus/blob/9f903fb3f7841f55d1b634d5fb02986a8bfc5e0c/pkg/textparse/promparse.go#L230).

An additional check may also be needed to make sure that the first value is always `__name__`

## Changes

* Add test cases for `GatherIndexIssueStats`
* Change sorted label validation to skip the first element

## Verification

Here's a simple config that generates data that will crash the compactor. I validated that my fix no longer crashed the compactor on a similar dataset.

Use the following scrape config in prometheus to generate a metrics `up{Z="one", a="two", instance="localhost:9090",job="prometheus"}`
```
scrape_configs:
  - job_name: 'prometheus'
    static_configs:
    - targets:
      - 'localhost:9090'
      labels:
        Z: one
        a: two
```

Start the compactor running the `improbable/thanos:v0.3.0` image and read the bucket that the thanos sidecar is writing. When the container encounters this timeseries, it will crash with the the following log line

`level=error ts=... caller=main.go:181 msg="running command failed" err="error executing compaction: compaction failed: compaction: gather index issues for block /var/thanos/store/compact/0@{monitor=\"prometheus\",replica=\"prometheus-0\"}/01D36C79GDX5DVXZ1PAD5ZT65M: out-of-order label set {__name__=\"up\",Z=\"one\",a=\"two\",instance=\"localhost:9090\",job=\"prometheus\"} for series 2739605"
`



