### PR TITLE
SD: add etcdv3 and zookeeper support

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -17,59 +17,6 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-func regSDFlags(cmd *kingpin.CmdClause) (
-	sdType *string,
-	sdServers *[]string,
-	sdRefreshInterval *model.Duration,
-	buildSDSecureOptionsFunc func() map[string]string,
-	calculateSDAdvStoreAPIAddressFunc func(*string) (string, error),
-) {
-
-	sdType = cmd.Flag("sd.type", "Service Discovery type, currently support etcdv3/etcd/zookeeper").Default("").String()
-
-	sdServers = cmd.Flag("sd.server", "Addresses of sd servers (repeatable). ").
-		PlaceHolder("<url>").Strings()
-
-	sdRefreshInterval = modelDuration(cmd.Flag("sd.refresh-interval", "Interval between SD").
-		Default("30s"))
-
-	sdAdvertiseAddr := cmd.Flag("sd.advertise-address", "Explicit (external) ip:port address to advertise for service discovery. Used internally for membership only.").
-		String()
-
-	// etcd tls
-	sdEtcdTLSSecure := cmd.Flag("sd.etcd-tls-secure", "Use TLS when talking to the etcd server").Default("false").Bool()
-	sdEtcdTLSCert := cmd.Flag("sd.etcd-tls-cert", "TLS Certificates to use to identify this client to the server").Default("").String()
-	sdEtcdTLSKey := cmd.Flag("sd.etcd-tls-key", "TLS Key for the client's certificate").Default("").String()
-	sdEtcdTLSCaCert := cmd.Flag("sd.etcd-tls-ca", "TLS CA Certificates to use to verify etcd servers").Default("").String()
-	sdEtcdUsername := cmd.Flag("sd.etcd-username", "Etcd username").Default("").String()
-	sdEtcdPassword := cmd.Flag("sd.etcd-password", "Etcd password").Default("").String()
-
-	// TODO: add zookeeper acl options
-
-	buildSDSecureOptions := func() (sdSecureOptions map[string]string) {
-		sdSecureOptions = map[string]string{}
-		if *sdEtcdTLSSecure {
-			sdSecureOptions["etcd-tls-cert"] = *sdEtcdTLSCert
-			sdSecureOptions["etcd-tls-key"] = *sdEtcdTLSKey
-			sdSecureOptions["etcd-tls-ca"] = *sdEtcdTLSCaCert
-			sdSecureOptions["etcd-username"] = *sdEtcdUsername
-			sdSecureOptions["etcd-password"] = *sdEtcdPassword
-		}
-		return
-	}
-
-	calculateSDAdvStoreAPIAddress := func(grpcBindAddr *string) (string, error) {
-		host, port, err := cluster.CalculateAdvertiseAddress(*grpcBindAddr, *sdAdvertiseAddr)
-		if err != nil {
-			return "", err
-		}
-		sdAdvStoreAPIAddress := net.JoinHostPort(host, strconv.Itoa(port))
-		return sdAdvStoreAPIAddress, nil
-	}
-
-	return sdType, sdServers, sdRefreshInterval, buildSDSecureOptions, calculateSDAdvStoreAPIAddress
-}
-
 func regCommonServerFlags(cmd *kingpin.CmdClause) (
 	grpcBindAddr *string,
 	httpBindAddr *string,
@@ -241,4 +188,57 @@ func regCommonObjStoreFlags(cmd *kingpin.CmdClause, suffix string, required bool
 		path:    bucketConfFile,
 		content: bucketConf,
 	}
+}
+
+func regSDFlags(cmd *kingpin.CmdClause) (
+	sdType *string,
+	sdServers *[]string,
+	sdRefreshInterval *model.Duration,
+	buildSDSecureOptionsFunc func() map[string]string,
+	calculateSDAdvStoreAPIAddressFunc func(*string) (string, error),
+) {
+
+	sdType = cmd.Flag("sd.type", "Service Discovery type, currently support etcdv3/zookeeper").Default("").String()
+
+	sdServers = cmd.Flag("sd.server", "Addresses of sd servers (repeatable). ").
+		PlaceHolder("<url>").Strings()
+
+	sdRefreshInterval = modelDuration(cmd.Flag("sd.refresh-interval", "Interval between SD").
+		Default("30s"))
+
+	sdAdvertiseAddr := cmd.Flag("sd.advertise-address", "Explicit (external) ip:port address to advertise for service discovery. Used internally for membership only.").
+		String()
+
+	// etcd tls
+	sdEtcdTLSSecure := cmd.Flag("sd.etcd-tls-secure", "Use TLS when talking to the etcd server").Default("false").Bool()
+	sdEtcdTLSCert := cmd.Flag("sd.etcd-tls-cert", "TLS Certificates to use to identify this client to the server").Default("").String()
+	sdEtcdTLSKey := cmd.Flag("sd.etcd-tls-key", "TLS Key for the client's certificate").Default("").String()
+	sdEtcdTLSCaCert := cmd.Flag("sd.etcd-tls-ca", "TLS CA Certificates to use to verify etcd servers").Default("").String()
+	sdEtcdUsername := cmd.Flag("sd.etcd-username", "Etcd username").Default("").String()
+	sdEtcdPassword := cmd.Flag("sd.etcd-password", "Etcd password").Default("").String()
+
+	// TODO: add zookeeper acl options
+
+	buildSDSecureOptionsFunc = func() (sdSecureOptions map[string]string) {
+		sdSecureOptions = map[string]string{}
+		if *sdEtcdTLSSecure {
+			sdSecureOptions["etcd-tls-cert"] = *sdEtcdTLSCert
+			sdSecureOptions["etcd-tls-key"] = *sdEtcdTLSKey
+			sdSecureOptions["etcd-tls-ca"] = *sdEtcdTLSCaCert
+			sdSecureOptions["etcd-username"] = *sdEtcdUsername
+			sdSecureOptions["etcd-password"] = *sdEtcdPassword
+		}
+		return
+	}
+
+	calculateSDAdvStoreAPIAddress := func(grpcBindAddr *string) (string, error) {
+		host, port, err := cluster.CalculateAdvertiseAddress(*grpcBindAddr, *sdAdvertiseAddr)
+		if err != nil {
+			return "", err
+		}
+		sdAdvStoreAPIAddress := net.JoinHostPort(host, strconv.Itoa(port))
+		return sdAdvStoreAPIAddress, nil
+	}
+
+	return sdType, sdServers, sdRefreshInterval, buildSDSecureOptionsFunc, calculateSDAdvStoreAPIAddress
 }

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -427,7 +427,7 @@ func runQuery(
 			cancel()
 		})
 	}
-	// Periodically update the addresses from sd into KVStore
+	// Periodically update the addresses from sd server into nodeSet
 	// TODO: refactor here, change to watch instead of periodically update
 	if sdType != "" {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -440,12 +440,9 @@ func runQuery(
 			return runutil.Repeat(sdRefreshInterval, ctx.Done(), func() error {
 				addresses, err := client.RoleState(cluster.RoleStore, cluster.RoleSource)
 				if err != nil {
-					return errors.Wrap(err, "sd client get role state list")
+					return errors.Wrapf(err, "%s client get role state list", sdType)
 				}
-
-				// TODO: just test it
 				nodeSet.ReplaceBy(addresses)
-
 				return nil
 			})
 		}, func(error) {

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -105,7 +105,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 	dnsSDInterval := modelDuration(cmd.Flag("query.sd-dns-interval", "Interval between DNS resolutions.").
 		Default("30s"))
 
-	sdType, sdServers, _, buildSDSecureOptions, calculateSDAdvStoreAPIAddressFunc := regSDFlags(cmd)
+	sdType, sdServers, _, buildSDSecureOptionsFunc, calculateSDAdvStoreAPIAddressFunc := regSDFlags(cmd)
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
 		lset, err := parseFlagLabels(*labelStrs)
@@ -155,7 +155,7 @@ func registerRule(m map[string]setupFunc, app *kingpin.Application, name string)
 			return errors.Wrap(err, "calculate sd advertise-address")
 		}
 
-		sdSecureOptions := buildSDSecureOptions()
+		sdSecureOptions := buildSDSecureOptionsFunc()
 
 		return runRule(g,
 			logger,

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -204,7 +204,6 @@ func runSidecar(
 	}
 	// Register and keepalive
 	if sdType != "" {
-		// TODO: register what address?
 		ctx, cancel := context.WithCancel(context.Background())
 		client, err := discovery.NewClient(ctx, logger, sdType, sdAddrs, sdSecureOptions)
 		if err != nil {

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -55,7 +55,7 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application, name stri
 
 	uploadCompacted := cmd.Flag("shipper.upload-compacted", "[Experimental] If true sidecar will try to upload compacted blocks as well. Useful for migration purposes. Works only if compaction is disabled on Prometheus.").Default("false").Hidden().Bool()
 
-	sdType, sdServers, _, buildSDSecureOptions, calculateSDAdvStoreAPIAddressFunc := regSDFlags(cmd)
+	sdType, sdServers, _, buildSDSecureOptionsFunc, calculateSDAdvStoreAPIAddressFunc := regSDFlags(cmd)
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
 		rl := reloader.New(
@@ -74,7 +74,7 @@ func registerSidecar(m map[string]setupFunc, app *kingpin.Application, name stri
 		if err != nil {
 			return errors.Wrap(err, "calculate sd advertise-address")
 		}
-		sdSecureOptions := buildSDSecureOptions()
+		sdSecureOptions := buildSDSecureOptionsFunc()
 
 		return runSidecar(
 			g,

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -46,7 +46,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 	blockSyncConcurrency := cmd.Flag("block-sync-concurrency", "Number of goroutines to use when syncing blocks from object storage.").
 		Default("20").Int()
 
-	sdType, sdServers, _, buildSDSecureOptions, calculateSDAdvStoreAPIAddressFunc := regSDFlags(cmd)
+	sdType, sdServers, _, buildSDSecureOptionsFunc, calculateSDAdvStoreAPIAddressFunc := regSDFlags(cmd)
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, debugLogging bool) error {
 		peer, err := newPeerFn(logger, reg, false, "", false)
@@ -58,7 +58,7 @@ func registerStore(m map[string]setupFunc, app *kingpin.Application, name string
 		if err != nil {
 			return errors.Wrap(err, "calculate sd advertise-address")
 		}
-		sdSecureOptions := buildSDSecureOptions()
+		sdSecureOptions := buildSDSecureOptionsFunc()
 
 		return runStore(g,
 			logger,

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -190,7 +190,6 @@ func runStore(
 	}
 	// Register and keepalive
 	if sdType != "" {
-		// TODO: register what address?
 		ctx, cancel := context.WithCancel(context.Background())
 		client, err := discovery.NewClient(ctx, logger, sdType, sdAddrs, sdSecureOptions)
 		if err != nil {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -567,3 +567,20 @@ func (n noopPeer) PeerState(id string) (PeerState, bool)                      { 
 func (n noopPeer) Join(peerType PeerType, initialMetadata PeerMetadata) error { return nil }
 func (n noopPeer) PeerStates(types ...PeerType) map[string]PeerState          { return nil }
 func (n noopPeer) Close(timeout time.Duration)                                {}
+
+const RootPath = "/thanos/"
+
+// Role describes a component's role in the cluster.
+type Role string
+
+// Constants holding valid PeerType values.
+const (
+	// RoleStore is for components that implements StoreAPI and are used for browsing historical data.
+	RoleStore = "store"
+	// RoleSource is for components that implements StoreAPI and are used for scraping data. They tend to
+	// have data accessible only for short period.
+	RoleSource = "source"
+
+	// RoleQuery is for components that implements QueryAPI and are used for querying the metrics.
+	RoleQuery = "query"
+)

--- a/pkg/discovery/cache/kv.go
+++ b/pkg/discovery/cache/kv.go
@@ -1,0 +1,59 @@
+package cache
+
+import (
+	"sync"
+)
+
+// Cache is a store for target groups. It provides thread safe updates and a way for obtaining all addresses from
+// the stored target groups.
+type KVStore struct {
+	set map[string]bool
+	sync.Mutex
+}
+
+// New returns a new empty Cache.
+func NewKVStore() *KVStore {
+	return &KVStore{
+		set: make(map[string]bool),
+	}
+}
+
+// Update stores the targets for the given groups.
+// Note: targets for a group are replaced entirely on update. If a group with no target is given this is equivalent to
+// deleting all the targets for this group.
+func (c *KVStore) Add(address string) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.set[address] = true
+}
+
+func (c *KVStore) Delete(address string) {
+	c.Lock()
+	defer c.Unlock()
+
+	if _, ok := c.set[address]; ok {
+		delete(c.set, address)
+	}
+}
+
+// TODO: replace it, don't just remove all
+func (c *KVStore) Clear() {
+	c.Lock()
+	defer c.Unlock()
+
+	c.set = make(map[string]bool)
+
+}
+
+// Addresses returns all the addresses from all target groups present in the Cache.
+func (c *KVStore) Addresses() []string {
+	c.Lock()
+	defer c.Unlock()
+
+	var addresses []string
+	for address, _ := range c.set {
+		addresses = append(addresses, address)
+	}
+	return addresses
+}

--- a/pkg/discovery/cache/set.go
+++ b/pkg/discovery/cache/set.go
@@ -4,8 +4,7 @@ import (
 	"sync"
 )
 
-// Cache is a store for target groups. It provides thread safe updates and a way for obtaining all addresses from
-// the stored target groups.
+// Cache is a store for address via SD. It provides thread safe updates and a way for obtaining all addresses
 type Set struct {
 	data map[string]bool
 	sync.Mutex
@@ -18,9 +17,6 @@ func NewSet() *Set {
 	}
 }
 
-// Update stores the targets for the given groups.
-// Note: targets for a group are replaced entirely on update. If a group with no target is given this is equivalent to
-// deleting all the targets for this group.
 func (c *Set) Add(address string) {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/discovery/cache/set.go
+++ b/pkg/discovery/cache/set.go
@@ -6,53 +6,61 @@ import (
 
 // Cache is a store for target groups. It provides thread safe updates and a way for obtaining all addresses from
 // the stored target groups.
-type KVStore struct {
-	set map[string]bool
+type Set struct {
+	data map[string]bool
 	sync.Mutex
 }
 
-// New returns a new empty Cache.
-func NewKVStore() *KVStore {
-	return &KVStore{
-		set: make(map[string]bool),
+// New returns a new empty Set.
+func NewSet() *Set {
+	return &Set{
+		data: make(map[string]bool),
 	}
 }
 
 // Update stores the targets for the given groups.
 // Note: targets for a group are replaced entirely on update. If a group with no target is given this is equivalent to
 // deleting all the targets for this group.
-func (c *KVStore) Add(address string) {
+func (c *Set) Add(address string) {
 	c.Lock()
 	defer c.Unlock()
 
-	c.set[address] = true
+	c.data[address] = true
 }
 
-func (c *KVStore) Delete(address string) {
+func (c *Set) Delete(address string) {
 	c.Lock()
 	defer c.Unlock()
 
-	if _, ok := c.set[address]; ok {
-		delete(c.set, address)
+	if _, ok := c.data[address]; ok {
+		delete(c.data, address)
 	}
 }
 
-// TODO: replace it, don't just remove all
-func (c *KVStore) Clear() {
+func (c *Set) Clear() {
 	c.Lock()
 	defer c.Unlock()
 
-	c.set = make(map[string]bool)
+	c.data = make(map[string]bool)
+}
 
+func (c *Set) ReplaceBy(addresses []string) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.data = make(map[string]bool)
+	for _, addr := range addresses {
+		c.data[addr] = true
+	}
 }
 
 // Addresses returns all the addresses from all target groups present in the Cache.
-func (c *KVStore) Addresses() []string {
+func (c *Set) Addresses() []string {
 	c.Lock()
 	defer c.Unlock()
 
 	var addresses []string
-	for address, _ := range c.set {
+	for address, _ := range c.data {
 		addresses = append(addresses, address)
 	}
 	return addresses

--- a/pkg/discovery/client.go
+++ b/pkg/discovery/client.go
@@ -19,12 +19,12 @@ type Client interface {
 	RoleState(types ...cluster.Role) ([]string, error)
 }
 
-func NewClient(ctx context.Context, logger log.Logger, t string, addrs []string) (Client, error) {
+func NewClient(ctx context.Context, logger log.Logger, t string, addrs []string, sdSecureOptions map[string]string) (Client, error) {
 	switch t {
 	case "etcdv3":
-		return etcd.NewEtcdV3Client(ctx, logger, addrs)
+		return etcd.NewEtcdV3Client(ctx, logger, addrs, sdSecureOptions)
 	case "zookeeper", "zk":
-		return zk.NewZKClient(logger, addrs)
+		return zk.NewZKClient(logger, addrs, sdSecureOptions)
 	}
 	return nil, errors.New("sdType Not Supported")
 }

--- a/pkg/discovery/client.go
+++ b/pkg/discovery/client.go
@@ -1,0 +1,30 @@
+package discovery
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/improbable-eng/thanos/pkg/discovery/zk"
+
+	"github.com/improbable-eng/thanos/pkg/cluster"
+
+	"github.com/go-kit/kit/log"
+
+	"github.com/improbable-eng/thanos/pkg/discovery/etcd"
+)
+
+type Client interface {
+	Register(role cluster.Role, address string) error
+	RoleState(types ...cluster.Role) ([]string, error)
+}
+
+func NewClient(ctx context.Context, logger log.Logger, t string, addrs []string) (Client, error) {
+	switch t {
+	case "etcdv3":
+		return etcd.NewEtcdV3Client(ctx, logger, addrs)
+	case "zookeeper", "zk":
+		return zk.NewZKClient(logger, addrs)
+	}
+	return nil, errors.New("sdType Not Supported")
+}

--- a/pkg/discovery/etcd/etcdv3.go
+++ b/pkg/discovery/etcd/etcdv3.go
@@ -1,0 +1,64 @@
+package etcd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kit/kit/log/level"
+
+	"github.com/improbable-eng/thanos/pkg/cluster"
+
+	"github.com/go-kit/kit/sd/etcdv3"
+
+	"github.com/go-kit/kit/log"
+)
+
+type EtcdV3Client struct {
+	client *etcdv3.Client
+	logger log.Logger
+}
+
+func NewEtcdV3Client(ctx context.Context, logger log.Logger, addrs []string) (*EtcdV3Client, error) {
+	// machines := []string{"http://10.99.242.255:2379"}
+
+	options := etcdv3.ClientOptions{}
+
+	client, err := etcdv3.NewClient(ctx, addrs, options)
+	if err != nil {
+		level.Error(logger).Log("msg", "connect to service discovery server failed", "addr", addrs, "err", err)
+		return nil, err
+	}
+
+	return &EtcdV3Client{client: &client, logger: logger}, nil
+
+}
+
+func (s *EtcdV3Client) Register(roleType cluster.Role, address string) error {
+	service := etcdv3.Service{
+		Key:   fmt.Sprintf("%s%s/%s", cluster.RootPath, roleType, address),
+		Value: address,
+	}
+
+	level.Info(s.logger).Log("msg", "register", "key", fmt.Sprintf("%s%s/%s", cluster.RootPath, roleType, address))
+
+	err := (*(s.client)).Register(service)
+	return err
+}
+
+func (s *EtcdV3Client) RoleState(types ...cluster.Role) ([]string, error) {
+	addresses := []string{}
+	for _, t := range types {
+		path := fmt.Sprintf("%s%s/", cluster.RootPath, t)
+		fmt.Println(path)
+
+		data, err := (*(s.client)).GetEntries(path)
+		if err != nil {
+			level.Info(s.logger).Log("msg", "client GetEntires fail", "err", err)
+			continue
+		}
+		addresses = append(addresses, data...)
+	}
+	return addresses, nil
+}
+
+// TODO: add a watch func here?

--- a/pkg/discovery/etcd/etcdv3.go
+++ b/pkg/discovery/etcd/etcdv3.go
@@ -38,7 +38,7 @@ func NewEtcdV3Client(ctx context.Context, logger log.Logger, addrs []string, sdS
 
 	client, err := etcdv3.NewClient(ctx, addrs, options)
 	if err != nil {
-		level.Error(logger).Log("msg", "connect to service discovery server failed", "addr", addrs, "err", err)
+		level.Error(logger).Log("msg", "connect to EtcdV3 server failed", "addr", addrs, "err", err)
 		return nil, err
 	}
 
@@ -46,26 +46,26 @@ func NewEtcdV3Client(ctx context.Context, logger log.Logger, addrs []string, sdS
 
 }
 
-func (s *EtcdV3Client) Register(roleType cluster.Role, address string) error {
-	key := fmt.Sprintf("%s%s/%s", cluster.RootPath, roleType, address)
+func (s *EtcdV3Client) Register(role cluster.Role, address string) error {
+	key := fmt.Sprintf("%s%s/%s", cluster.RootPath, role, address)
 	service := etcdv3.Service{
 		Key:   key,
 		Value: address,
 	}
 
-	level.Info(s.logger).Log("msg", "register", "key", key)
+	level.Info(s.logger).Log("msg", "register to EtcdV3", "key", key)
 
 	err := s.client.Register(service)
 	return err
 }
 
-func (s *EtcdV3Client) RoleState(types ...cluster.Role) ([]string, error) {
+func (s *EtcdV3Client) RoleState(roles ...cluster.Role) ([]string, error) {
 	addresses := []string{}
-	for _, t := range types {
-		path := fmt.Sprintf("%s%s/", cluster.RootPath, t)
+	for _, r := range roles {
+		path := fmt.Sprintf("%s%s/", cluster.RootPath, r)
 		data, err := s.client.GetEntries(path)
 		if err != nil {
-			level.Info(s.logger).Log("msg", "client GetEntires fail", "err", err)
+			level.Info(s.logger).Log("msg", "GetEntires from EtcdV3 failed", "err", err)
 			continue
 		}
 		addresses = append(addresses, data...)

--- a/pkg/discovery/zk/zk.go
+++ b/pkg/discovery/zk/zk.go
@@ -1,0 +1,71 @@
+package zk
+
+import (
+	"fmt"
+
+	"github.com/go-kit/kit/log/level"
+
+	"github.com/improbable-eng/thanos/pkg/cluster"
+
+	"github.com/go-kit/kit/log"
+
+	zk2 "github.com/samuel/go-zookeeper/zk"
+
+	"github.com/go-kit/kit/sd/zk"
+)
+
+type ZKClient struct {
+	client *zk.Client
+	logger log.Logger
+}
+
+func NewZKClient(logger log.Logger, addrs []string) (*ZKClient, error) {
+
+	// servers := []string{"10.99.242.255:2379"}
+	handler := zk.EventHandler(func(event zk2.Event) {
+		fmt.Println(event)
+	})
+
+	client, err := zk.NewClient(addrs, logger, handler)
+	if err != nil {
+		level.Error(logger).Log("msg", "connect to service discovery server failed", "addr", addrs, "err", err)
+		return nil, err
+	}
+
+	return &ZKClient{client: &client, logger: logger}, nil
+}
+
+func (s *ZKClient) Register(roleType cluster.Role, address string) error {
+	service := &zk.Service{
+		Path: fmt.Sprintf("%s%s/", cluster.RootPath, roleType),
+		Name: address,
+		Data: []byte(address),
+	}
+	// TODO: createparentNode 会导致 /thanos/query/[address]/ 空, 然后register加入了 /thanos/query/_xxxx/有值是address
+
+	level.Info(s.logger).Log("msg", "register", "key", fmt.Sprintf("%s%s/", cluster.RootPath, roleType))
+
+	err := (*(s.client)).Register(service)
+	return err
+}
+
+func (s *ZKClient) RoleState(types ...cluster.Role) ([]string, error) {
+	addresses := []string{}
+
+	for _, t := range types {
+		path := fmt.Sprintf("%s%s", cluster.RootPath, t)
+		nodes, _, err := (*(s.client)).GetEntries(path)
+		if err != nil {
+			level.Info(s.logger).Log("msg", "client GetEntires fail", "path", path, "err", err)
+			continue
+		}
+
+		// should not return empty address, while go-kit/kit/sd/zk will create empty node
+		for _, node := range nodes {
+			if node != "" {
+				addresses = append(addresses, node)
+			}
+		}
+	}
+	return addresses, nil
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

We deployed thanos 0.3.2 in K8S Cluster, k8s DNS as in-cluster-SD(for all components of thanos), and Gossip as out-cluster-SD(for all sidecars in other cluster). And we have a global etcd/zk cluster as SD servers, so we want to know if it's possible to replace `Gossip` with `etcd`.

While Thanos SD support File-SD/DNS/Gossip(will remove soon?), I am not sure if this is appropriate to make the `discovery` module to support etcd, zk and consul?

DNS and file-SD are just enough for most conditions, but I want to make sure is Thanos will support more SD options? 


More to add later:
- unittest
- etcd support
- push go mode dependency files
- docs and comments

related issue: #723 

## Changes

<!-- Enumerate changes you made -->
- add etcdv3 / zookeeper as SD options
- add tls support for etcdv3 SD


## Verification
- tested locally and  in a k8s cluster

<!-- How you tested it? How do you know it works? -->