### PR TITLE
query: Add Store timeout to Thanos Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ NOTE: As semantic versioning states all 0.y.z releases can contain breaking chan
 We use *breaking* word for marking changes that are not backward compatible (relates only to v0.y.z releases.)
 
 ## Unreleased
-
+- [#920](https://github.com/improbable-eng/thanos/pull/920) Add Thanos store.read-timeout. Maximum time to read response from store, which defaults to 2 minutes. If request to one of stores is timed out and store.read-timeout < query.timeout partial response will be returned. If store.read-timeout >= query.timeout one of stores is timed out the client will get no data and timeout error.
 ### Added
 - [#811](https://github.com/improbable-eng/thanos/pull/811) Remote write receiver
 

--- a/benchmark/cmd/thanosbench/resources.go
+++ b/benchmark/cmd/thanosbench/resources.go
@@ -231,6 +231,7 @@ func createPrometheus(opts *opts, name string, bucket string) *appsv1.StatefulSe
 					"--storage.tsdb.max-block-duration=2h",
 					"--storage.tsdb.retention=2h",
 					"--query.timeout=10m",
+					"--store.read-timeout=10m",
 				},
 				VolumeMounts: []v1.VolumeMount{
 					{

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -316,7 +316,7 @@ func runQuery(
 			},
 			dialOpts,
 		)
-		proxy            = store.NewProxyStore(logger, stores.Get, component.Query, selectorLset)
+		proxy            = store.NewProxyStore(logger, stores.Get, component.Query, selectorLset, storeReadTimeout)
 		queryableCreator = query.NewQueryableCreator(logger, proxy, replicaLabel, storeReadTimeout)
 		engine           = promql.NewEngine(
 			promql.EngineOpts{

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -91,7 +91,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	enablePartialResponse := cmd.Flag("query.partial-response", "Enable partial response for queries if no partial_response param is specified.").
 		Default("true").Bool()
 
-	storeReadTimeout := modelDuration(cmd.Flag("store.read-timeout", "Maximum time to read response from store. If request to one of stores is timed out and store.read-timeout < query.timeout partial response will be returned. If store.read-timeout >= query.timeout one of stores is timed out clien will get no data and timeout error.").
+	storeReadTimeout := modelDuration(cmd.Flag("store.read-timeout", "Maximum time to read response from store. If request to one of stores is timed out and store.read-timeout < query.timeout partial response will be returned. If store.read-timeout >= query.timeout one of stores is timed out the client will get no data and timeout error.").
 		Default("2m"))
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -91,7 +91,7 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	enablePartialResponse := cmd.Flag("query.partial-response", "Enable partial response for queries if no partial_response param is specified.").
 		Default("true").Bool()
 
-	storeReadTimeout := modelDuration(cmd.Flag("store.read-timeout", "Maximum time to read response from store.").
+	storeReadTimeout := modelDuration(cmd.Flag("store.read-timeout", "Maximum time to read response from store. If request to one of stores is timed out and store.read-timeout < query.timeout partial response will be returned. If store.read-timeout >= query.timeout one of stores is timed out clien will get no data and timeout error.").
 		Default("2m"))
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -249,13 +249,6 @@ Flags:
                                  which data is deduplicated. Still you will be
                                  able to query without deduplication using
                                  'dedup=false' parameter.
-      --store.read-timeout=2m    Maximum time to read response from store.
-                                 If request to one of stores is timed out
-                                 and store.read-timeout < query.timeout
-                                 partial response will be returned.
-                                 If store.read-timeout >= query.timeout
-                                 one of stores is timed out client
-                                 will get no data and timeout error.
       --selector-label=<name>="<value>" ...  
                                  Query selector labels that will be exposed in
                                  info endpoint (repeated).
@@ -277,5 +270,12 @@ Flags:
                                  if no max_source_resolution param is specified.
       --query.partial-response   Enable partial response for queries if no
                                  partial_response param is specified.
+      --store.read-timeout=2m    Maximum time to read response from store. If
+                                 request to one of stores is timed out and
+                                 store.read-timeout < query.timeout partial
+                                 response will be returned. If
+                                 store.read-timeout >= query.timeout one of
+                                 stores is timed out clien will get no data and
+                                 timeout error.
 
 ```

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -249,6 +249,13 @@ Flags:
                                  which data is deduplicated. Still you will be
                                  able to query without deduplication using
                                  'dedup=false' parameter.
+      --store.read-timeout=2m    Maximum time to read response from store.
+                                 If request to one of stores is timed out
+                                 and store.read-timeout < query.timeout
+                                 partial response will be returned.
+                                 If store.read-timeout >= query.timeout
+                                 one of stores is timed out client
+                                 will get no data and timeout error.
       --selector-label=<name>="<value>" ...  
                                  Query selector labels that will be exposed in
                                  info endpoint (repeated).

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -275,7 +275,7 @@ Flags:
                                  store.read-timeout < query.timeout partial
                                  response will be returned. If
                                  store.read-timeout >= query.timeout one of
-                                 stores is timed out clien will get no data and
-                                 timeout error.
+                                 stores is timed out the client will get no data
+                                 and timeout error.
 
 ```

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -57,7 +57,7 @@ type queryable struct {
 
 // Querier returns a new storage querier against the underlying proxy store API.
 func (q *queryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-	return newQuerier(ctx, q.logger, mint, maxt, q.replicaLabel, q.proxy, q.deduplicate, int64(q.maxSourceResolution/time.Millisecond), q.storeReadTimeout, q.partialResponse, q.warningReporter), nil
+	return newQuerier(ctx, q.logger, mint, maxt, q.replicaLabel, q.proxy, q.deduplicate, int64(q.maxSourceResolution/time.Millisecond), q.partialResponse, q.warningReporter), nil
 }
 
 type querier struct {
@@ -71,11 +71,6 @@ type querier struct {
 	maxSourceResolution int64
 	partialResponse     bool
 	warningReporter     WarningReporter
-
-	// storeReadTimeout is an additional timeout for reading data from stores.
-	// Its separated from ctx because querier.ctx is forwarded from prometheus query executor
-	// and already contains timeout for entire query execution.
-	storeReadTimeout time.Duration
 }
 
 // newQuerier creates implementation of storage.Querier that fetches data from the proxy
@@ -88,7 +83,6 @@ func newQuerier(
 	proxy storepb.StoreServer,
 	deduplicate bool,
 	maxSourceResolution int64,
-	storeReadTimeout time.Duration,
 	partialResponse bool,
 	warningReporter WarningReporter,
 ) *querier {
@@ -109,7 +103,6 @@ func newQuerier(
 		proxy:               proxy,
 		deduplicate:         deduplicate,
 		maxSourceResolution: maxSourceResolution,
-		storeReadTimeout:    storeReadTimeout,
 		partialResponse:     partialResponse,
 		warningReporter:     warningReporter,
 	}
@@ -189,16 +182,7 @@ func (q *querier) Select(params *storage.SelectParams, ms ...*labels.Matcher) (s
 
 	queryAggrs, resAggr := aggrsFromFunc(params.Func)
 
-	// We're limiting store read time here.
-	// This limit affects behaviour what result Thanos Query will return to user if one of requested stores timed out.
-	// If query.timeout > store.read-timeout
-	// client will get partial response from stores who responded faster than store.read-timeout
-	// If query.timeout <= store.read-timeout
-	// client will get an error with timeout for whole request even if some of stores responded in time, but one timed out
-	storeReadCtx, storeReadCancelFunc := context.WithTimeout(ctx, q.storeReadTimeout)
-	defer storeReadCancelFunc()
-
-	resp := &seriesServer{ctx: storeReadCtx}
+	resp := &seriesServer{ctx: ctx}
 	if err := q.proxy.Series(&storepb.SeriesRequest{
 		MinTime:                 q.mint,
 		MaxTime:                 q.maxt,
@@ -270,10 +254,7 @@ func (q *querier) LabelValues(name string) ([]string, error) {
 	span, ctx := tracing.StartSpan(q.ctx, "querier_label_values")
 	defer span.Finish()
 
-	storeReadCtx, storeReadCancelFunc := context.WithTimeout(ctx, q.storeReadTimeout)
-	defer storeReadCancelFunc()
-
-	resp, err := q.proxy.LabelValues(storeReadCtx, &storepb.LabelValuesRequest{Label: name, PartialResponseDisabled: !q.partialResponse})
+	resp, err := q.proxy.LabelValues(ctx, &storepb.LabelValuesRequest{Label: name, PartialResponseDisabled: !q.partialResponse})
 	if err != nil {
 		return nil, errors.Wrap(err, "proxy LabelValues()")
 	}

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -303,13 +303,15 @@ func TestQuerier_StoreReadTimeout(t *testing.T) {
 	queryCtx, _ := context.WithTimeout(context.Background(), queryTimeout)
 
 	q := newQuerier(queryCtx, nil, 1, 300, "", proxy, false, 0, storeReadTimeout, true, nil)
-	defer q.Close()
 
 	storeQueryDone := make(chan struct{})
 
 	go func() {
-		q.Select(&storage.SelectParams{})
+		_, _, err := q.Select(&storage.SelectParams{})
+		testutil.Ok(t, err)
+
 		storeQueryDone <- struct{}{}
+
 	}()
 
 	select {
@@ -319,6 +321,8 @@ func TestQuerier_StoreReadTimeout(t *testing.T) {
 		// Something went wrong - global query context expected to close last
 		testutil.Ok(t, errors.New("query finished first, but expected store query will finish first (storeReadTimeout is smaller that query timeout)"))
 	}
+
+	testutil.Ok(t, q.Close())
 }
 
 func BenchmarkDedupSeriesIterator(b *testing.B) {

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -11,12 +11,15 @@ import (
 	"time"
 
 	"github.com/fortytw2/leaktest"
+	"github.com/improbable-eng/thanos/pkg/component"
+	"github.com/improbable-eng/thanos/pkg/store"
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/tsdb/chunkenc"
+	"google.golang.org/grpc"
 )
 
 func TestQuerier_Series(t *testing.T) {
@@ -33,7 +36,7 @@ func TestQuerier_Series(t *testing.T) {
 
 	// Querier clamps the range to [1,300], which should drop some samples of the result above.
 	// The store API allows endpoints to send more data then initially requested.
-	q := newQuerier(context.Background(), nil, 1, 300, "", testProxy, false, 0, true, nil)
+	q := newQuerier(context.Background(), nil, 1, 300, "", testProxy, false, 0, time.Minute, true, nil)
 	defer func() { testutil.Ok(t, q.Close()) }()
 
 	res, _, err := q.Select(&storage.SelectParams{})
@@ -271,6 +274,50 @@ func TestDedupSeriesIterator(t *testing.T) {
 		)
 		res := expandSeries(t, it)
 		testutil.Equals(t, c.exp, res)
+	}
+}
+
+func TestQuerier_StoreReadTimeout(t *testing.T) {
+	storeClient := &store.ClientMock{
+		StoreClientMock: &storepb.StoreClientMock{
+			SeriesCallback: func(ctx context.Context, in *storepb.SeriesRequest, opts ...grpc.CallOption) (storepb.Store_SeriesClient, error) {
+				// Just wait for ctx.Done() as it works internally in GRPC StoreClient
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		},
+		TimeRangeCallback: func() (mint int64, maxt int64) { return 1, 1 },
+		LabelsCallback:    func() []storepb.Label { return nil },
+	}
+
+	proxy := store.NewProxyStore(
+		nil,
+		func(context.Context) ([]store.Client, error) { return []store.Client{storeClient}, nil },
+		component.Query,
+		nil,
+	)
+
+	queryTimeout := 1 * time.Second
+	storeReadTimeout := 1 * time.Millisecond
+
+	queryCtx, _ := context.WithTimeout(context.Background(), queryTimeout)
+
+	q := newQuerier(queryCtx, nil, 1, 300, "", proxy, false, 0, storeReadTimeout, true, nil)
+	defer q.Close()
+
+	storeQueryDone := make(chan struct{})
+
+	go func() {
+		q.Select(&storage.SelectParams{})
+		storeQueryDone <- struct{}{}
+	}()
+
+	select {
+	case <-storeQueryDone:
+		// Do nothing - storeQuery expected to finish first
+	case <-queryCtx.Done():
+		// Something went wrong - global query context expected to close last
+		testutil.Ok(t, errors.New("query finished first, but expected store query will finish first (storeReadTimeout is smaller that query timeout)"))
 	}
 }
 

--- a/pkg/store/mock.go
+++ b/pkg/store/mock.go
@@ -1,0 +1,26 @@
+package store
+
+import "github.com/improbable-eng/thanos/pkg/store/storepb"
+
+// ClientMock is a structure for mocking storepb.Client interface
+type ClientMock struct {
+	*storepb.StoreClientMock
+
+	LabelsCallback    func() []storepb.Label
+	TimeRangeCallback func() (mint int64, maxt int64)
+	StringCallback    func() string
+}
+
+var _ Client = &ClientMock{}
+
+func (c *ClientMock) Labels() []storepb.Label {
+	return c.LabelsCallback()
+}
+
+func (c *ClientMock) TimeRange() (mint int64, maxt int64) {
+	return c.TimeRangeCallback()
+}
+
+func (c *ClientMock) String() string {
+	return c.StringCallback()
+}

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -51,7 +51,7 @@ func TestProxyStore_Info(t *testing.T) {
 	q := NewProxyStore(nil,
 		func() []Client { return nil },
 		component.Query,
-		nil,
+		nil, 100*time.Second,
 	)
 
 	resp, err := q.Info(ctx, &storepb.InfoRequest{})
@@ -405,6 +405,7 @@ func TestProxyStore_Series(t *testing.T) {
 				func() []Client { return tc.storeAPIs },
 				component.Query,
 				tc.selectorLabels,
+				100*time.Second,
 			)
 
 			s := newStoreSeriesServer(context.Background())
@@ -446,6 +447,7 @@ func TestProxyStore_Series_RequestParamsProxied(t *testing.T) {
 		func() []Client { return cls },
 		component.Query,
 		nil,
+		100*time.Second,
 	)
 
 	ctx := context.Background()
@@ -504,6 +506,7 @@ func TestProxyStore_Series_RegressionFillResponseChannel(t *testing.T) {
 		func() []Client { return cls },
 		component.Query,
 		tlabels.FromStrings("fed", "a"),
+		100*time.Second,
 	)
 
 	ctx := context.Background()
@@ -541,6 +544,7 @@ func TestProxyStore_LabelValues(t *testing.T) {
 		func() []Client { return cls },
 		component.Query,
 		nil,
+		100*time.Second,
 	)
 
 	ctx := context.Background()

--- a/pkg/store/storepb/mock.go
+++ b/pkg/store/storepb/mock.go
@@ -1,0 +1,33 @@
+package storepb
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// StoreClientMock is a structure for mocking StoreClient interface
+type StoreClientMock struct {
+	InfoCallback        func(ctx context.Context, in *InfoRequest, opts ...grpc.CallOption) (*InfoResponse, error)
+	SeriesCallback      func(ctx context.Context, in *SeriesRequest, opts ...grpc.CallOption) (Store_SeriesClient, error)
+	LabelNamesCallback  func(ctx context.Context, in *LabelNamesRequest, opts ...grpc.CallOption) (*LabelNamesResponse, error)
+	LabelValuesCallback func(ctx context.Context, in *LabelValuesRequest, opts ...grpc.CallOption) (*LabelValuesResponse, error)
+}
+
+var _ StoreClient = &StoreClientMock{}
+
+func (c *StoreClientMock) Info(ctx context.Context, in *InfoRequest, opts ...grpc.CallOption) (*InfoResponse, error) {
+	return c.InfoCallback(ctx, in, opts...)
+}
+
+func (c *StoreClientMock) Series(ctx context.Context, in *SeriesRequest, opts ...grpc.CallOption) (Store_SeriesClient, error) {
+	return c.SeriesCallback(ctx, in, opts...)
+}
+
+func (c *StoreClientMock) LabelNames(ctx context.Context, in *LabelNamesRequest, opts ...grpc.CallOption) (*LabelNamesResponse, error) {
+	return c.LabelNames(ctx, in, opts...)
+}
+
+func (c *StoreClientMock) LabelValues(ctx context.Context, in *LabelValuesRequest, opts ...grpc.CallOption) (*LabelValuesResponse, error) {
+	return c.LabelValues(ctx, in, opts...)
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Taking over https://github.com/improbable-eng/thanos/pull/895 as I'm affected by it too  https://github.com/improbable-eng/thanos/issues/919

@d-ulyanov has done a great job and only one thing left from that PR to fix, which I'm fixing here:

https://github.com/improbable-eng/thanos/pull/895#discussion_r264279655

I move time out from querier to proxy
