### PR TITLE
WIP: Update the shipper metadata after each upload

### DIFF
--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -346,6 +346,9 @@ func (s *Shipper) Sync(ctx context.Context) (uploaded int, err error) {
 			return nil
 		}
 		meta.Uploaded = append(meta.Uploaded, m.ULID)
+		if err := WriteMetaFile(s.logger, s.dir, meta); err != nil {
+			level.Warn(s.logger).Log("msg", "updating meta file failed", "err", err)
+		}
 
 		uploaded++
 		s.metrics.uploads.Inc()


### PR DESCRIPTION
## Changes

Update the shipper metadata after each upload rather than waiting to the end of the sync.

Partly fixes https://github.com/improbable-eng/thanos/issues/934

## Verification

Not tested yet.