### PR TITLE
Add time based partitioning to store component

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -145,6 +145,31 @@ func modelDuration(flags *kingpin.FlagClause) *model.Duration {
 	return value
 }
 
+type flagTime struct {
+	time time.Time
+}
+
+func (ft *flagTime) Set(s string) error {
+	var err error
+	ft.time, err = time.Parse(time.RFC3339, s)
+	return err
+}
+
+func (ft flagTime) String() string {
+	return ft.time.String()
+}
+
+func (ft flagTime) Time() time.Time {
+	return ft.time
+}
+
+func timeFlag(flags *kingpin.FlagClause) *flagTime {
+	var value = new(flagTime)
+	flags.SetValue(value)
+
+	return value
+}
+
 type pathOrContent struct {
 	fileFlagName    string
 	contentFlagName string

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -115,5 +115,9 @@ Flags:
       --block-sync-concurrency=20
                                  Number of goroutines to use when syncing blocks
                                  from object storage.
+      --min-time=0000-01-01T00:00:00Z
+                                 Start of time range limit to serve
+      --max-time=9999-12-31T23:59:59Z
+                                 End of time range limit to serve
 
 ```

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1042,7 +1042,9 @@ func newBucketBlock(
 	// containing the blocks within the start and end times.  If the MinTime is
 	// outside our time range, then clean up downloaded files and return early.
 	if b.meta.MinTime < minTime || b.meta.MinTime > maxTime {
-		os.RemoveAll(dir)
+		if err = os.RemoveAll(dir); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 

--- a/pkg/store/bucket_e2e_test.go
+++ b/pkg/store/bucket_e2e_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -87,7 +88,7 @@ func prepareStoreWithTestBlocks(t testing.TB, dir string, bkt objstore.Bucket, m
 		testutil.Ok(t, os.RemoveAll(dir2))
 	}
 
-	store, err := NewBucketStore(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, 100, 0, false, 20)
+	store, err := NewBucketStore(log.NewLogfmtLogger(os.Stderr), nil, bkt, dir, 100, 0, false, 20, math.MinInt64, math.MaxInt64)
 	testutil.Ok(t, err)
 
 	s.store = store

--- a/pkg/store/bucket_test.go
+++ b/pkg/store/bucket_test.go
@@ -283,7 +283,7 @@ func TestBucketStore_Info(t *testing.T) {
 	dir, err := ioutil.TempDir("", "prometheus-test")
 	testutil.Ok(t, err)
 
-	bucketStore, err := NewBucketStore(nil, nil, nil, dir, 2e5, 2e5, false, 20)
+	bucketStore, err := NewBucketStore(nil, nil, nil, dir, 2e5, 2e5, false, 20, math.MaxInt64, math.MaxInt64)
 	testutil.Ok(t, err)
 
 	resp, err := bucketStore.Info(ctx, &storepb.InfoRequest{})


### PR DESCRIPTION
## Changes

Add `--min-time` and `--max-time` command-line flags to store component.  This will cause the store component to only load blocks whose start time lies within the time given.  These two can be given independently and the defaults are effectively "forever ago" and "forever in the future" respectively. 

## Verification

I've tested this against a copy of one of our production buckets and I've updated the e2e tests to test this functionality.

cc: #814 