### PR TITLE
querier: do A lookups after SRV lookups for store discovery

### DIFF
--- a/pkg/discovery/dns/resolver.go
+++ b/pkg/discovery/dns/resolver.go
@@ -82,7 +82,14 @@ func (s *dnsSD) Resolve(ctx context.Context, name string, qtype QType) ([]string
 			if resPort == "" {
 				resPort = strconv.Itoa(int(rec.Port))
 			}
-			res = append(res, appendScheme(scheme, net.JoinHostPort(rec.Target, resPort)))
+			// Do A lookup for the domain in SRV answer
+			resIPs, err := s.resolver.LookupIPAddr(ctx, rec.Target)
+			if err != nil {
+				return nil, errors.Wrapf(err, "look IP addresses %q", rec.Target)
+			}
+			for _, resIP := range resIPs {
+				res = append(res, appendScheme(scheme, net.JoinHostPort(resIP.String(), resPort)))
+			}
 		}
 	default:
 		return nil, errors.Errorf("invalid lookup scheme %q", qtype)

--- a/pkg/discovery/dns/resolver.go
+++ b/pkg/discovery/dns/resolver.go
@@ -82,7 +82,7 @@ func (s *dnsSD) Resolve(ctx context.Context, name string, qtype QType) ([]string
 			if resPort == "" {
 				resPort = strconv.Itoa(int(rec.Port))
 			}
-			// Do A lookup for the domain in SRV answer
+			// Do A lookup for the domain in SRV answer.
 			resIPs, err := s.resolver.LookupIPAddr(ctx, rec.Target)
 			if err != nil {
 				return nil, errors.Wrapf(err, "look IP addresses %q", rec.Target)

--- a/pkg/discovery/dns/resolver_test.go
+++ b/pkg/discovery/dns/resolver_test.go
@@ -85,14 +85,18 @@ var (
 			resolver: &mockHostnameResolver{
 				resultSRVs: map[string][]*net.SRV{
 					"_test._tcp.mycompany.com": {
-						&net.SRV{Target: "192.168.0.1", Port: 8080},
-						&net.SRV{Target: "192.168.0.2", Port: 8081},
+						&net.SRV{Target: "alt1.mycompany.com.", Port: 8080},
+						&net.SRV{Target: "alt2.mycompany.com.", Port: 8081},
 					},
+				},
+				resultIPs: map[string][]net.IPAddr{
+					"alt1.mycompany.com.": {net.IPAddr{IP: net.ParseIP("192.168.0.1")}},
+					"alt2.mycompany.com.": {net.IPAddr{IP: net.ParseIP("192.168.0.2")}},
 				},
 			},
 		},
 		{
-			testName:       "multiple srv records from srv lookup",
+			testName:       "multiple srv records from srv lookup with specified port",
 			addr:           "_test._tcp.mycompany.com:8082",
 			qtype:          SRV,
 			expectedResult: []string{"192.168.0.1:8082", "192.168.0.2:8082"},
@@ -100,9 +104,13 @@ var (
 			resolver: &mockHostnameResolver{
 				resultSRVs: map[string][]*net.SRV{
 					"_test._tcp.mycompany.com": {
-						&net.SRV{Target: "192.168.0.1", Port: 8080},
-						&net.SRV{Target: "192.168.0.2", Port: 8081},
+						&net.SRV{Target: "alt1.mycompany.com.", Port: 8080},
+						&net.SRV{Target: "alt2.mycompany.com.", Port: 8081},
 					},
+				},
+				resultIPs: map[string][]net.IPAddr{
+					"alt1.mycompany.com.": {net.IPAddr{IP: net.ParseIP("192.168.0.1")}},
+					"alt2.mycompany.com.": {net.IPAddr{IP: net.ParseIP("192.168.0.2")}},
 				},
 			},
 		},

--- a/pkg/discovery/dns/resolver_test.go
+++ b/pkg/discovery/dns/resolver_test.go
@@ -77,7 +77,7 @@ var (
 			resolver:       &mockHostnameResolver{},
 		},
 		{
-			testName:       "multiple srv records from srv lookup",
+			testName:       "multiple SRV records from SRV lookup",
 			addr:           "_test._tcp.mycompany.com",
 			qtype:          SRV,
 			expectedResult: []string{"192.168.0.1:8080", "192.168.0.2:8081"},
@@ -96,7 +96,7 @@ var (
 			},
 		},
 		{
-			testName:       "multiple srv records from srv lookup with specified port",
+			testName:       "multiple SRV records from SRV lookup with specified port",
 			addr:           "_test._tcp.mycompany.com:8082",
 			qtype:          SRV,
 			expectedResult: []string{"192.168.0.1:8082", "192.168.0.2:8082"},
@@ -116,6 +116,44 @@ var (
 		},
 		{
 			testName:       "error from SRV resolver",
+			addr:           "_test._tcp.mycompany.com",
+			qtype:          SRV,
+			expectedResult: nil,
+			expectedErr:    errors.Wrapf(errorFromResolver, "lookup SRV records \"_test._tcp.mycompany.com\""),
+			resolver:       &mockHostnameResolver{err: errorFromResolver},
+		},
+		{
+			testName:       "multiple SRV records from SRV no A lookup",
+			addr:           "_test._tcp.mycompany.com",
+			qtype:          SRVNoA,
+			expectedResult: []string{"192.168.0.1:8080", "192.168.0.2:8081"},
+			expectedErr:    nil,
+			resolver: &mockHostnameResolver{
+				resultSRVs: map[string][]*net.SRV{
+					"_test._tcp.mycompany.com": {
+						&net.SRV{Target: "192.168.0.1", Port: 8080},
+						&net.SRV{Target: "192.168.0.2", Port: 8081},
+					},
+				},
+			},
+		},
+		{
+			testName:       "multiple SRV records from SRV no A lookup with specified port",
+			addr:           "_test._tcp.mycompany.com:8082",
+			qtype:          SRVNoA,
+			expectedResult: []string{"192.168.0.1:8082", "192.168.0.2:8082"},
+			expectedErr:    nil,
+			resolver: &mockHostnameResolver{
+				resultSRVs: map[string][]*net.SRV{
+					"_test._tcp.mycompany.com": {
+						&net.SRV{Target: "192.168.0.1", Port: 8080},
+						&net.SRV{Target: "192.168.0.2", Port: 8081},
+					},
+				},
+			},
+		},
+		{
+			testName:       "error from SRV no A lookup",
 			addr:           "_test._tcp.mycompany.com",
 			qtype:          SRV,
 			expectedResult: nil,


### PR DESCRIPTION
## Changes

This adds an A lookup after the SRV lookups in order to resolve https://github.com/improbable-eng/thanos/issues/752.

## Verification

I made ran the query with `--store` set to a random SRV record (i.e., not something running a store node) then immediately killed the process.  During close down, we see what address the querier was attempting to use for the store node.

On master:
```
martin@swift:~/go/src/github.com/improbable-eng/thanos$ ./thanos query --store=dnssrv+_xmpp-server._tcp.google.com.
level=info ts=2019-02-23T10:17:17.886702366Z caller=flags.go:90 msg="StoreAPI address that will be propagated through gossip" address=192.168.0.14:10901
level=info ts=2019-02-23T10:17:17.891416133Z caller=flags.go:105 msg="QueryAPI address that will be propagated through gossip" address=192.168.0.14:10902
level=info ts=2019-02-23T10:17:17.897047229Z caller=main.go:256 component=query msg="disabled TLS, key and cert must be set to enable"
level=info ts=2019-02-23T10:17:17.897083198Z caller=query.go:468 msg="starting query node"
level=info ts=2019-02-23T10:17:17.897113872Z caller=query.go:437 msg="Listening for query and metrics" address=0.0.0.0:10902
level=info ts=2019-02-23T10:17:17.897256901Z caller=query.go:460 component=query msg="Listening for StoreAPI gRPC" address=0.0.0.0:10901
^Clevel=info ts=2019-02-23T10:17:18.997878046Z caller=main.go:192 msg="caught signal. Exiting." signal=interrupt
level=warn ts=2019-02-23T10:17:18.998304451Z caller=runutil.go:107 component=query msg="detected close error" err="store gRPC listener: close tcp [::]:10901: use of closed netw
ork connection"     
level=warn ts=2019-02-23T10:17:18.998382583Z caller=storeset.go:308 component=storeset msg="update of store node failed" err="initial store client info fetch: rpc error: code =
 Canceled desc = context canceled" address=xmpp-server.l.google.com.:5269                                          
level=warn ts=2019-02-23T10:17:18.998385267Z caller=storeset.go:308 component=storeset msg="update of store node failed" err="initial store client info fetch: rpc error: code =
 Canceled desc = context canceled" address=alt3.xmpp-server.l.google.com.:5269                                                                           
level=warn ts=2019-02-23T10:17:18.998465318Z caller=storeset.go:308 component=storeset msg="update of store node failed" err="initial store client info fetch: rpc error: code =
 Canceled desc = context canceled" address=alt2.xmpp-server.l.google.com.:5269            
level=warn ts=2019-02-23T10:17:18.998606842Z caller=storeset.go:308 component=storeset msg="update of store node failed" err="initial store client info fetch: rpc error: code =
 Canceled desc = context canceled" address=alt4.xmpp-server.l.google.com.:5269                                                          
level=warn ts=2019-02-23T10:17:18.998649891Z caller=storeset.go:308 component=storeset msg="update of store node failed" err="initial store client info fetch: rpc error: code =
 Canceled desc = context canceled" address=alt1.xmpp-server.l.google.com.:5269                                                                                                  level=info ts=2019-02-23T10:17:18.998730396Z caller=main.go:184 msg=exiting
```

On this branch
```
martin@swift:~/go/src/github.com/improbable-eng/thanos$ ./thanos query --store=dnssrv+_xmpp-server._tcp.google.com.
level=info ts=2019-02-23T10:18:45.607836325Z caller=flags.go:90 msg="StoreAPI address that will be propagated through gossip" address=192.168.0.14:10901
level=info ts=2019-02-23T10:18:45.615876888Z caller=flags.go:105 msg="QueryAPI address that will be propagated through gossip" address=192.168.0.14:10902
level=info ts=2019-02-23T10:18:45.632843468Z caller=main.go:256 component=query msg="disabled TLS, key and cert must be set to enable"
level=info ts=2019-02-23T10:18:45.632973588Z caller=query.go:468 msg="starting query node"
level=info ts=2019-02-23T10:18:45.633066084Z caller=query.go:437 msg="Listening for query and metrics" address=0.0.0.0:10902
level=info ts=2019-02-23T10:18:45.633309377Z caller=query.go:460 component=query msg="Listening for StoreAPI gRPC" address=0.0.0.0:10901
^Clevel=info ts=2019-02-23T10:18:47.534010903Z caller=main.go:192 msg="caught signal. Exiting." signal=interrupt
level=warn ts=2019-02-23T10:18:47.534306619Z caller=storeset.go:308 component=storeset msg="update of store node failed" err="initial store client info fetch: rpc error: code = Canceled desc = context canceled" address=74.125.195.125:5269
level=warn ts=2019-02-23T10:18:47.534338676Z caller=storeset.go:308 component=storeset msg="update of store node failed" err="initial store client info fetch: rpc error: code = Canceled desc = context canceled" address=108.177.125.125:5269
```

The second one is what we want, as it is the correct `<ip>:>port>` list that we can also pass in directly