### PR TITLE
makefile: Excluded tencent doc check.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ docs: $(EMBEDMD) build
 .PHONY: check-docs
 check-docs: $(EMBEDMD) $(LICHE) build
 	@EMBEDMD_BIN="$(EMBEDMD)" scripts/genflagdocs.sh check
-	@$(LICHE) --recursive docs --document-root .
+	@$(LICHE) --recursive docs --exclude "cloud.tencent.com" --document-root .
 
 # errcheck performs static analysis and returns error if any of the errors is not checked.
 .PHONY: errcheck


### PR DESCRIPTION
China firewall does not like our CI check it causes flakes - excluding.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>

