### PR TITLE
bucket verify: repair out of order labels

### DIFF
--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -85,7 +85,7 @@ func registerBucketVerify(m map[string]setupFunc, root *kingpin.CmdClause, name 
 		var backupBkt objstore.Bucket
 		if len(backupconfContentYaml) == 0 {
 			if *repair {
-				return fmt.Errorf("repair is specified, so backup client is required")
+				return errors.Errorf("repair is specified, so backup client is required")
 			}
 		} else {
 			// nil Prometheus registerer: don't create conflicting metrics

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -85,10 +85,11 @@ func registerBucketVerify(m map[string]setupFunc, root *kingpin.CmdClause, name 
 		var backupBkt objstore.Bucket
 		if len(backupconfContentYaml) == 0 {
 			if *repair {
-				return errors.Wrap(err, "repair is specified, so backup client is required")
+				return fmt.Errorf("repair is specified, so backup client is required")
 			}
 		} else {
-			backupBkt, err = client.NewBucket(logger, backupconfContentYaml, reg, name)
+			// nil Prometheus registerer: don't create conflicting metrics
+			backupBkt, err = client.NewBucket(logger, backupconfContentYaml, nil, name)
 			if err != nil {
 				return err
 			}

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -85,7 +85,7 @@ func registerBucketVerify(m map[string]setupFunc, root *kingpin.CmdClause, name 
 		var backupBkt objstore.Bucket
 		if len(backupconfContentYaml) == 0 {
 			if *repair {
-				return errors.Errorf("repair is specified, so backup client is required")
+				return errors.New("repair is specified, so backup client is required")
 			}
 		} else {
 			// nil Prometheus registerer: don't create conflicting metrics

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -559,6 +559,11 @@ func sanitizeChunkSequence(chks []chunks.Meta, mint int64, maxt int64, ignoreChk
 	var last *chunks.Meta
 
 OUTER:
+	// This compares the current chunk to the chunk from the last iteration
+	// by pointers.  If we use "i, c := range cks" the variable c is a new
+	// variable who's address doesn't change through the entire loop.
+	// The current element of the chks slice is copied into it.  We must take
+	// the address of the indexed slice instead.
 	for i := range chks {
 		for _, ignoreChkFn := range ignoreChkFns {
 			ignore, err := ignoreChkFn(mint, maxt, last, &chks[i])

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -560,9 +560,9 @@ func sanitizeChunkSequence(chks []chunks.Meta, mint int64, maxt int64, ignoreChk
 
 OUTER:
 	// This compares the current chunk to the chunk from the last iteration
-	// by pointers.  If we use "i, c := range cks" the variable c is a new
+	// by pointers.  If we use "i, c := range chks" the variable c is a new
 	// variable who's address doesn't change through the entire loop.
-	// The current element of the chks slice is copied into it.  We must take
+	// The current element of the chks slice is copied into it. We must take
 	// the address of the indexed slice instead.
 	for i := range chks {
 		for _, ignoreChkFn := range ignoreChkFns {
@@ -626,7 +626,7 @@ func rewrite(
 		if err := indexr.Series(id, &lset, &chks); err != nil {
 			return err
 		}
-		// Make sure labels are in sorted order
+		// Make sure labels are in sorted order.
 		sort.Sort(lset)
 
 		for i, c := range chks {
@@ -655,12 +655,13 @@ func rewrite(
 		return errors.Wrap(all.Err(), "iterate series")
 	}
 
-	// sort the series -- if labels moved around the ordering will be different
+	// Sort the series, if labels are re-ordered then the ordering of series
+	// will be different.
 	sort.Slice(series, func(i, j int) bool {
 		return labels.Compare(series[i].lset, series[j].lset) < 0
 	})
 
-	// build new TSDB block
+	// Build a new TSDB block.
 	for _, s := range series {
 		if err := chunkw.WriteChunks(s.chks...); err != nil {
 			return errors.Wrap(err, "write chunks")

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -627,9 +627,8 @@ func rewrite(
 			return err
 		}
 		// Make sure labels are in sorted order
-		sort.Slice(lset, func(i, j int) bool {
-			return lset[i].Name < lset[j].Name
-		})
+		sort.Sort(lset)
+
 		for i, c := range chks {
 			chks[i].Chunk, err = chunkr.Chunk(c.Ref)
 			if err != nil {

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -616,6 +616,10 @@ func rewrite(
 		if err := indexr.Series(id, &lset, &chks); err != nil {
 			return err
 		}
+		// Make sure labels are in sorted order
+		sort.Slice(lset, func(i, j int) bool {
+			return lset[i].Name < lset[j].Name
+		})
 		for i, c := range chks {
 			chks[i].Chunk, err = chunkr.Chunk(c.Ref)
 			if err != nil {

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -531,7 +531,7 @@ func IgnoreDuplicateOutsideChunk(_ int64, _ int64, last *chunks.Meta, curr *chun
 	// the current one.
 	if curr.MinTime != last.MinTime || curr.MaxTime != last.MaxTime {
 		return false, errors.Errorf("non-sequential chunks not equal: [%d, %d] and [%d, %d]",
-			last.MaxTime, last.MaxTime, curr.MinTime, curr.MaxTime)
+			last.MinTime, last.MaxTime, curr.MinTime, curr.MaxTime)
 	}
 	ca := crc32.Checksum(last.Chunk.Bytes(), castagnoli)
 	cb := crc32.Checksum(curr.Chunk.Bytes(), castagnoli)
@@ -559,9 +559,9 @@ func sanitizeChunkSequence(chks []chunks.Meta, mint int64, maxt int64, ignoreChk
 	var last *chunks.Meta
 
 OUTER:
-	for _, c := range chks {
+	for i := range chks {
 		for _, ignoreChkFn := range ignoreChkFns {
-			ignore, err := ignoreChkFn(mint, maxt, last, &c)
+			ignore, err := ignoreChkFn(mint, maxt, last, &chks[i])
 			if err != nil {
 				return nil, errors.Wrap(err, "ignore function")
 			}
@@ -571,8 +571,8 @@ OUTER:
 			}
 		}
 
-		last = &c
-		repl = append(repl, c)
+		last = &chks[i]
+		repl = append(repl, chks[i])
 	}
 
 	return repl, nil

--- a/pkg/verifier/overlapped_blocks.go
+++ b/pkg/verifier/overlapped_blocks.go
@@ -2,6 +2,8 @@ package verifier
 
 import (
 	"context"
+	"sort"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/block"
@@ -10,7 +12,6 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb"
-	"sort"
 )
 
 const OverlappedBlocksIssueID = "overlapped_blocks"


### PR DESCRIPTION
Detected and worked around in #953 this PR introduces code into the repair function that should repair affected TSDB blocks.

## Changes

* When repairing index issues be sure to sort the label sets