### PR TITLE
Makefile: fix mac OS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX            ?= $(shell pwd)
-FILES             ?= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+DIRECTORIES       ?= $(shell find . -path './*' -prune -type d -not -path "./vendor")
 DOCKER_IMAGE_NAME ?= thanos
 DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short HEAD)
 # $GOPATH/bin might not be in $PATH, so we can't assume `which` would give use
@@ -132,7 +132,7 @@ errcheck: $(ERRCHECK)
 .PHONY: format
 format: $(GOIMPORTS)
 	@echo ">> formatting code"
-	@$(GOIMPORTS) -w $(FILES)
+	@$(GOIMPORTS) -w $(DIRECTORIES)
 
 # proto generates golang files from Thanos proto files.
 .PHONY: proto


### PR DESCRIPTION
On one of my mac OS machines the `find . -type f ...` expands to *a lot*
of files, and then all of them are passed as parameters to `goimports`.
Unfortunately, it seems like that hits the default limits of ARG_MAX
i.e. the maximum amount of bytes that can be allocated for the
parameters of a single command line.

Fix this by only passing the directories. `goimports` already descends
to all child directories and checks all of the files. Also, it properly
checks only the Go files as implemented here:
https://github.com/golang/tools/blob/master/cmd/goimports/goimports.go#L64

Verified that no changes are made with this patch by running `make format`.
The part to exclude `./vendor` is kind of moot now since we use Go modules but
I still left it since it seems used in some parts. Also, perhaps someone might want
to run `go mod vendor` and bring it back for some reason e.g. their editor still
doesn't support Go modules :smile: 