### PR TITLE
store/cache: fix broken metric and current index cache size handling

### DIFF
--- a/pkg/store/cache.go
+++ b/pkg/store/cache.go
@@ -127,7 +127,7 @@ func (c *indexCache) ensureFits(b []byte) bool {
 	if uint64(len(b)) > c.maxSize {
 		return false
 	}
-	for c.curSize+uint64(len(b)) > c.maxSize {
+	for c.curSize > c.maxSize-uint64(len(b)) {
 		if _, val, ok := c.lru.RemoveOldest(); ok {
 			v := val.([]byte)
 			c.curSize -= uint64(len(v))

--- a/pkg/store/cache.go
+++ b/pkg/store/cache.go
@@ -151,6 +151,7 @@ func (c *indexCache) setPostings(b ulid.ULID, l labels.Label, v []byte) {
 	c.lru.Add(cacheItem{b, cacheKeyPostings(l)}, cv)
 
 	c.currentSize.WithLabelValues(cacheTypePostings).Add(float64(len(v)))
+	c.current.WithLabelValues(cacheTypePostings).Inc()
 }
 
 func (c *indexCache) postings(b ulid.ULID, l labels.Label) ([]byte, bool) {
@@ -185,6 +186,7 @@ func (c *indexCache) setSeries(b ulid.ULID, id uint64, v []byte) {
 	c.lru.Add(cacheItem{b, cacheKeySeries(id)}, cv)
 
 	c.currentSize.WithLabelValues(cacheTypeSeries).Add(float64(len(v)))
+	c.current.WithLabelValues(cacheTypeSeries).Inc()
 }
 
 func (c *indexCache) series(b ulid.ULID, id uint64) ([]byte, bool) {

--- a/pkg/store/cache.go
+++ b/pkg/store/cache.go
@@ -128,10 +128,7 @@ func (c *indexCache) ensureFits(b []byte) bool {
 		return false
 	}
 	for c.curSize > c.maxSize-uint64(len(b)) {
-		if _, val, ok := c.lru.RemoveOldest(); ok {
-			v := val.([]byte)
-			c.curSize -= uint64(len(v))
-		}
+		c.lru.RemoveOldest()
 	}
 	return true
 }

--- a/pkg/store/cache_test.go
+++ b/pkg/store/cache_test.go
@@ -3,9 +3,13 @@ package store
 
 import (
 	"testing"
+	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/tsdb/labels"
 )
 
 // TestIndexCacheEdge tests the index cache edge cases.
@@ -19,4 +23,39 @@ func TestIndexCacheEdge(t *testing.T) {
 
 	fits = cache.ensureFits([]byte{42})
 	testutil.Equals(t, fits, true)
+}
+
+// TestIndexCacheSmoke runs the smoke tests for the index cache.
+func TestIndexCacheSmoke(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 10*time.Second)()
+
+	metrics := prometheus.NewRegistry()
+	cache, err := newIndexCache(metrics, 20)
+	testutil.Ok(t, err)
+
+	blid := ulid.ULID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	labels := labels.Label{Name: "test", Value: "123"}
+
+	cache.setPostings(blid, labels, []byte{42})
+
+	p, ok := cache.postings(blid, labels)
+	testutil.Equals(t, ok, true)
+	testutil.Equals(t, p, []byte{42})
+	testutil.Equals(t, cache.curSize, uint64(1))
+
+	cache.setSeries(blid, 1234, []byte{42, 42})
+
+	s, ok := cache.series(blid, 1234)
+	testutil.Equals(t, ok, true)
+	testutil.Equals(t, s, []byte{42, 42})
+	testutil.Equals(t, cache.curSize, uint64(3))
+
+	cache.lru.RemoveOldest()
+	testutil.Equals(t, cache.curSize, uint64(2))
+
+	cache.lru.RemoveOldest()
+	testutil.Equals(t, cache.curSize, uint64(0))
+
+	cache.lru.RemoveOldest()
+	testutil.Equals(t, cache.curSize, uint64(0))
 }


### PR DESCRIPTION
Potpourri of fixes to the cache:

* Do not forget to increase the c.current metric with relevant labels when
adding items to the cache. Without this the metric `thanos_store_index_cache_items` is unavailable.

* Properly adjust c.curSize when adding items to the cache.

* Switch the order of operands in a check to avoid a *potential* uint64 overflow and thus not removing enough items to satisfy our size constraints.

Without these last two fixes essentially the metric `thanos_store_index_cache_items_evicted_total` is always zero together with `thanos_store_index_cache_items_overflowed_total` (most of the time). This is because we never enter the loop, and we never increase c.curSize before this.

Verification:
* New smoke tests pass which check if curSize is properly adjusted.