### PR TITLE
store/proxy: set {Min,Max}Time accordingly to the nodes

### DIFF
--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -91,6 +91,12 @@ func (s *ProxyStore) Info(ctx context.Context, r *storepb.InfoRequest) (*storepb
 		}
 	}
 
+	// Edge case: we have all of the data if there are no stores.
+	if len(stores) == 0 {
+		MinTime = 0
+		MaxTime = math.MaxInt64
+	}
+
 	res.MaxTime = MaxTime
 	res.MinTime = MinTime
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -75,9 +75,25 @@ func (s *ProxyStore) Info(ctx context.Context, r *storepb.InfoRequest) (*storepb
 	res := &storepb.InfoResponse{
 		Labels:    make([]storepb.Label, 0, len(s.selectorLabels)),
 		StoreType: s.component.ToProto(),
-		MinTime:   0,
-		MaxTime:   math.MaxInt64,
 	}
+
+	MinTime := int64(math.MaxInt64)
+	MaxTime := int64(0)
+
+	stores := s.stores()
+	for _, s := range stores {
+		mint, maxt := s.TimeRange()
+		if mint < MinTime {
+			MinTime = mint
+		}
+		if maxt > MaxTime {
+			MaxTime = maxt
+		}
+	}
+
+	res.MaxTime = MaxTime
+	res.MinTime = MinTime
+
 	for _, l := range s.selectorLabels {
 		res.Labels = append(res.Labels, storepb.Label{
 			Name:  l.Name,
@@ -393,7 +409,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequ
 		store := st
 		g.Go(func() error {
 			resp, err := store.LabelValues(gctx, &storepb.LabelValuesRequest{
-				Label:                   r.Label,
+				Label: r.Label,
 				PartialResponseDisabled: r.PartialResponseDisabled,
 			})
 			if err != nil {


### PR DESCRIPTION
It doesn't make sense to advertise that a Thanos Query node has data
since the beginning of the time and till the end of time if it only has
nodes which have specific time ranges of data.

Change it accordingly by checking each time range of each node and
setting it to the min/max values.

Calling these functions is fine as the values are cached and `TimeRange()` functions are protected by mutexes.