### PR TITLE
compact: add concurrency to group compact

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -70,5 +70,7 @@ Flags:
       --block-sync-concurrency=20  
                            Number of goroutines to use when syncing block
                            metadata from object storage.
+      --group-compact-concurrency=1  
+                           Number of goroutines to use when compacting group.
 
 ```

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -922,6 +922,7 @@ func (c *BucketCompactor) Compact(ctx context.Context, groupCompactConcurrency i
 		}
 		for _, g := range groups {
 			<-groupChan
+			wg.Add(1)
 			go func(g *Group) {
 				defer func() {
 					wg.Done()


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
Allow for compacting of group in parallel.
<!-- Enumerate changes you made -->

## Verification
Tested by running thanos compact to see that compacting much quicker when concurrency is added.
<!-- How you tested it? How do you know it works? -->