### PR TITLE
examples: Use $labelvalue and $labelselector rather than hard coding app and thanos-query

### DIFF
--- a/examples/grafana/thanos-query.json
+++ b/examples/grafana/thanos-query.json
@@ -956,7 +956,7 @@
         "multi": false,
         "name": "pod",
         "options": [],
-        "query": "label_values(thanos_build_info{app=\"thanos-query\"}, kubernetes_pod_name)",
+        "query": "label_values(thanos_build_info{$labelselector=\"$labelvalue\"}, kubernetes_pod_name)",
         "refresh": 1,
         "regex": "",
         "sort": 0,


### PR DESCRIPTION
## Changes

Avoid hard coding app and thanos query, use the template parameters.

## Verification

Manually verified in Grafana