### PR TITLE
objstore: do not set last successful time metric before 1st upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Added
 - [#811](https://github.com/improbable-eng/thanos/pull/811) Remote write receiver
 
+### Fixed
+- [#921](https://github.com/improbable-eng/thanos/pull/921) `thanos_objstore_bucket_last_successful_upload_time` now does not appear when no blocks have been uploaded so far
+
 ## [v0.3.2](https://github.com/improbable-eng/thanos/releases/tag/v0.3.2) - 2019.03.04
 
 ### Added


### PR DESCRIPTION
Convert lastSuccessfullUploadTime into a GaugeVec with one dimension:
bucket, which makes client_golang *not* make that metric unless at least
one value has appeared.

This is better for users since Grafana will show that last upload has
been 49+ years ago instead of N/A when no uploads had happened before.

Fixes #886.