### PR TITLE
query: Add store.response-timeout

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -308,7 +308,7 @@ func runQuery(
 			},
 			dialOpts,
 		)
-		proxy            = store.NewProxyStore(logger, reg, stores.Get, component.Query, selectorLset, storeResponseTimeout)
+		proxy            = store.NewProxyStore(logger, stores.Get, component.Query, selectorLset, storeResponseTimeout)
 		queryableCreator = query.NewQueryableCreator(logger, proxy, replicaLabel)
 		engine           = promql.NewEngine(
 			promql.EngineOpts{

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -270,5 +270,10 @@ Flags:
                                  if no max_source_resolution param is specified.
       --query.partial-response   Enable partial response for queries if no
                                  partial_response param is specified.
+      --store.receive-timeout=200ms  
+                                 Maximum time to wait for any data from store.
+                                 If Store doesn't send any data any
+                                 storeReceiveTimeout the Store will be igored
+                                 and partial data will be returned.
 
 ```

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -270,10 +270,10 @@ Flags:
                                  if no max_source_resolution param is specified.
       --query.partial-response   Enable partial response for queries if no
                                  partial_response param is specified.
-      --store.receive-timeout=200ms  
-                                 Maximum time to wait for any data from store.
-                                 If Store doesn't send any data any
-                                 storeReceiveTimeout the Store will be igored
-                                 and partial data will be returned.
+      --store.response-timeout=0ms
+                                 If a Store doesn't send any data in this
+                                 specified duration then a Store will be ignored
+                                 and partial data will be returned if it's
+                                 enabled. 0 disables timeout.
 
 ```

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -196,6 +196,10 @@ func (s *storeRef) String() string {
 	return fmt.Sprintf("Addr: %s Labels: %v Mint: %d Maxt: %d", s.addr, s.Labels(), mint, maxt)
 }
 
+func (s *storeRef) Addr() string {
+	return s.addr
+}
+
 func (s *storeRef) close() {
 	runutil.CloseWithLogOnErr(s.logger, s.cc, fmt.Sprintf("store %v connection close", s.addr))
 }

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -34,7 +34,7 @@ type Client interface {
 	TimeRange() (mint int64, maxt int64)
 
 	String() string
-	// Addr address of a Client.
+	// Addr returns address of a Client.
 	Addr() string
 }
 
@@ -348,7 +348,7 @@ func (s *streamSeriesSet) Next() (ok bool) {
 	case s.currSeries, ok = <-s.recvCh:
 		return ok
 	case <-ctx.Done():
-		//shutdown a goroutine in startStreamSeriesSet
+		// closeSeries to shutdown a goroutine in startStreamSeriesSet.
 		s.closeSeries()
 
 		err := errors.Wrap(ctx.Err(), timeoutMsg)

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -174,8 +174,10 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 				continue
 			}
 
-			// Schedule streamSeriesSet that translates gRPC streamed response into seriesSet (if series) or respCh if warnings.
-			seriesSet = append(seriesSet, startStreamSeriesSet(seriesCtx, s.logger, closeSeries, wg, sc, respSender, st.String(), !r.PartialResponseDisabled, s.responseTimeout))
+			// Schedule streamSeriesSet that translates gRPC streamed response
+			// into seriesSet (if series) or respCh if warnings.
+			seriesSet = append(seriesSet, startStreamSeriesSet(seriesCtx, s.logger, closeSeries,
+				wg, sc, respSender, st.String(), !r.PartialResponseDisabled, s.responseTimeout))
 		}
 
 		level.Debug(s.logger).Log("msg", strings.Join(storeDebugMsgs, ";"))

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -155,7 +155,7 @@ func (s *ProxyStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 			}
 			storeDebugMsgs = append(storeDebugMsgs, fmt.Sprintf("store %s queried", st))
 
-			//This is used to cancel this stream when one operations takes too long
+			// This is used to cancel this stream when one operations takes too long.
 			seriesCtx, closeSeries := context.WithCancel(gctx)
 			defer closeSeries()
 

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/tsdb/chunkenc"
 	tlabels "github.com/prometheus/tsdb/labels"
@@ -53,7 +52,7 @@ func TestProxyStore_Info(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	q := NewProxyStore(nil, prometheus.NewRegistry(),
+	q := NewProxyStore(nil,
 		func() []Client { return nil },
 		component.Query,
 		nil, 0*time.Second,
@@ -407,7 +406,7 @@ func TestProxyStore_Series(t *testing.T) {
 	} {
 
 		if ok := t.Run(tc.title, func(t *testing.T) {
-			q := NewProxyStore(nil, prometheus.NewRegistry(),
+			q := NewProxyStore(nil,
 				func() []Client { return tc.storeAPIs },
 				component.Query,
 				tc.selectorLabels,
@@ -529,7 +528,7 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 		},
 	} {
 		if ok := t.Run(tc.title, func(t *testing.T) {
-			q := NewProxyStore(nil, prometheus.NewRegistry(),
+			q := NewProxyStore(nil,
 				func() []Client { return tc.storeAPIs },
 				component.Query,
 				tc.selectorLabels,
@@ -571,7 +570,7 @@ func TestProxyStore_Series_RequestParamsProxied(t *testing.T) {
 			maxTime:     300,
 		},
 	}
-	q := NewProxyStore(nil, prometheus.NewRegistry(),
+	q := NewProxyStore(nil,
 		func() []Client { return cls },
 		component.Query,
 		nil,
@@ -630,7 +629,7 @@ func TestProxyStore_Series_RegressionFillResponseChannel(t *testing.T) {
 
 	}
 
-	q := NewProxyStore(nil, prometheus.NewRegistry(),
+	q := NewProxyStore(nil,
 		func() []Client { return cls },
 		component.Query,
 		tlabels.FromStrings("fed", "a"),
@@ -668,7 +667,7 @@ func TestProxyStore_LabelValues(t *testing.T) {
 			},
 		}},
 	}
-	q := NewProxyStore(nil, prometheus.NewRegistry(),
+	q := NewProxyStore(nil,
 		func() []Client { return cls },
 		component.Query,
 		nil,

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -51,7 +51,7 @@ func TestProxyStore_Info(t *testing.T) {
 	q := NewProxyStore(nil,
 		func() []Client { return nil },
 		component.Query,
-		nil,
+		nil, 1*time.Second,
 	)
 
 	resp, err := q.Info(ctx, &storepb.InfoRequest{})
@@ -405,6 +405,7 @@ func TestProxyStore_Series(t *testing.T) {
 				func() []Client { return tc.storeAPIs },
 				component.Query,
 				tc.selectorLabels,
+				1*time.Second,
 			)
 
 			s := newStoreSeriesServer(context.Background())
@@ -446,6 +447,7 @@ func TestProxyStore_Series_RequestParamsProxied(t *testing.T) {
 		func() []Client { return cls },
 		component.Query,
 		nil,
+		1*time.Second,
 	)
 
 	ctx := context.Background()
@@ -504,6 +506,7 @@ func TestProxyStore_Series_RegressionFillResponseChannel(t *testing.T) {
 		func() []Client { return cls },
 		component.Query,
 		tlabels.FromStrings("fed", "a"),
+		1*time.Second,
 	)
 
 	ctx := context.Background()
@@ -541,6 +544,7 @@ func TestProxyStore_LabelValues(t *testing.T) {
 		func() []Client { return cls },
 		component.Query,
 		nil,
+		1*time.Second,
 	)
 
 	ctx := context.Background()

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"os"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/tsdb/chunkenc"
 	tlabels "github.com/prometheus/tsdb/labels"
@@ -42,16 +44,19 @@ func (c *testClient) String() string {
 	return "test"
 }
 
+func (c *testClient) Addr() string {
+	return "testaddr"
+}
 func TestProxyStore_Info(t *testing.T) {
 	defer leaktest.CheckTimeout(t, 10*time.Second)()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	q := NewProxyStore(nil,
+	q := NewProxyStore(nil, prometheus.NewRegistry(),
 		func() []Client { return nil },
 		component.Query,
-		nil, 1*time.Second,
+		nil, 0*time.Second,
 	)
 
 	resp, err := q.Info(ctx, &storepb.InfoRequest{})
@@ -400,12 +405,135 @@ func TestProxyStore_Series(t *testing.T) {
 			expectedErr: errors.New("fetch series for [name:\"ext\" value:\"1\" ] test: error!"),
 		},
 	} {
+
 		if ok := t.Run(tc.title, func(t *testing.T) {
-			q := NewProxyStore(nil,
+			q := NewProxyStore(nil, prometheus.NewRegistry(),
 				func() []Client { return tc.storeAPIs },
 				component.Query,
 				tc.selectorLabels,
-				1*time.Second,
+				0*time.Second,
+			)
+
+			s := newStoreSeriesServer(context.Background())
+
+			err := q.Series(tc.req, s)
+			if tc.expectedErr != nil {
+				testutil.NotOk(t, err)
+				testutil.Equals(t, tc.expectedErr.Error(), err.Error())
+				return
+			}
+
+			testutil.Ok(t, err)
+
+			seriesEqual(t, tc.expectedSeries, s.SeriesSet)
+			testutil.Equals(t, tc.expectedWarningsLen, len(s.Warnings), "got %v", s.Warnings)
+		}); !ok {
+			return
+		}
+	}
+}
+
+func TestProxyStore_SeriesSlowStores(t *testing.T) {
+	enable := os.Getenv("THANOS_ENABLE_STORE_READ_TIMEOUT_TESTS")
+	if enable == "" {
+		t.Skip("enable THANOS_ENABLE_STORE_READ_TIMEOUT_TESTS to run store-read-timeout tests")
+	}
+
+	defer leaktest.CheckTimeout(t, 20*time.Second)()
+
+	for _, tc := range []struct {
+		title          string
+		storeAPIs      []Client
+		selectorLabels tlabels.Labels
+
+		req *storepb.SeriesRequest
+
+		expectedSeries      []rawSeries
+		expectedErr         error
+		expectedWarningsLen int
+	}{
+		{
+			title: "partial response disabled one thanos query is slow to respond",
+			storeAPIs: []Client{
+				&testClient{
+					StoreClient: &mockedStoreAPI{
+						RespSeries: []*storepb.SeriesResponse{
+							storepb.NewWarnSeriesResponse(errors.New("warning")),
+							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
+						},
+						RespDuration: 10 * time.Second,
+					},
+					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
+					minTime: 1,
+					maxTime: 300,
+				},
+				&testClient{
+					StoreClient: &mockedStoreAPI{
+						RespSeries: []*storepb.SeriesResponse{
+							storepb.NewWarnSeriesResponse(errors.New("warning")),
+							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
+						},
+					},
+					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
+					minTime: 1,
+					maxTime: 300,
+				},
+			},
+			req: &storepb.SeriesRequest{
+				MinTime:                 1,
+				MaxTime:                 300,
+				Matchers:                []storepb.LabelMatcher{{Name: "ext", Value: "1", Type: storepb.LabelMatcher_EQ}},
+				PartialResponseDisabled: true,
+			},
+			expectedErr: errors.New("test: failed to receive any data in 4s from test: context deadline exceeded"),
+		},
+		{
+			title: "partial response enabled one thanos query is slow to respond",
+			storeAPIs: []Client{
+				&testClient{
+					StoreClient: &mockedStoreAPI{
+						RespSeries: []*storepb.SeriesResponse{
+							storepb.NewWarnSeriesResponse(errors.New("warning")),
+							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
+						},
+					},
+					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
+					minTime: 1,
+					maxTime: 300,
+				},
+				&testClient{
+					StoreClient: &mockedStoreAPI{
+						RespSeries: []*storepb.SeriesResponse{
+							storepb.NewWarnSeriesResponse(errors.New("warning")),
+							storeSeriesResponse(t, labels.FromStrings("b", "c"), []sample{{1, 1}, {2, 2}, {3, 3}}),
+						},
+						RespDuration: 10 * time.Second,
+					},
+					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
+					minTime: 1,
+					maxTime: 300,
+				},
+			},
+			req: &storepb.SeriesRequest{
+				MinTime:  1,
+				MaxTime:  300,
+				Matchers: []storepb.LabelMatcher{{Name: "ext", Value: "1", Type: storepb.LabelMatcher_EQ}},
+			},
+			expectedSeries: []rawSeries{
+				{
+					lset:    []storepb.Label{{Name: "a", Value: "b"}},
+					samples: []sample{{1, 1}, {2, 2}, {3, 3}},
+				},
+			},
+			expectedWarningsLen: 2,
+		},
+	} {
+		if ok := t.Run(tc.title, func(t *testing.T) {
+			q := NewProxyStore(nil, prometheus.NewRegistry(),
+				func() []Client { return tc.storeAPIs },
+				component.Query,
+				tc.selectorLabels,
+				4*time.Second,
 			)
 
 			s := newStoreSeriesServer(context.Background())
@@ -443,11 +571,11 @@ func TestProxyStore_Series_RequestParamsProxied(t *testing.T) {
 			maxTime:     300,
 		},
 	}
-	q := NewProxyStore(nil,
+	q := NewProxyStore(nil, prometheus.NewRegistry(),
 		func() []Client { return cls },
 		component.Query,
 		nil,
-		1*time.Second,
+		0*time.Second,
 	)
 
 	ctx := context.Background()
@@ -502,11 +630,11 @@ func TestProxyStore_Series_RegressionFillResponseChannel(t *testing.T) {
 
 	}
 
-	q := NewProxyStore(nil,
+	q := NewProxyStore(nil, prometheus.NewRegistry(),
 		func() []Client { return cls },
 		component.Query,
 		tlabels.FromStrings("fed", "a"),
-		1*time.Second,
+		0*time.Second,
 	)
 
 	ctx := context.Background()
@@ -540,11 +668,11 @@ func TestProxyStore_LabelValues(t *testing.T) {
 			},
 		}},
 	}
-	q := NewProxyStore(nil,
+	q := NewProxyStore(nil, prometheus.NewRegistry(),
 		func() []Client { return cls },
 		component.Query,
 		nil,
-		1*time.Second,
+		0*time.Second,
 	)
 
 	ctx := context.Background()
@@ -704,6 +832,7 @@ type mockedStoreAPI struct {
 	RespSeries      []*storepb.SeriesResponse
 	RespLabelValues *storepb.LabelValuesResponse
 	RespError       error
+	RespDuration    time.Duration
 
 	LastSeriesReq      *storepb.SeriesRequest
 	LastLabelValuesReq *storepb.LabelValuesRequest
@@ -716,7 +845,7 @@ func (s *mockedStoreAPI) Info(ctx context.Context, req *storepb.InfoRequest, _ .
 func (s *mockedStoreAPI) Series(ctx context.Context, req *storepb.SeriesRequest, _ ...grpc.CallOption) (storepb.Store_SeriesClient, error) {
 	s.LastSeriesReq = req
 
-	return &StoreSeriesClient{ctx: ctx, respSet: s.RespSeries}, s.RespError
+	return &StoreSeriesClient{ctx: ctx, respSet: s.RespSeries, respDur: s.RespDuration}, s.RespError
 }
 
 func (s *mockedStoreAPI) LabelNames(ctx context.Context, req *storepb.LabelNamesRequest, _ ...grpc.CallOption) (*storepb.LabelNamesResponse, error) {
@@ -736,9 +865,12 @@ type StoreSeriesClient struct {
 	ctx     context.Context
 	i       int
 	respSet []*storepb.SeriesResponse
+	respDur time.Duration
 }
 
 func (c *StoreSeriesClient) Recv() (*storepb.SeriesResponse, error) {
+	time.Sleep(c.respDur)
+
 	if c.i >= len(c.respSet) {
 		return nil, io.EOF
 	}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Improves handling of timed out data/
Adds `--store.response-timeout` in order to have a timeout on a single stream operation.

Some times GRPC streams get stuck and don't send any data for long periods of time
E.G. Simple GRPC Store API, which just sleeps.

Right now the only option to time them out in GRPC is to set `context.WithTimeout()`
The issue is that it is a global timeout,
 if we set it to 10s, we won't ever get results from Thanos Store (backed by object store)
if we set it to 120s, we will always be waiting 120s for the HTTP queries to finish, which is :/
As we will be waiting for the slowest one to finish

This fix adds a timeout per single data receive operation

Ref: https://github.com/improbable-eng/thanos/pull/928

Thanos Query will log if timeout was reached:

```
thanos-query-66f5864584-kh6wp thanos-query level=warn ts=2019-03-19T11:12:41.659624416Z caller=proxy.go:373 err="failed to receive any data in 500ms from Addr: prometheus-0.thanos-sidecar.sys-mon:10901 Labels: [{cloud_provider aws {} [] 0} {kubernetes_cluster dev-aws {} [] 0} {monitor sys-mon-prometheus {} [] 0} {replica sys-mon-prometheus-0 {} [] 0} {uw_environment dev {} [] 0}] Mint: 1552824000000 Maxt: 9223372036854775807:: context deadline exceeded" msg="returning partial response"
thanos-query-66f5864584-kh6wp thanos-query level=warn ts=2019-03-19T11:13:50.291321886Z caller=proxy.go:373 err="failed to receive any data in 500ms from Addr: thanos-store.telecom:10901 Labels: [] Mint: 1535673600000 Maxt: 1552989600000:: context deadline exceeded" msg="returning partial response"
thanos-query-66f5864584-kh6wp thanos-query level=warn ts=2019-03-19T11:15:37.430210112Z caller=proxy.go:373 err="failed to receive any data in 500ms from Addr: thanos-store.customer-platform:10901 Labels: [] Mint: 1549807838621 Maxt: 1552989600000:: context deadline exceeded" msg="returning partial response"
```

## Verification

Tested locally on our cluster, both turned on and turned off (default).

Unit tests.

