### PR TITLE
objstore.s3: add trace functionality

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -63,7 +63,7 @@ For debug and testing purposes you can set
 
 * `insecure: true` to switch to plain insecure HTTP instead of HTTPS
 * `http_config.insecure_skip_verify: true` to disable TLS certificate verification (if your S3 based storage is using a self-signed certificate, for example)
-* `traceon: true` to enable the mino client's verbose logging. Each request and response will be logged into the debug logger, so debug level logging must be enabled for this functionality. 
+* `traceon: true` to enable the minio client's verbose logging. Each request and response will be logged into the debug logger, so debug level logging must be enabled for this functionality. 
 
 ### Credentials
 By default Thanos will try to retrieve credentials from the following sources:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -48,10 +48,10 @@ config:
   encrypt_sse: false
   secret_key: ""
   put_user_metadata: {}
-  traceon: false
   http_config:
     idle_conn_timeout: 0s
     insecure_skip_verify: false
+  traceon: false
 ```
 
 AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -48,6 +48,7 @@ config:
   encrypt_sse: false
   secret_key: ""
   put_user_metadata: {}
+  traceon: false
   http_config:
     idle_conn_timeout: 0s
     insecure_skip_verify: false
@@ -62,6 +63,7 @@ For debug and testing purposes you can set
 
 * `insecure: true` to switch to plain insecure HTTP instead of HTTPS
 * `http_config.insecure_skip_verify: true` to disable TLS certificate verification (if your S3 based storage is using a self-signed certificate, for example)
+* `traceon: true` to enable the mino client's verbose logging. Each request and response will be logged into the debug logger, so debug level logging must be enabled for this functionality. 
 
 ### Credentials
 By default Thanos will try to retrieve credentials from the following sources:

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -51,7 +51,8 @@ config:
   http_config:
     idle_conn_timeout: 0s
     insecure_skip_verify: false
-  traceon: false
+  trace:
+    enable: false
 ```
 
 AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
@@ -63,7 +64,7 @@ For debug and testing purposes you can set
 
 * `insecure: true` to switch to plain insecure HTTP instead of HTTPS
 * `http_config.insecure_skip_verify: true` to disable TLS certificate verification (if your S3 based storage is using a self-signed certificate, for example)
-* `traceon: true` to enable the minio client's verbose logging. Each request and response will be logged into the debug logger, so debug level logging must be enabled for this functionality. 
+* `trace.enable: true` to enable the minio client's verbose logging. Each request and response will be logged into the debug logger, so debug level logging must be enabled for this functionality.
 
 ### Credentials
 By default Thanos will try to retrieve credentials from the following sources:

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -44,7 +44,11 @@ type Config struct {
 	SecretKey       string            `yaml:"secret_key"`
 	PutUserMetadata map[string]string `yaml:"put_user_metadata"`
 	HTTPConfig      HTTPConfig        `yaml:"http_config"`
-	TraceOn         bool              `yaml:"traceon"`
+	TraceConfig     TraceConfig       `yaml:"trace"`
+}
+
+type TraceConfig struct {
+	Enable bool `yaml:"enable"`
 }
 
 // HTTPConfig stores the http.Transport configuration for the s3 minio client.
@@ -153,7 +157,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		sse = encrypt.NewSSE()
 	}
 
-	if config.TraceOn {
+	if config.TraceConfig.Enable {
 		logWriter := log.NewStdlibAdapter(level.Debug(logger), log.MessageKey("s3TraceMsg"))
 		client.TraceOn(logWriter)
 	}

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -44,6 +44,7 @@ type Config struct {
 	SecretKey       string            `yaml:"secret_key"`
 	PutUserMetadata map[string]string `yaml:"put_user_metadata"`
 	HTTPConfig      HTTPConfig        `yaml:"http_config"`
+	TraceOn         bool              `yaml:"traceon"`
 }
 
 // HTTPConfig stores the http.Transport configuration for the s3 minio client.
@@ -150,6 +151,11 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	var sse encrypt.ServerSide
 	if config.SSEEncryption {
 		sse = encrypt.NewSSE()
+	}
+
+	if config.TraceOn {
+		logWriter := log.NewStdlibAdapter(level.Debug(logger), log.MessageKey("s3TraceMsg"))
+		client.TraceOn(logWriter)
 	}
 
 	bkt := &Bucket{


### PR DESCRIPTION
## Changes
`minio.Client` has a `TraceOn` method which will be
called when one set the `traceon: true` in the bucket config.

This was a feature request here
https://github.com/improbable-eng/thanos/issues/530

## Verification

1. Started a `minio` server locally and created a bucket called `test1`
2.  Created `store.yml` file (no `traceon`)
```
type: S3
config:
  bucket: "test1"
  endpoint: "localhost:9000"
  access_key: "1NRJ8U7TDIKNAJOSG03Q"
  insecure: true
  signature_version2: false
  encrypt_sse: false
  secret_key: "gUFrMkH2PySW5SunGQ3hizixNMwenYu31yZdot+m"
  put_user_metadata: {}
  http_config:
    idle_conn_timeout: 1s
    insecure_skip_verify: true
```
3.  Run `./thanos bucket ls --log.level=debug --objstore.config-file=store.yml`
  Output: 
```
 level=info ts=2019-03-18T22:21:58.554021848Z caller=factory.go:39 msg="loading bucket configuration"
level=info ts=2019-03-18T22:21:58.558332917Z caller=main.go:185 msg=exiting
```
4. Added `traceon: true` to the configfile and run the same command.
    Output:
```
level=info ts=2019-03-18T22:21:39.027884607Z caller=factory.go:39 msg="loading bucket configuration"
level=debug ts=2019-03-18T22:21:39.031199041Z caller=stdlib.go:89 s3TraceMsg=---------START-HTTP---------
level=debug ts=2019-03-18T22:21:39.031418548Z caller=stdlib.go:89 s3TraceMsg="GET /test1/?location= HTTP/1.1\r"
level=debug ts=2019-03-18T22:21:39.031470657Z caller=stdlib.go:89 s3TraceMsg="HTTP/1.1 200 OK\r"
level=debug ts=2019-03-18T22:21:39.031484449Z caller=stdlib.go:89 s3TraceMsg=---------END-HTTP---------
level=debug ts=2019-03-18T22:21:39.032384732Z caller=stdlib.go:89 s3TraceMsg=---------START-HTTP---------
level=debug ts=2019-03-18T22:21:39.032596011Z caller=stdlib.go:89 s3TraceMsg="GET /test1/?delimiter=%2F&max-keys=1000&prefix= HTTP/1.1\r"
level=debug ts=2019-03-18T22:21:39.032632794Z caller=stdlib.go:89 s3TraceMsg="HTTP/1.1 200 OK\r"
level=debug ts=2019-03-18T22:21:39.032646396Z caller=stdlib.go:89 s3TraceMsg=---------END-HTTP---------
level=info ts=2019-03-18T22:21:39.032808851Z caller=main.go:185 msg=exiting
```
5. Set `traceon: false`. Got the same result as in 3. 

