### PR TITLE
query: support POST method for query/query_range endpoints

### DIFF
--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -168,7 +168,10 @@ func (api *API) Register(r *route.Router, tracer opentracing.Tracer, logger log.
 	r.Options("/*path", instr("options", api.options))
 
 	r.Get("/query", instr("query", api.query))
+	r.Post("/query", instr("query", api.query))
+
 	r.Get("/query_range", instr("query_range", api.queryRange))
+	r.Post("/query_range", instr("query_range", api.queryRange))
 
 	r.Get("/label/:name/values", instr("label_values", api.labelValues))
 


### PR DESCRIPTION
Signed-off-by: Joseph Lee <joseph.t.lee@outlook.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

The Prometheus support POST method for `query/query_range` endpoints, and Grafana support POST method for Prometheus too. 

When do complex query with multi label values from Grafana used GET method such as `count(node_load{instance=~"11\\.11\\.11\\.11|\\8\\.8\\.8\\.8"}) `  that label `instance` have much more IP  will failed, but if support POST method in Thanos Query, the query will work.

<!-- Enumerate changes you made -->

## Verification

I have test it in my daily environment and production environment.

<!-- How you tested it? How do you know it works? -->