### PR TITLE
query: allow multiple TLS server names

### DIFF
--- a/cmd/thanos/query_test.go
+++ b/cmd/thanos/query_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/improbable-eng/thanos/pkg/testutil"
+)
+
+func TestParseServerNameMaps(t *testing.T) {
+	regexMap, err := ParseServerNameMaps([]string{
+		"thanos-.*=thanos-prometheus.local",
+	})
+	testutil.Ok(t, err)
+	for k, v := range regexMap {
+		testutil.Equals(t, k.String(), "thanos-.*")
+		testutil.Equals(t, v, "thanos-prometheus.local")
+	}
+}
+
+func TestParseBadServerNameMaps(t *testing.T) {
+	_, err := ParseServerNameMaps([]string{
+		"thanos-.*=",
+	})
+	testutil.NotOk(t, err)
+}
+
+func TestParseBadRegexServerNameMaps(t *testing.T) {
+	_, err := ParseServerNameMaps([]string{
+		"[0=thanos-prometheus.local",
+	})
+	testutil.NotOk(t, err)
+}


### PR DESCRIPTION
Signed-off-by: Adrien Fillon <adrien.fillon@cdiscount.com>

Alright, I managed to spent a bit of time working on this. As I learned in https://github.com/golang/go/issues/22836 the same feature doesn't exist on the client side apparently so we can't just add a hook and be done. I had to wrap the TLS handshake to send the right server name based on the hostname.

I'm happy with this change though I wonder if I should split the transport wrapper to another file ?

## Changes

* query: remove `--grpc-client-server-name` flag
* query: add `--grpc-client-server-name-map` multi-flag that can look like `thanos-.*=thanos-prometheus.local` to match against any hostname starting with `thanos-` to send `thanos-prometheus.local` as server name for TLS handshake.

## Verification

Added a few tests and deployed it live :smile: I have different certificates for my stores and for my sidecars, both now work.