### PR TITLE
compact: do not accept chunks in the future by default

### DIFF
--- a/pkg/compact/compact_e2e_test.go
+++ b/pkg/compact/compact_e2e_test.go
@@ -32,7 +32,7 @@ func TestSyncer_SyncMetas_e2e(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 		defer cancel()
 
-		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false, false)
 		testutil.Ok(t, err)
 
 		// Generate 15 blocks. Initially the first 10 are synced into memory and only the last
@@ -134,7 +134,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		}
 
 		// Do one initial synchronization with the bucket.
-		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false)
+		sy, err := NewSyncer(nil, nil, bkt, 0, 1, false, false)
 		testutil.Ok(t, err)
 		testutil.Ok(t, sy.SyncMetas(ctx))
 
@@ -244,6 +244,7 @@ func TestGroup_Compact_e2e(t *testing.T) {
 			bkt,
 			extLset,
 			124,
+			false,
 			false,
 			metrics.compactions.WithLabelValues(""),
 			metrics.compactionFailures.WithLabelValues(""),

--- a/pkg/discovery/dns/provider.go
+++ b/pkg/discovery/dns/provider.go
@@ -29,12 +29,12 @@ func NewProvider(logger log.Logger, reg prometheus.Registerer) *Provider {
 		resolved: make(map[string][]string),
 		logger:   logger,
 		resolverLookupsCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name:      "dns_lookups_total",
-			Help:      "The number of DNS lookups resolutions attempts",
+			Name: "dns_lookups_total",
+			Help: "The number of DNS lookups resolutions attempts",
 		}),
 		resolverFailuresCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name:      "dns_failures_total",
-			Help:      "The number of DNS lookup failures",
+			Name: "dns_failures_total",
+			Help: "The number of DNS lookup failures",
 		}),
 	}
 

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -415,7 +415,7 @@ func (s *ProxyStore) LabelValues(ctx context.Context, r *storepb.LabelValuesRequ
 		store := st
 		g.Go(func() error {
 			resp, err := store.LabelValues(gctx, &storepb.LabelValuesRequest{
-				Label: r.Label,
+				Label:                   r.Label,
 				PartialResponseDisabled: r.PartialResponseDisabled,
 			})
 			if err != nil {

--- a/pkg/verifier/overlapped_blocks.go
+++ b/pkg/verifier/overlapped_blocks.go
@@ -2,6 +2,8 @@ package verifier
 
 import (
 	"context"
+	"sort"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/improbable-eng/thanos/pkg/block"
@@ -10,7 +12,6 @@ import (
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/tsdb"
-	"sort"
 )
 
 const OverlappedBlocksIssueID = "overlapped_blocks"


### PR DESCRIPTION
Create a new flag for compactor `--accept-future-chunks` which is false by default. IMO we should never accept chunks which are purely in the future because compaction is supposed to happen after the fact that they were uploaded. This provides a nice sanity check which you can disable in extreme cases (we could possibly even remove the flag).

I think that this is a good check to have because we need to be extra careful with time here. If Thanos is not running, when only a pure Prometheus is used, the possible time problems are not issues because compaction happens on the same node. However, in my case and possibly others, Thanos Compactor runs on a separate instance and they *might* have a difference in time. This means that users would get confused because the retention policies might not be applied on time like they expect unless they will run `thanos bucket ls` and check the time ranges.

TODO:
* Write tests for this case

Thoughts?
