### PR TITLE
*:Fix version info after change to go mods.

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -6,11 +6,11 @@ build:
           path: ./cmd/thanos
     flags: -a -tags netgo
     ldflags: |
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Revision={{.Revision}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Branch={{.Branch}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
+        -X github.com/prometheus/common/version.Version={{.Version}}
+        -X github.com/prometheus/common/version.Revision={{.Revision}}
+        -X github.com/prometheus/common/version.Branch={{.Branch}}
+        -X github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
+        -X github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
 crossbuild:
     platforms:
         - linux/amd64


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Removed `{{repoPath}}/vendor/` from .promu so that version info correctly populates after transition to go mods.

## Verification

Build info is now correctly populated:
```
thanos, version 0.3.2-master (branch: master, revision: 57a58a75254d60be5fdb74cb63ceff829318117c)
  build user:       jdfalk@mm1
  build date:       20190328-15:08:32
  go version:       go1.12.1
```