### PR TITLE
WIP store: Add --skip-window functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Added
 - [#811](https://github.com/improbable-eng/thanos/pull/811) Remote write receiver
+- [#930](https://github.com/improbable-eng/thanos/pull/930) New Thanos Store --skip-window flag. Time duration, which won't be reported to Thanos Query.
 
 ### Fixed
 - [#921](https://github.com/improbable-eng/thanos/pull/921) `thanos_objstore_bucket_last_successful_upload_time` now does not appear when no blocks have been uploaded so far

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -44,7 +44,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 	blockSyncConcurrency := cmd.Flag("block-sync-concurrency", "Number of goroutines to use when syncing blocks from object storage.").
 		Default("20").Int()
 
-	skipWindow := modelDuration(cmd.Flag("skip-window", "Time duration, which won't be reported to Thanos Query."))
+	skipWindow := modelDuration(cmd.Flag("skip-window", "Time duration, which won't be reported to Thanos Query.").Default("0h"))
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, debugLogging bool) error {
 		peer, err := newPeerFn(logger, reg, false, "", false)
@@ -52,11 +52,6 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 			return errors.Wrap(err, "new cluster peer")
 		}
 
-		var skipWindowDur *time.Duration
-		if skipWindow != nil {
-			dur := time.Duration(*skipWindow)
-			skipWindowDur = &dur
-		}
 		return runStore(g,
 			logger,
 			reg,
@@ -75,7 +70,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 			debugLogging,
 			*syncInterval,
 			*blockSyncConcurrency,
-			skipWindowDur,
+			time.Duration(*skipWindow),
 		)
 	}
 }
@@ -100,7 +95,7 @@ func runStore(
 	verbose bool,
 	syncInterval time.Duration,
 	blockSyncConcurrency int,
-	skipWindow *time.Duration,
+	skipWindow time.Duration,
 ) error {
 	{
 		confContentYaml, err := objStoreConfig.Content()

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -115,5 +115,7 @@ Flags:
       --block-sync-concurrency=20  
                                  Number of goroutines to use when syncing blocks
                                  from object storage.
+      --skip-window=0h           Time duration, which won't be reported to
+                                 Thanos Query.
 
 ```

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -174,7 +174,7 @@ type BucketStore struct {
 	blockSyncConcurrency int
 
 	partitioner partitioner
-	skipWindow  *time.Duration
+	skipWindow  time.Duration
 }
 
 // NewBucketStore creates a new bucket backed store that implements the store API against
@@ -188,7 +188,7 @@ func NewBucketStore(
 	maxChunkPoolBytes uint64,
 	debugLogging bool,
 	blockSyncConcurrency int,
-	skipWindow *time.Duration,
+	skipWindow time.Duration,
 ) (*BucketStore, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
@@ -215,6 +215,7 @@ func NewBucketStore(
 		debugLogging:         debugLogging,
 		blockSyncConcurrency: blockSyncConcurrency,
 		partitioner:          gapBasedPartitioner{maxGapSize: maxGapSize},
+		skipWindow:           skipWindow,
 	}
 	s.metrics = newBucketStoreMetrics(reg)
 
@@ -432,9 +433,9 @@ func (s *BucketStore) TimeRange() (mint, maxt int64) {
 func (s *BucketStore) Info(context.Context, *storepb.InfoRequest) (*storepb.InfoResponse, error) {
 	mint, maxt := s.TimeRange()
 
-	if s.skipWindow != nil {
+	if s.skipWindow != 0 {
 		//TODO: is TimeRange really a Unix timestamp?
-		newt := time.Now().Add(-*s.skipWindow).Unix()
+		newt := time.Now().Add(-s.skipWindow).Unix()
 		if maxt > newt {
 			maxt = newt
 		}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -433,12 +433,9 @@ func (s *BucketStore) TimeRange() (mint, maxt int64) {
 func (s *BucketStore) Info(context.Context, *storepb.InfoRequest) (*storepb.InfoResponse, error) {
 	mint, maxt := s.TimeRange()
 
-	if s.skipWindow != 0 {
-		//TODO: is TimeRange really a Unix timestamp?
-		newt := time.Now().Add(-s.skipWindow).Unix()
-		if maxt > newt {
-			maxt = newt
-		}
+	newt := time.Now().Add(-s.skipWindow).Truncate(1*time.Hour).Unix() * 1000
+	if maxt > newt {
+		maxt = newt
 	}
 	// Store nodes hold global data and thus have no labels.
 	return &storepb.InfoResponse{

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -87,7 +87,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		testutil.Ok(t, os.RemoveAll(dir2))
 	}
 
-	store, err := NewBucketStore(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, 100, 0, false, 20, 0, 0)
+	store, err := NewBucketStore(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, 100, 0, false, 20, 0)
 	testutil.Ok(t, err)
 
 	s.store = store

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -87,7 +87,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		testutil.Ok(t, os.RemoveAll(dir2))
 	}
 
-	store, err := NewBucketStore(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, 100, 0, false, 20)
+	store, err := NewBucketStore(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, 100, 0, false, 20, 0, 0)
 	testutil.Ok(t, err)
 
 	s.store = store

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -283,7 +283,7 @@ func TestBucketStore_Info(t *testing.T) {
 	dir, err := ioutil.TempDir("", "prometheus-test")
 	testutil.Ok(t, err)
 
-	bucketStore, err := NewBucketStore(nil, nil, nil, dir, 2e5, 2e5, false, 20)
+	bucketStore, err := NewBucketStore(nil, nil, nil, dir, 2e5, 2e5, false, 20, 0)
 	testutil.Ok(t, err)
 
 	resp, err := bucketStore.Info(ctx, &storepb.InfoRequest{})


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Adds --skip-window to Thanos Store, this allows users to configure time duration, which won't be reported to Thanos Query.

Let's say we do `--skip-window=2d` and have Prometheus of retention of 60h, 

Thanos Query will only query Prometheus via Thanos Sidecar for first 2 days.
For more than 2d, it will hit both Thanos Sidecar + Thanos Store.

## Verification

Tested locally in our dev environment (both turned on and turned off)
Also unit tests