### PR TITLE
Make config reloader file writes atomic

### DIFF
--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -200,7 +200,9 @@ func (r *Reloader) apply(ctx context.Context) error {
 			}
 
 			tmpFile := r.cfgOutputFile + ".tmp"
-			defer os.Remove(tmpFile)
+			defer func() {
+				_ = os.Remove(tmpFile)
+			}()
 			if err := ioutil.WriteFile(tmpFile, b, 0666); err != nil {
 				return errors.Wrap(err, "write file")
 			}

--- a/pkg/reloader/reloader.go
+++ b/pkg/reloader/reloader.go
@@ -199,8 +199,13 @@ func (r *Reloader) apply(ctx context.Context) error {
 				return errors.Wrap(err, "expand environment variables")
 			}
 
-			if err := ioutil.WriteFile(r.cfgOutputFile, b, 0666); err != nil {
+			tmpFile := r.cfgOutputFile + ".tmp"
+			defer os.Remove(tmpFile)
+			if err := ioutil.WriteFile(tmpFile, b, 0666); err != nil {
 				return errors.Wrap(err, "write file")
+			}
+			if err := os.Rename(tmpFile, r.cfgOutputFile); err != nil {
+				return errors.Wrap(err, "rename file")
 			}
 		}
 	}


### PR DESCRIPTION
This addresses an issue found in the Prometheus Operator, which reuses
this reloader sidecar, but which then also has a second sidecar which
may trigger rule-based reloads while the config sidecar is in the middle
of writing out its config (in a non-atomic way):

https://github.com/coreos/prometheus-operator/issues/2501

I didn't add a test for this because it's hard to catch the original
problem to begin with, but it has happened.

Signed-off-by: Julius Volz <julius.volz@gmail.com>