### PR TITLE
compact: add concurrency to meta sync

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -92,6 +92,9 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 	maxCompactionLevel := cmd.Flag("debug.max-compaction-level", fmt.Sprintf("Maximum compaction level, default is %d: %s", compactions.maxLevel(), compactions.String())).
 		Hidden().Default(strconv.Itoa(compactions.maxLevel())).Int()
 
+	metaSyncConcurrency := cmd.Flag("meta-sync-concurrency", "Number of goroutines to use when syncing metadata from object storage.").
+		Default("1").Int()
+
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
 		return runCompact(g, logger, reg,
 			*httpAddr,
@@ -108,6 +111,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 			name,
 			*disableDownsampling,
 			*maxCompactionLevel,
+			*metaSyncConcurrency,
 		)
 	}
 }
@@ -126,6 +130,7 @@ func runCompact(
 	component string,
 	disableDownsampling bool,
 	maxCompactionLevel int,
+	metaSyncConcurrency int,
 ) error {
 	halted := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_compactor_halted",
@@ -157,7 +162,7 @@ func runCompact(
 		}
 	}()
 
-	sy, err := compact.NewSyncer(logger, reg, bkt, syncDelay)
+	sy, err := compact.NewSyncer(logger, reg, bkt, syncDelay, metaSyncConcurrency)
 	if err != nil {
 		return errors.Wrap(err, "create syncer")
 	}

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -31,41 +31,44 @@ usage: thanos compact [<flags>]
 continuously compacts blocks in an object store bucket
 
 Flags:
-  -h, --help               Show context-sensitive help (also try --help-long and
-                           --help-man).
-      --version            Show application version.
-      --log.level=info     Log filtering level.
-      --log.format=logfmt  Log format to use.
+  -h, --help                     Show context-sensitive help (also try
+                                 --help-long and --help-man).
+      --version                  Show application version.
+      --log.level=info           Log filtering level.
+      --log.format=logfmt        Log format to use.
       --gcloudtrace.project=GCLOUDTRACE.PROJECT  
-                           GCP project to send Google Cloud Trace tracings to.
-                           If empty, tracing will be disabled.
+                                 GCP project to send Google Cloud Trace tracings
+                                 to. If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
-                           How often we send traces (1/<sample-factor>). If 0 no
-                           trace will be sent periodically, unless forced by
-                           baggage item. See `pkg/tracing/tracing.go` for
-                           details.
+                                 How often we send traces (1/<sample-factor>).
+                                 If 0 no trace will be sent periodically, unless
+                                 forced by baggage item. See
+                                 `pkg/tracing/tracing.go` for details.
       --http-address="0.0.0.0:10902"  
-                           Listen host:port for HTTP endpoints.
-      --data-dir="./data"  Data directory in which to cache blocks and process
-                           compactions.
+                                 Listen host:port for HTTP endpoints.
+      --data-dir="./data"        Data directory in which to cache blocks and
+                                 process compactions.
       --objstore.config-file=<bucket.config-yaml-path>  
-                           Path to YAML file that contains object store
-                           configuration.
+                                 Path to YAML file that contains object store
+                                 configuration.
       --objstore.config=<bucket.config-yaml>  
-                           Alternative to 'objstore.config-file' flag. Object
-                           store configuration in YAML.
-      --sync-delay=30m     Minimum age of fresh (non-compacted) blocks before
-                           they are being processed.
+                                 Alternative to 'objstore.config-file' flag.
+                                 Object store configuration in YAML.
+      --sync-delay=30m           Minimum age of fresh (non-compacted) blocks
+                                 before they are being processed.
       --retention.resolution-raw=0d  
-                           How long to retain raw samples in bucket. 0d -
-                           disables this retention
+                                 How long to retain raw samples in bucket. 0d -
+                                 disables this retention
       --retention.resolution-5m=0d  
-                           How long to retain samples of resolution 1 (5
-                           minutes) in bucket. 0d - disables this retention
+                                 How long to retain samples of resolution 1 (5
+                                 minutes) in bucket. 0d - disables this
+                                 retention
       --retention.resolution-1h=0d  
-                           How long to retain samples of resolution 2 (1 hour)
-                           in bucket. 0d - disables this retention
-  -w, --wait               Do not exit after all compactions have been processed
-                           and wait for new work.
+                                 How long to retain samples of resolution 2 (1
+                                 hour) in bucket. 0d - disables this retention
+  -w, --wait                     Do not exit after all compactions have been
+                                 processed and wait for new work.
+      --meta-sync-concurrency=1  Number of goroutines to use when syncing
+                                 metadata from object storage.
 
 ```

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -31,44 +31,44 @@ usage: thanos compact [<flags>]
 continuously compacts blocks in an object store bucket
 
 Flags:
-  -h, --help                     Show context-sensitive help (also try
-                                 --help-long and --help-man).
-      --version                  Show application version.
-      --log.level=info           Log filtering level.
-      --log.format=logfmt        Log format to use.
+  -h, --help               Show context-sensitive help (also try --help-long and
+                           --help-man).
+      --version            Show application version.
+      --log.level=info     Log filtering level.
+      --log.format=logfmt  Log format to use.
       --gcloudtrace.project=GCLOUDTRACE.PROJECT  
-                                 GCP project to send Google Cloud Trace tracings
-                                 to. If empty, tracing will be disabled.
+                           GCP project to send Google Cloud Trace tracings to.
+                           If empty, tracing will be disabled.
       --gcloudtrace.sample-factor=1  
-                                 How often we send traces (1/<sample-factor>).
-                                 If 0 no trace will be sent periodically, unless
-                                 forced by baggage item. See
-                                 `pkg/tracing/tracing.go` for details.
+                           How often we send traces (1/<sample-factor>). If 0 no
+                           trace will be sent periodically, unless forced by
+                           baggage item. See `pkg/tracing/tracing.go` for
+                           details.
       --http-address="0.0.0.0:10902"  
-                                 Listen host:port for HTTP endpoints.
-      --data-dir="./data"        Data directory in which to cache blocks and
-                                 process compactions.
+                           Listen host:port for HTTP endpoints.
+      --data-dir="./data"  Data directory in which to cache blocks and process
+                           compactions.
       --objstore.config-file=<bucket.config-yaml-path>  
-                                 Path to YAML file that contains object store
-                                 configuration.
+                           Path to YAML file that contains object store
+                           configuration.
       --objstore.config=<bucket.config-yaml>  
-                                 Alternative to 'objstore.config-file' flag.
-                                 Object store configuration in YAML.
-      --sync-delay=30m           Minimum age of fresh (non-compacted) blocks
-                                 before they are being processed.
+                           Alternative to 'objstore.config-file' flag. Object
+                           store configuration in YAML.
+      --sync-delay=30m     Minimum age of fresh (non-compacted) blocks before
+                           they are being processed.
       --retention.resolution-raw=0d  
-                                 How long to retain raw samples in bucket. 0d -
-                                 disables this retention
+                           How long to retain raw samples in bucket. 0d -
+                           disables this retention
       --retention.resolution-5m=0d  
-                                 How long to retain samples of resolution 1 (5
-                                 minutes) in bucket. 0d - disables this
-                                 retention
+                           How long to retain samples of resolution 1 (5
+                           minutes) in bucket. 0d - disables this retention
       --retention.resolution-1h=0d  
-                                 How long to retain samples of resolution 2 (1
-                                 hour) in bucket. 0d - disables this retention
-  -w, --wait                     Do not exit after all compactions have been
-                                 processed and wait for new work.
-      --meta-sync-concurrency=1  Number of goroutines to use when syncing
-                                 metadata from object storage.
+                           How long to retain samples of resolution 2 (1 hour)
+                           in bucket. 0d - disables this retention
+  -w, --wait               Do not exit after all compactions have been processed
+                           and wait for new work.
+      --block-sync-concurrency=20  
+                           Number of goroutines to use when syncing block
+                           metadata from object storage.
 
 ```

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -32,7 +32,7 @@ func TestSyncer_SyncMetas_e2e(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
-		sy, err := NewSyncer(nil, nil, bkt, 0)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1)
 		testutil.Ok(t, err)
 
 		// Generate 15 blocks. Initially the first 10 are synced into memory and only the last
@@ -134,7 +134,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		}
 
 		// Do one initial synchronization with the bucket.
-		sy, err := NewSyncer(nil, nil, bkt, 0)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1)
 		testutil.Ok(t, err)
 		testutil.Ok(t, sy.SyncMetas(ctx))
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Add a flag to the `compact` command to allow for fetching of the block metadata in parallel.

## Verification

Tested by running `thanos compact` with `--log.level=debug` to see that it fetches the metadata much quicker when concurrency is added.
