### PR TITLE
compact: accept malformed index

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -167,7 +167,8 @@ func runCompact(
 		}
 	}()
 
-	sy, err := compact.NewSyncer(logger, reg, bkt, syncDelay, blockSyncConcurrency)
+	sy, err := compact.NewSyncer(logger, reg, bkt, syncDelay,
+		blockSyncConcurrency, acceptMalformedIndex)
 	if err != nil {
 		return errors.Wrap(err, "create syncer")
 	}
@@ -197,8 +198,7 @@ func runCompact(
 		return errors.Wrap(err, "clean working downsample directory")
 	}
 
-	compactor := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt,
-		acceptMalformedIndex)
+	compactor := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt)
 
 	if retentionByResolution[compact.ResolutionLevelRaw].Seconds() != 0 {
 		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retentionByResolution[compact.ResolutionLevelRaw])

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -66,6 +66,9 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 
 	haltOnError := cmd.Flag("debug.halt-on-error", "Halt the process if a critical compaction error is detected.").
 		Hidden().Default("true").Bool()
+	acceptMalformed := cmd.Flag("debug.accept-malformed-index",
+		"Compaction index verification will ignore out of order label names.").
+		Hidden().Default("false").Bool()
 
 	httpAddr := regHTTPAddrFlag(cmd)
 
@@ -102,6 +105,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 			objStoreConfig,
 			time.Duration(*syncDelay),
 			*haltOnError,
+			*acceptMalformed,
 			*wait,
 			map[compact.ResolutionLevel]time.Duration{
 				compact.ResolutionLevelRaw: time.Duration(*retentionRaw),
@@ -125,6 +129,7 @@ func runCompact(
 	objStoreConfig *pathOrContent,
 	syncDelay time.Duration,
 	haltOnError bool,
+	acceptMalformed bool,
 	wait bool,
 	retentionByResolution map[compact.ResolutionLevel]time.Duration,
 	component string,
@@ -206,7 +211,7 @@ func runCompact(
 
 	ctx, cancel := context.WithCancel(context.Background())
 	f := func() error {
-		if err := compactor.Compact(ctx); err != nil {
+		if err := compactor.Compact(ctx, acceptMalformed); err != nil {
 			return errors.Wrap(err, "compaction failed")
 		}
 		level.Info(logger).Log("msg", "compaction iterations done")

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -254,9 +254,9 @@ type Stats struct {
 	OutOfOrderLabels int
 }
 
-// PrometheusIssue5372Err returns an error if statsd indicates postings with out
-// of order labels.  This is introduced by Prometheus Issue #5372 in 2.8.0 and
-// below.
+// PrometheusIssue5372Err returns an error if the Stats object indicates
+// postings with out of order labels.  This is corrected by Prometheus Issue
+// #5372 and affects Prometheus versions 2.8.0 and below.
 func (i Stats) PrometheusIssue5372Err() error {
 	if i.OutOfOrderLabels > 0 {
 		return errors.Errorf("index contains %d postings with out of order labels",

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -370,7 +370,7 @@ func GatherIndexIssueStats(logger log.Logger, fn string, minTime int64, maxTime 
 				stats.OutOfOrderLabels++
 				level.Warn(logger).Log("msg",
 					"out-of-order label set: known bug in Prometheus 2.8.0 and below",
-					"label set", fmt.Sprintf("%s", lset),
+					"labelset", fmt.Sprintf("%s", lset),
 					"series", fmt.Sprintf("%d", id),
 				)
 			}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -820,7 +820,7 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor, i
 	}
 
 	// Ensure the output block is valid.
-	if err := block.VerifyIndex(cg.logger, filepath.Join(bdir, block.IndexFilename), newMeta.MinTime, newMeta.MaxTime); err != nil {
+	if err := block.VerifyIndex(cg.logger, filepath.Join(bdir, block.IndexFilename), newMeta.MinTime, newMeta.MaxTime); !ignoreMalformed && err != nil {
 		return false, ulid.ULID{}, halt(errors.Wrapf(err, "invalid result block %s", bdir))
 	}
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -777,7 +777,8 @@ func (cg *Group) compact(ctx context.Context, dir string, comp tsdb.Compactor) (
 		}
 
 		if err := stats.PrometheusIssue5372Err(); !cg.acceptMalformedIndex && err != nil {
-			return false, ulid.ULID{}, errors.Wrapf(err, "block id %s", id)
+			return false, ulid.ULID{}, errors.Wrapf(err,
+				"block id %s, try running with --debug.accept-malformed-index", id)
 		}
 	}
 	level.Debug(cg.logger).Log("msg", "downloaded and verified blocks",

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -62,13 +62,13 @@ func TestSyncer_SyncMetas_e2e(t *testing.T) {
 			testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), metadata.MetaFilename), &buf))
 		}
 
-		groups, err := sy.Groups()
+		groups, err := sy.Groups(false)
 		testutil.Ok(t, err)
 		testutil.Equals(t, ids[:10], groups[0].IDs())
 
 		testutil.Ok(t, sy.SyncMetas(ctx))
 
-		groups, err = sy.Groups()
+		groups, err = sy.Groups(false)
 		testutil.Ok(t, err)
 		testutil.Equals(t, ids[5:], groups[0].IDs())
 	})
@@ -157,7 +157,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		testutil.Ok(t, sy.SyncMetas(ctx))
 
 		// Only the level 3 block, the last source block in both resolutions should be left.
-		groups, err := sy.Groups()
+		groups, err := sy.Groups(false)
 		testutil.Ok(t, err)
 
 		testutil.Equals(t, "0@{}", groups[0].Key())
@@ -244,6 +244,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 			bkt,
 			extLset,
 			124,
+			false,
 			metrics.compactions.WithLabelValues(""),
 			metrics.compactionFailures.WithLabelValues(""),
 			metrics.garbageCollectedBlocks,
@@ -253,7 +254,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		comp, err := tsdb.NewLeveledCompactor(nil, log.NewLogfmtLogger(os.Stderr), []int64{1000, 3000}, nil)
 		testutil.Ok(t, err)
 
-		shouldRerun, id, err := g.Compact(ctx, dir, comp, false)
+		shouldRerun, id, err := g.Compact(ctx, dir, comp)
 		testutil.Ok(t, err)
 		testutil.Assert(t, !shouldRerun, "group should be empty, but compactor did a compaction and told us to rerun")
 
@@ -262,7 +263,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 			testutil.Ok(t, g.Add(m))
 		}
 
-		shouldRerun, id, err = g.Compact(ctx, dir, comp, false)
+		shouldRerun, id, err = g.Compact(ctx, dir, comp)
 		testutil.Ok(t, err)
 		testutil.Assert(t, shouldRerun, "there should be compactible data, but the compactor reported there was not")
 

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -253,7 +253,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 		comp, err := tsdb.NewLeveledCompactor(nil, log.NewLogfmtLogger(os.Stderr), []int64{1000, 3000}, nil)
 		testutil.Ok(t, err)
 
-		shouldRerun, id, err := g.Compact(ctx, dir, comp)
+		shouldRerun, id, err := g.Compact(ctx, dir, comp, false)
 		testutil.Ok(t, err)
 		testutil.Assert(t, !shouldRerun, "group should be empty, but compactor did a compaction and told us to rerun")
 
@@ -262,7 +262,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 			testutil.Ok(t, g.Add(m))
 		}
 
-		shouldRerun, id, err = g.Compact(ctx, dir, comp)
+		shouldRerun, id, err = g.Compact(ctx, dir, comp, false)
 		testutil.Ok(t, err)
 		testutil.Assert(t, shouldRerun, "there should be compactible data, but the compactor reported there was not")
 

--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -32,7 +32,7 @@ func TestSyncer_SyncMetas_e2e(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
-		sy, err := NewSyncer(nil, nil, bkt, 0, 1)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false)
 		testutil.Ok(t, err)
 
 		// Generate 15 blocks. Initially the first 10 are synced into memory and only the last
@@ -62,13 +62,13 @@ func TestSyncer_SyncMetas_e2e(t *testing.T) {
 			testutil.Ok(t, bkt.Upload(ctx, path.Join(m.ULID.String(), metadata.MetaFilename), &buf))
 		}
 
-		groups, err := sy.Groups(false)
+		groups, err := sy.Groups()
 		testutil.Ok(t, err)
 		testutil.Equals(t, ids[:10], groups[0].IDs())
 
 		testutil.Ok(t, sy.SyncMetas(ctx))
 
-		groups, err = sy.Groups(false)
+		groups, err = sy.Groups()
 		testutil.Ok(t, err)
 		testutil.Equals(t, ids[5:], groups[0].IDs())
 	})
@@ -134,7 +134,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		}
 
 		// Do one initial synchronization with the bucket.
-		sy, err := NewSyncer(nil, nil, bkt, 0, 1)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false)
 		testutil.Ok(t, err)
 		testutil.Ok(t, sy.SyncMetas(ctx))
 
@@ -157,7 +157,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		testutil.Ok(t, sy.SyncMetas(ctx))
 
 		// Only the level 3 block, the last source block in both resolutions should be left.
-		groups, err := sy.Groups(false)
+		groups, err := sy.Groups()
 		testutil.Ok(t, err)
 
 		testutil.Equals(t, "0@{}", groups[0].Key())


### PR DESCRIPTION
This PR attempts to address https://github.com/improbable-eng/thanos/issues/888

## Changes

* Added --debug.accept-malformed-index that will ignore errors caused by Prometheus Issue https://github.com/prometheus/prometheus/pull/5372
* Log at warn level when out of order labels are seen, the Status struct keeps track of how many of these errors are present in a TSDB block

## Verification

I've run this code with and without the added CLI option against my Prometheus TSDB blocks known to exhibit this condition.  The condition is flagged appropriately.  New compacted blocks are built.

## WIP Status

