### PR TITLE
Compact: skip compaction for blocks with no samples

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -790,7 +790,9 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 				continue
 			}
 			if meta.Stats.NumSamples == 0 {
-				cg.deleteBlock(block)
+				if err := cg.deleteBlock(block); err != nil {
+					level.Warn(cg.logger).Log("msg", "failed to delete empty block found during compaction", "block", block)
+				}
 			}
 		}
 		return compID, emptyCompactedBlockSentinelError

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -34,7 +34,6 @@ const (
 )
 
 var blockTooFreshSentinelError = errors.New("Block too fresh")
-var emptyBlockSentinelULID = ulid.MustNew(123, nil)
 
 // Syncer syncronizes block metas from a bucket into a local directory.
 // It sorts them into compaction groups based on equal label sets.
@@ -795,7 +794,8 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 				}
 			}
 		}
-		return emptyBlockSentinelULID, nil
+		// Return a dummy ULID since the bucket compactor takes this as a signal to continue
+		return ulid.New(123, nil)
 	}
 	level.Debug(cg.logger).Log("msg", "compacted blocks",
 		"blocks", fmt.Sprintf("%v", plan), "duration", time.Since(begin))

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -513,23 +513,23 @@ func (cg *Group) Resolution() int64 {
 
 // Compact plans and runs a single compaction against the group. The compacted result
 // is uploaded into the bucket the blocks were retrieved from.
-func (cg *Group) Compact(ctx context.Context, dir string, comp tsdb.Compactor) (ulid.ULID, error) {
+func (cg *Group) Compact(ctx context.Context, dir string, comp tsdb.Compactor) (bool, error) {
 	subDir := filepath.Join(dir, cg.Key())
 
 	if err := os.RemoveAll(subDir); err != nil {
-		return ulid.ULID{}, errors.Wrap(err, "clean compaction group dir")
+		return false, errors.Wrap(err, "clean compaction group dir")
 	}
 	if err := os.MkdirAll(subDir, 0777); err != nil {
-		return ulid.ULID{}, errors.Wrap(err, "create compaction group dir")
+		return false, errors.Wrap(err, "create compaction group dir")
 	}
 
-	compID, err := cg.compact(ctx, subDir, comp)
+	done, err := cg.compact(ctx, subDir, comp)
 	if err != nil {
 		cg.compactionFailures.Inc()
 	}
 	cg.compactions.Inc()
 
-	return compID, err
+	return done, err
 }
 
 // Issue347Error is a type wrapper for errors that should invoke repair process for broken block.
@@ -688,13 +688,13 @@ func RepairIssue347(ctx context.Context, logger log.Logger, bkt objstore.Bucket,
 	return nil
 }
 
-func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (compID ulid.ULID, err error) {
+func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (isFullyCompacted bool, err error) {
 	cg.mtx.Lock()
 	defer cg.mtx.Unlock()
 
 	// Check for overlapped blocks.
 	if err := cg.areBlocksOverlapping(nil); err != nil {
-		return compID, halt(errors.Wrap(err, "pre compaction overlap check"))
+		return false, halt(errors.Wrap(err, "pre compaction overlap check"))
 	}
 
 	// Planning a compaction works purely based on the meta.json files in our future group's dir.
@@ -702,21 +702,21 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 	for _, meta := range cg.blocks {
 		bdir := filepath.Join(dir, meta.ULID.String())
 		if err := os.MkdirAll(bdir, 0777); err != nil {
-			return compID, errors.Wrap(err, "create planning block dir")
+			return false, errors.Wrap(err, "create planning block dir")
 		}
 		if err := metadata.Write(cg.logger, bdir, meta); err != nil {
-			return compID, errors.Wrap(err, "write planning meta file")
+			return false, errors.Wrap(err, "write planning meta file")
 		}
 	}
 
 	// Plan against the written meta.json files.
 	plan, err := comp.Plan(dir)
 	if err != nil {
-		return compID, errors.Wrap(err, "plan compaction")
+		return false, errors.Wrap(err, "plan compaction")
 	}
 	if len(plan) == 0 {
 		// Nothing to do.
-		return compID, nil
+		return true, nil
 	}
 
 	// Due to #183 we verify that none of the blocks in the plan have overlapping sources.
@@ -729,45 +729,45 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 	for _, pdir := range plan {
 		meta, err := metadata.Read(pdir)
 		if err != nil {
-			return compID, errors.Wrapf(err, "read meta from %s", pdir)
+			return false, errors.Wrapf(err, "read meta from %s", pdir)
 		}
 
 		if cg.Key() != GroupKey(*meta) {
-			return compID, halt(errors.Wrapf(err, "compact planned compaction for mixed groups. group: %s, planned block's group: %s", cg.Key(), GroupKey(*meta)))
+			return false, halt(errors.Wrapf(err, "compact planned compaction for mixed groups. group: %s, planned block's group: %s", cg.Key(), GroupKey(*meta)))
 		}
 
 		for _, s := range meta.Compaction.Sources {
 			if _, ok := uniqueSources[s]; ok {
-				return compID, halt(errors.Errorf("overlapping sources detected for plan %v", plan))
+				return false, halt(errors.Errorf("overlapping sources detected for plan %v", plan))
 			}
 			uniqueSources[s] = struct{}{}
 		}
 
 		id, err := ulid.Parse(filepath.Base(pdir))
 		if err != nil {
-			return compID, errors.Wrapf(err, "plan dir %s", pdir)
+			return false, errors.Wrapf(err, "plan dir %s", pdir)
 		}
 
 		if meta.ULID.Compare(id) != 0 {
-			return compID, errors.Errorf("mismatch between meta %s and dir %s", meta.ULID, id)
+			return false, errors.Errorf("mismatch between meta %s and dir %s", meta.ULID, id)
 		}
 
 		if err := block.Download(ctx, cg.logger, cg.bkt, id, pdir); err != nil {
-			return compID, retry(errors.Wrapf(err, "download block %s", id))
+			return false, retry(errors.Wrapf(err, "download block %s", id))
 		}
 
 		// Ensure all input blocks are valid.
 		stats, err := block.GatherIndexIssueStats(cg.logger, filepath.Join(pdir, block.IndexFilename), meta.MinTime, meta.MaxTime)
 		if err != nil {
-			return compID, errors.Wrapf(err, "gather index issues for block %s", pdir)
+			return false, errors.Wrapf(err, "gather index issues for block %s", pdir)
 		}
 
 		if err := stats.CriticalErr(); err != nil {
-			return compID, halt(errors.Wrapf(err, "block with not healthy index found %s; Compaction level %v; Labels: %v", pdir, meta.Compaction.Level, meta.Thanos.Labels))
+			return false, halt(errors.Wrapf(err, "block with not healthy index found %s; Compaction level %v; Labels: %v", pdir, meta.Compaction.Level, meta.Thanos.Labels))
 		}
 
 		if err := stats.Issue347OutsideChunksErr(); err != nil {
-			return compID, issue347Error(errors.Wrapf(err, "invalid, but reparable block %s", pdir), meta.ULID)
+			return false, issue347Error(errors.Wrapf(err, "invalid, but reparable block %s", pdir), meta.ULID)
 		}
 	}
 	level.Debug(cg.logger).Log("msg", "downloaded and verified blocks",
@@ -775,9 +775,9 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 
 	begin = time.Now()
 
-	compID, err = comp.Compact(dir, plan, nil)
+	compID, err := comp.Compact(dir, plan, nil)
 	if err != nil {
-		return compID, halt(errors.Wrapf(err, "compact blocks %v", plan))
+		return false, halt(errors.Wrapf(err, "compact blocks %v", plan))
 	}
 	if compID == (ulid.ULID{}) {
 		// Prometheus compactor found that the compacted block would have no samples.
@@ -794,8 +794,8 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 				}
 			}
 		}
-		// Return a dummy ULID since the bucket compactor takes this as a signal to continue.
-		return ulid.New(123, nil)
+		// Even though this block was empty, there may be more work to do
+		return false, nil
 	}
 	level.Debug(cg.logger).Log("msg", "compacted blocks",
 		"blocks", fmt.Sprintf("%v", plan), "duration", time.Since(begin))
@@ -808,27 +808,27 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 		Source:     metadata.CompactorSource,
 	}, nil)
 	if err != nil {
-		return compID, errors.Wrapf(err, "failed to finalize the block %s", bdir)
+		return false, errors.Wrapf(err, "failed to finalize the block %s", bdir)
 	}
 
 	if err = os.Remove(filepath.Join(bdir, "tombstones")); err != nil {
-		return compID, errors.Wrap(err, "remove tombstones")
+		return false, errors.Wrap(err, "remove tombstones")
 	}
 
 	// Ensure the output block is valid.
 	if err := block.VerifyIndex(cg.logger, filepath.Join(bdir, block.IndexFilename), newMeta.MinTime, newMeta.MaxTime); err != nil {
-		return compID, halt(errors.Wrapf(err, "invalid result block %s", bdir))
+		return false, halt(errors.Wrapf(err, "invalid result block %s", bdir))
 	}
 
 	// Ensure the output block is not overlapping with anything else.
 	if err := cg.areBlocksOverlapping(newMeta, plan...); err != nil {
-		return compID, halt(errors.Wrapf(err, "resulted compacted block %s overlaps with something", bdir))
+		return false, halt(errors.Wrapf(err, "resulted compacted block %s overlaps with something", bdir))
 	}
 
 	begin = time.Now()
 
 	if err := block.Upload(ctx, cg.logger, cg.bkt, bdir); err != nil {
-		return compID, retry(errors.Wrapf(err, "upload of %s failed", compID))
+		return false, retry(errors.Wrapf(err, "upload of %s failed", compID))
 	}
 	level.Debug(cg.logger).Log("msg", "uploaded block", "result_block", compID, "duration", time.Since(begin))
 
@@ -837,12 +837,12 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 	// Eventually the block we just uploaded should get synced into the group again (including sync-delay).
 	for _, b := range plan {
 		if err := cg.deleteBlock(b); err != nil {
-			return compID, retry(errors.Wrapf(err, "delete old block from bucket"))
+			return false, retry(errors.Wrapf(err, "delete old block from bucket"))
 		}
 		cg.groupGarbageCollectedBlocks.Inc()
 	}
 
-	return compID, nil
+	return false, nil
 }
 
 func (cg *Group) deleteBlock(b string) error {
@@ -912,27 +912,25 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "build compaction groups")
 		}
-		done := true
+		finishedAllGroups := true
 		for _, g := range groups {
-			id, err := g.Compact(ctx, c.compactDir, c.comp)
+			finishedGroup, err := g.Compact(ctx, c.compactDir, c.comp)
 			if err == nil {
-				// If the returned ID has a zero value, the group had no blocks to be compacted.
-				// We keep going through the outer loop until no group has any work left.
-				if id != (ulid.ULID{}) {
-					done = false
+				if !finishedGroup {
+					finishedAllGroups = false
 				}
 				continue
 			}
 
 			if IsIssue347Error(err) {
 				if err := RepairIssue347(ctx, c.logger, c.bkt, err); err == nil {
-					done = false
+					finishedAllGroups = false
 					continue
 				}
 			}
 			return errors.Wrap(err, "compaction")
 		}
-		if done {
+		if finishedAllGroups {
 			break
 		}
 	}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -794,7 +794,7 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 				}
 			}
 		}
-		// Return a dummy ULID since the bucket compactor takes this as a signal to continue
+		// Return a dummy ULID since the bucket compactor takes this as a signal to continue.
 		return ulid.New(123, nil)
 	}
 	level.Debug(cg.logger).Log("msg", "compacted blocks",

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -779,6 +779,11 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 	if err != nil {
 		return compID, halt(errors.Wrapf(err, "compact blocks %v", plan))
 	}
+	if compID == (ulid.ULID{}) {
+		// Prometheus compactor found that the compacted block would have no samples.
+		level.Info(cg.logger).Log("msg", "skipping compaction as compacted block would have no samples", "blocks", fmt.Sprintf("%v", plan))
+		return compID, nil
+	}
 	level.Debug(cg.logger).Log("msg", "compacted blocks",
 		"blocks", fmt.Sprintf("%v", plan), "duration", time.Since(begin))
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -34,7 +34,7 @@ const (
 )
 
 var blockTooFreshSentinelError = errors.New("Block too fresh")
-var emptyCompactedBlockSentinelError = errors.New("Compaction would have created empty block")
+var emptyBlockSentinelULID = ulid.MustNew(123, nil)
 
 // Syncer syncronizes block metas from a bucket into a local directory.
 // It sorts them into compaction groups based on equal label sets.
@@ -795,7 +795,7 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 				}
 			}
 		}
-		return compID, emptyCompactedBlockSentinelError
+		return emptyBlockSentinelULID, nil
 	}
 	level.Debug(cg.logger).Log("msg", "compacted blocks",
 		"blocks", fmt.Sprintf("%v", plan), "duration", time.Since(begin))
@@ -921,10 +921,6 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 				if id != (ulid.ULID{}) {
 					done = false
 				}
-				continue
-			}
-
-			if err == emptyCompactedBlockSentinelError {
 				continue
 			}
 

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -253,18 +253,18 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		comp, err := tsdb.NewLeveledCompactor(nil, log.NewLogfmtLogger(os.Stderr), []int64{1000, 3000}, nil)
 		testutil.Ok(t, err)
 
-		id, err := g.Compact(ctx, dir, comp)
+		shouldRerun, id, err := g.Compact(ctx, dir, comp)
 		testutil.Ok(t, err)
-		testutil.Assert(t, id == ulid.ULID{}, "group should be empty, but somehow compaction took place")
+		testutil.Assert(t, shouldRerun, "group should be empty, but compactor did a compaction and told us to rerun")
 
 		// Add all metas that would be gathered by syncMetas.
 		for _, m := range metas {
 			testutil.Ok(t, g.Add(m))
 		}
 
-		id, err = g.Compact(ctx, dir, comp)
+		shouldRerun, id, err = g.Compact(ctx, dir, comp)
 		testutil.Ok(t, err)
-		testutil.Assert(t, id != ulid.ULID{}, "no compaction took place")
+		testutil.Assert(t, !shouldRerun, "there should be compactible data, but the compactor reported there was not")
 
 		resDir := filepath.Join(dir, id.String())
 		testutil.Ok(t, block.Download(ctx, log.NewNopLogger(), bkt, id, resDir))

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -255,7 +255,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 
 		shouldRerun, id, err := g.Compact(ctx, dir, comp)
 		testutil.Ok(t, err)
-		testutil.Assert(t, shouldRerun, "group should be empty, but compactor did a compaction and told us to rerun")
+		testutil.Assert(t, !shouldRerun, "group should be empty, but compactor did a compaction and told us to rerun")
 
 		// Add all metas that would be gathered by syncMetas.
 		for _, m := range metas {
@@ -264,7 +264,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 
 		shouldRerun, id, err = g.Compact(ctx, dir, comp)
 		testutil.Ok(t, err)
-		testutil.Assert(t, !shouldRerun, "there should be compactible data, but the compactor reported there was not")
+		testutil.Assert(t, shouldRerun, "there should be compactible data, but the compactor reported there was not")
 
 		resDir := filepath.Join(dir, id.String())
 		testutil.Ok(t, block.Download(ctx, log.NewNopLogger(), bkt, id, resDir))


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

During the Thanos group compactor, in the case when the Prometheus compactor has found that the resulting block would have no data, delete the source blocks (after checking they are indeed empty) and exit early.  Introduce a sentinel error to mark this case, to force the caller (bucket compactor) to continue compacting the rest of that group.  

It is necessary to handle the empty compaction case separately because the later parts of the group compactor result in an error if we attempt to continue.

Note that the Prometheus compactor uses the empty ULID for the "block with no samples" case:
```
    // When resulting Block has 0 samples
    //  * No block is written.
    //  * The source dirs are marked Deletable.
    //  * Returns empty ulid.ULID{}.
    Compact(dest string, dirs []string, open []*Block) (ulid.ULID, error)
```

<!-- Enumerate changes you made -->

## Verification

Ran the compactor against a bucket where some of the compacted blocks would end up empty.

<!-- How you tested it? How do you know it works? -->