### PR TITLE
Fix panic when Azure error does not match pattern

### DIFF
--- a/pkg/objstore/azure/helpers.go
+++ b/pkg/objstore/azure/helpers.go
@@ -65,5 +65,9 @@ func getBlobURL(ctx context.Context, accountName, accountKey, containerName, blo
 
 func parseError(errorCode string) string {
 	re, _ := regexp.Compile(`X-Ms-Error-Code:\D*\[(\w+)\]`)
-	return re.FindStringSubmatch(errorCode)[1]
+	match := re.FindStringSubmatch(errorCode)
+	if match != nil && len(match) == 2 {
+		return match[1]
+	}
+	return errorCode
 }


### PR DESCRIPTION
Signed-off-by: Sylvain Rabot <s.rabot@lectra.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->