### PR TITLE
Add a multi-stage Dockerfile

### DIFF
--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -1,0 +1,17 @@
+FROM golang:1.11-alpine3.9 as builder
+
+ADD . $GOPATH/src/github.com/improbable-eng/thanos
+WORKDIR $GOPATH/src/github.com/improbable-eng/thanos
+
+RUN apk update && apk upgrade && apk add --no-cache alpine-sdk
+
+RUN git update-index --refresh; make
+
+# -----------------------------------------------------------------------------
+
+FROM quay.io/prometheus/busybox:latest
+LABEL maintainer="The Thanos Authors"
+
+COPY --from=builder /go/src/github.com/improbable-eng/thanos/thanos /bin/thanos
+
+ENTRYPOINT [ "/bin/thanos" ]

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,12 @@ docker: build
 	@echo ">> building docker image '${DOCKER_IMAGE_NAME}'"
 	@docker build -t "${DOCKER_IMAGE_NAME}" .
 
+#docker-multi-stage builds docker image using multi-stage.
+.PHONY: docker-multi-stage
+docker-multi-stage:
+	@echo ">> building docker image '${DOCKER_IMAGE_NAME}' with Dockerfile.multi-stage"
+	@docker build -f Dockerfile.multi-stage -t "${DOCKER_IMAGE_NAME}" .
+
 # docker-push pushes docker image build under `${DOCKER_IMAGE_NAME}` to improbable/"$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
 .PHONY: docker-push
 docker-push:


### PR DESCRIPTION
This makes it easy to build a thanos image without a proper dev env set up.

Also allows to build images using quay.io or docker hub services.