### PR TITLE
querier: Add /api/v1/labels support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#811](https://github.com/improbable-eng/thanos/pull/811) Remote write receiver
 - [#798](https://github.com/improbable-eng/thanos/pull/798) Ability to limit the maximum concurrent about of Series() calls in Thanos Store and the maximum amount of samples.
 - [#910](https://github.com/improbable-eng/thanos/pull/910) Query's stores UI page is now sorted by type and old DNS or File SD stores are removed after 5 minutes (configurable via the new `--store.unhealthy-timeout=5m` flag).
+- [#905](https://github.com/improbable-eng/thanos/pull/905) New Query API: /api/v1/labels. Noticed that the API was added in Prometheus v2.6.
 
 New options:
 

--- a/go.sum
+++ b/go.sum
@@ -239,7 +239,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.1/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.2.3-0.20181014000028-04af85275a5c/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tdewolff/minify/v2 v2.3.7/go.mod h1:DD1stRlSx6JsHfl1+E/HVMQeXiec9rD1UQ0epklIZLc=
 github.com/tdewolff/parse/v2 v2.3.5/go.mod h1:HansaqmN4I/U7L6/tUp0NcwT2tFO0F4EAWYGSDzkYNk=

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -856,8 +856,37 @@ func chunksSize(chks []storepb.AggrChunk) (size int) {
 }
 
 // LabelNames implements the storepb.StoreServer interface.
-func (s *BucketStore) LabelNames(context.Context, *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+func (s *BucketStore) LabelNames(ctx context.Context, _ *storepb.LabelNamesRequest) (*storepb.LabelNamesResponse, error) {
+	g, gctx := errgroup.WithContext(ctx)
+
+	s.mtx.RLock()
+
+	var mtx sync.Mutex
+	var sets [][]string
+
+	for _, b := range s.blocks {
+		indexr := b.indexReader(gctx)
+		g.Go(func() error {
+			defer runutil.CloseWithLogOnErr(s.logger, indexr, "label names")
+
+			res := indexr.LabelNames()
+
+			mtx.Lock()
+			sets = append(sets, res)
+			mtx.Unlock()
+
+			return nil
+		})
+	}
+
+	s.mtx.RUnlock()
+
+	if err := g.Wait(); err != nil {
+		return nil, status.Error(codes.Aborted, err.Error())
+	}
+	return &storepb.LabelNamesResponse{
+		Names: strutil.MergeSlices(sets...),
+	}, nil
 }
 
 // LabelValues implements the storepb.StoreServer interface.
@@ -1612,6 +1641,15 @@ func (r *bucketIndexReader) LabelValues(name string) []string {
 	res := make([]string, 0, len(r.block.lvals[name]))
 	for _, v := range r.block.lvals[name] {
 		res = append(res, v)
+	}
+	return res
+}
+
+// LabelNames returns a list of label names.
+func (r *bucketIndexReader) LabelNames() []string {
+	res := make([]string, 0, len(r.block.lvals))
+	for ln, _ := range r.block.lvals {
+		res = append(res, ln)
 	}
 	return res
 }

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -379,12 +379,12 @@ func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesR
 
 	if m.Status != "success" {
 		if !r.PartialResponseDisabled {
-			return &storepb.LabelNamesResponse{Names: m.Data}, nil
+			return &storepb.LabelNamesResponse{Names: m.Data, Warnings: []string{m.Error}}, nil
 		}
 
 		code, exists := statusToCode[resp.StatusCode]
 		if !exists {
-			code = codes.Internal
+			return nil, status.Error(codes.Internal, m.Error)
 		}
 		return nil, status.Error(code, m.Error)
 	}
@@ -435,12 +435,12 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 
 	if m.Status != "success" {
 		if !r.PartialResponseDisabled {
-			return &storepb.LabelValuesResponse{Values: m.Data}, nil
+			return &storepb.LabelValuesResponse{Values: m.Data, Warnings: []string{m.Error}}, nil
 		}
 
 		code, exists := statusToCode[resp.StatusCode]
 		if !exists {
-			code = codes.Internal
+			return nil, status.Error(codes.Internal, m.Error)
 		}
 		return nil, status.Error(code, m.Error)
 	}

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -375,16 +375,18 @@ func (p *PrometheusStore) LabelNames(ctx context.Context, r *storepb.LabelNamesR
 
 	if resp.StatusCode == http.StatusNoContent {
 		return &storepb.LabelNamesResponse{Names: []string{}}, nil
-	} else if m.Status != "success" {
+	}
+
+	if m.Status != "success" {
 		if !r.PartialResponseDisabled {
 			return &storepb.LabelNamesResponse{Names: m.Data}, nil
-		} else {
-			code, exists := statusToCode[resp.StatusCode]
-			if !exists {
-				code = codes.Internal
-			}
-			return nil, status.Error(code, m.Error)
 		}
+
+		code, exists := statusToCode[resp.StatusCode]
+		if !exists {
+			code = codes.Internal
+		}
+		return nil, status.Error(code, m.Error)
 	}
 
 	return &storepb.LabelNamesResponse{Names: m.Data}, nil
@@ -426,18 +428,21 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 	}
 
 	sort.Strings(m.Data)
+
 	if resp.StatusCode == http.StatusNoContent {
 		return &storepb.LabelValuesResponse{Values: []string{}}, nil
-	} else if m.Status != "success" {
+	}
+
+	if m.Status != "success" {
 		if !r.PartialResponseDisabled {
 			return &storepb.LabelValuesResponse{Values: m.Data}, nil
-		} else {
-			code, exists := statusToCode[resp.StatusCode]
-			if !exists {
-				code = codes.Internal
-			}
-			return nil, status.Error(code, m.Error)
 		}
+
+		code, exists := statusToCode[resp.StatusCode]
+		if !exists {
+			code = codes.Internal
+		}
+		return nil, status.Error(code, m.Error)
 	}
 
 	return &storepb.LabelValuesResponse{Values: m.Data}, nil

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -404,11 +404,7 @@ func (s *ProxyStore) LabelNames(ctx context.Context, r *storepb.LabelNamesReques
 		g, gctx  = errgroup.WithContext(ctx)
 	)
 
-	stores, err := s.stores(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Unknown, err.Error())
-	}
-	for _, st := range stores {
+	for _, st := range s.stores() {
 		st := st
 		g.Go(func() error {
 			resp, err := st.LabelNames(gctx, &storepb.LabelNamesRequest{
@@ -460,7 +456,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequ
 		store := st
 		g.Go(func() error {
 			resp, err := store.LabelValues(gctx, &storepb.LabelValuesRequest{
-				Label: r.Label,
+				Label:                   r.Label,
 				PartialResponseDisabled: r.PartialResponseDisabled,
 			})
 			if err != nil {

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -421,7 +421,7 @@ func (s *ProxyStore) LabelNames(ctx context.Context, r *storepb.LabelNamesReques
 				}
 
 				mtx.Lock()
-				warnings = append(warnings, errors.Wrap(err, "fetch label names").Error())
+				warnings = append(warnings, err.Error())
 				mtx.Unlock()
 				return nil
 			}

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -769,10 +769,12 @@ func TestProxyStore_LabelNames(t *testing.T) {
 		},
 	} {
 		if ok := t.Run(tc.title, func(t *testing.T) {
-			q := NewProxyStore(nil,
-				func(_ context.Context) ([]Client, error) { return tc.storeAPIs, nil },
+			q := NewProxyStore(
+				nil,
+				func() []Client { return tc.storeAPIs },
 				component.Query,
 				nil,
+				0*time.Second,
 			)
 
 			ctx := context.Background()


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
Implements: #702 

Add `/api/v1/labels` api to thanos query. 
<!-- Enumerate changes you made -->

## Verification
Run `curl <query url>/api/v1/labels` to fetch all of labels in Prometheus. Noticed that the api is added in Prometheus 2.6.

<!-- How you tested it? How do you know it works? -->