### PR TITLE
store: Fixed intersect matching when one matcher filters out all series.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+### Fixed
+- [#833](https://github.com/improbable-eng/thanos/issues/833) Store Gateway matcher regression for intersecting with empty posting.
+
 ## [v0.3.1](https://github.com/improbable-eng/thanos/releases/tag/v0.3.0) - 2019.02.18
 
 ### Fixed
 - [#829](https://github.com/improbable-eng/thanos/issues/829) Store Gateway crashing due to `slice bounds out of range`.
-- [#834](https://github.com/improbable-eng/thanos/issues/834) fixed matcher regression for `<>` `!=`.
+- [#834](https://github.com/improbable-eng/thanos/issues/834) Store Gateway matcher regression for `<>` `!=`.
 
 
 ## [v0.3.0](https://github.com/improbable-eng/thanos/releases/tag/v0.3.0) - 2019.02.08

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1182,13 +1182,8 @@ func (r *bucketIndexReader) ExpandedPostings(ms []labels.Matcher) ([]uint64, err
 
 	// NOTE: Derived from tsdb.PostingsForMatchers.
 	for _, m := range ms {
-		matchingGroup := toPostingGroup(r.LabelValues, m)
-		if matchingGroup == nil {
-			continue
-		}
-
 		// Each group is separate to tell later what postings are intersecting with what.
-		postingGroups = append(postingGroups, matchingGroup)
+		postingGroups = append(postingGroups, toPostingGroup(r.LabelValues, m))
 	}
 
 	if len(postingGroups) == 0 {
@@ -1240,6 +1235,10 @@ func (p *postingGroup) Fill(i int, posting index.Postings) {
 }
 
 func (p *postingGroup) Postings() index.Postings {
+	if len(p.keys) == 0 {
+		return index.EmptyPostings()
+	}
+
 	return p.aggregate(p.postings)
 }
 
@@ -1287,10 +1286,6 @@ func toPostingGroup(lvalsFn func(name string) []string, m labels.Matcher) *posti
 		if m.Matches(val) {
 			matchingLabels = append(matchingLabels, labels.Label{Name: m.Name(), Value: val})
 		}
-	}
-
-	if len(matchingLabels) == 0 {
-		return nil
 	}
 
 	return newPostingGroup(matchingLabels, merge)


### PR DESCRIPTION
Fixes https://github.com/improbable-eng/thanos/issues/833

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>
