### PR TITLE
Bucket: verify sort metas by MinTime before overlap check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 - [#921](https://github.com/improbable-eng/thanos/pull/921) `thanos_objstore_bucket_last_successful_upload_time` now does not appear when no blocks have been uploaded so far
+- [#966](https://github.com/improbable-eng/thanos/pull/966) Bucket: verify no longer warns about overlapping blocks, that overlap `0s` 
 
 ## [v0.3.2](https://github.com/improbable-eng/thanos/releases/tag/v0.3.2) - 2019.03.04
 

--- a/pkg/verifier/overlapped_blocks.go
+++ b/pkg/verifier/overlapped_blocks.go
@@ -2,7 +2,6 @@ package verifier
 
 import (
 	"context"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/block"
@@ -11,6 +10,7 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb"
+	"sort"
 )
 
 const OverlappedBlocksIssueID = "overlapped_blocks"
@@ -66,6 +66,11 @@ func fetchOverlaps(ctx context.Context, logger log.Logger, bkt objstore.Bucket) 
 
 	overlaps := map[string]tsdb.Overlaps{}
 	for k, groupMetas := range metas {
+
+		sort.Slice(groupMetas, func(i, j int) bool {
+			return groupMetas[i].MinTime < groupMetas[j].MinTime
+		})
+
 		o := tsdb.OverlappingBlocks(groupMetas)
 		if len(o) > 0 {
 			overlaps[k] = o


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Fixes #908 
## Changes
According to https://github.com/prometheus/tsdb/blob/master/db.go#L778 `OverlappingBlocks()` requires a sorted Slice by MinTime.
<!-- Enumerate changes you made -->

## Verification
Verify no longer shows overlapping blocks, that overlap by `0s`. `make test` passes
<!-- How you tested it? How do you know it works? -->