### PR TITLE
Compact: group concurrency 

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -98,6 +98,9 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 	blockSyncConcurrency := cmd.Flag("block-sync-concurrency", "Number of goroutines to use when syncing block metadata from object storage.").
 		Default("20").Int()
 
+	groupCompactConcurrency := cmd.Flag("group-compact-concurrency", "Number of goroutines to use when compacting group.").
+		Default("1").Int()
+
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
 		return runCompact(g, logger, reg,
 			*httpAddr,
@@ -116,6 +119,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 			*disableDownsampling,
 			*maxCompactionLevel,
 			*blockSyncConcurrency,
+			*groupCompactConcurrency,
 		)
 	}
 }
@@ -136,6 +140,7 @@ func runCompact(
 	disableDownsampling bool,
 	maxCompactionLevel int,
 	blockSyncConcurrency int,
+	groupCompactConcurrency int,
 ) error {
 	halted := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "thanos_compactor_halted",
@@ -212,7 +217,7 @@ func runCompact(
 
 	ctx, cancel := context.WithCancel(context.Background())
 	f := func() error {
-		if err := compactor.Compact(ctx); err != nil {
+		if err := compactor.Compact(ctx, groupCompactConcurrency); err != nil {
 			return errors.Wrap(err, "compaction failed")
 		}
 		level.Info(logger).Log("msg", "compaction iterations done")

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -203,7 +203,10 @@ func runCompact(
 		return errors.Wrap(err, "clean working downsample directory")
 	}
 
-	compactor := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt, concurrency)
+	compactor, err := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt, concurrency)
+	if err != nil {
+		return errors.Wrap(err, "create bucket compactor")
+	}
 
 	if retentionByResolution[compact.ResolutionLevelRaw].Seconds() != 0 {
 		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retentionByResolution[compact.ResolutionLevelRaw])

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -98,7 +98,7 @@ func registerCompact(m map[string]setupFunc, app *kingpin.Application, name stri
 	blockSyncConcurrency := cmd.Flag("block-sync-concurrency", "Number of goroutines to use when syncing block metadata from object storage.").
 		Default("20").Int()
 
-	compactionConcurrency := cmd.Flag("compact.concurrency", "Number of goroutines to use when compacting group.").
+	compactionConcurrency := cmd.Flag("compact.concurrency", "Number of goroutines to use when compacting groups.").
 		Default("1").Int()
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -203,7 +203,7 @@ func runCompact(
 		return errors.Wrap(err, "clean working downsample directory")
 	}
 
-	compactor := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt)
+	compactor := compact.NewBucketCompactor(logger, sy, comp, compactDir, bkt, concurrency)
 
 	if retentionByResolution[compact.ResolutionLevelRaw].Seconds() != 0 {
 		level.Info(logger).Log("msg", "retention policy of raw samples is enabled", "duration", retentionByResolution[compact.ResolutionLevelRaw])
@@ -217,7 +217,7 @@ func runCompact(
 
 	ctx, cancel := context.WithCancel(context.Background())
 	f := func() error {
-		if err := compactor.Compact(ctx, concurrency); err != nil {
+		if err := compactor.Compact(ctx); err != nil {
 			return errors.Wrap(err, "compaction failed")
 		}
 		level.Info(logger).Log("msg", "compaction iterations done")

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -70,5 +70,7 @@ Flags:
       --block-sync-concurrency=20
                            Number of goroutines to use when syncing block
                            metadata from object storage.
+      --group-compact-concurrency=1  
+                           Number of goroutines to use when compacting group.
 
 ```

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -71,6 +71,6 @@ Flags:
                                Number of goroutines to use when syncing block
                                metadata from object storage.
       --compact.concurrency=1  Number of goroutines to use when compacting
-                               group.
+                               groups.
 
 ```

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -31,46 +31,46 @@ usage: thanos compact [<flags>]
 continuously compacts blocks in an object store bucket
 
 Flags:
-  -h, --help               Show context-sensitive help (also try --help-long and
-                           --help-man).
-      --version            Show application version.
-      --log.level=info     Log filtering level.
-      --log.format=logfmt  Log format to use.
-      --gcloudtrace.project=GCLOUDTRACE.PROJECT
-                           GCP project to send Google Cloud Trace tracings to.
-                           If empty, tracing will be disabled.
-      --gcloudtrace.sample-factor=1
-                           How often we send traces (1/<sample-factor>). If 0 no
-                           trace will be sent periodically, unless forced by
-                           baggage item. See `pkg/tracing/tracing.go` for
-                           details.
-      --http-address="0.0.0.0:10902"
-                           Listen host:port for HTTP endpoints.
-      --data-dir="./data"  Data directory in which to cache blocks and process
-                           compactions.
-      --objstore.config-file=<bucket.config-yaml-path>
-                           Path to YAML file that contains object store
-                           configuration.
-      --objstore.config=<bucket.config-yaml>
-                           Alternative to 'objstore.config-file' flag. Object
-                           store configuration in YAML.
-      --sync-delay=30m     Minimum age of fresh (non-compacted) blocks before
-                           they are being processed.
-      --retention.resolution-raw=0d
-                           How long to retain raw samples in bucket. 0d -
-                           disables this retention
-      --retention.resolution-5m=0d
-                           How long to retain samples of resolution 1 (5
-                           minutes) in bucket. 0d - disables this retention
-      --retention.resolution-1h=0d
-                           How long to retain samples of resolution 2 (1 hour)
-                           in bucket. 0d - disables this retention
-  -w, --wait               Do not exit after all compactions have been processed
-                           and wait for new work.
-      --block-sync-concurrency=20
-                           Number of goroutines to use when syncing block
-                           metadata from object storage.
-      --group-compact-concurrency=1  
-                           Number of goroutines to use when compacting group.
+  -h, --help                   Show context-sensitive help (also try --help-long
+                               and --help-man).
+      --version                Show application version.
+      --log.level=info         Log filtering level.
+      --log.format=logfmt      Log format to use.
+      --gcloudtrace.project=GCLOUDTRACE.PROJECT  
+                               GCP project to send Google Cloud Trace tracings
+                               to. If empty, tracing will be disabled.
+      --gcloudtrace.sample-factor=1  
+                               How often we send traces (1/<sample-factor>). If
+                               0 no trace will be sent periodically, unless
+                               forced by baggage item. See
+                               `pkg/tracing/tracing.go` for details.
+      --http-address="0.0.0.0:10902"  
+                               Listen host:port for HTTP endpoints.
+      --data-dir="./data"      Data directory in which to cache blocks and
+                               process compactions.
+      --objstore.config-file=<bucket.config-yaml-path>  
+                               Path to YAML file that contains object store
+                               configuration.
+      --objstore.config=<bucket.config-yaml>  
+                               Alternative to 'objstore.config-file' flag.
+                               Object store configuration in YAML.
+      --sync-delay=30m         Minimum age of fresh (non-compacted) blocks
+                               before they are being processed.
+      --retention.resolution-raw=0d  
+                               How long to retain raw samples in bucket. 0d -
+                               disables this retention
+      --retention.resolution-5m=0d  
+                               How long to retain samples of resolution 1 (5
+                               minutes) in bucket. 0d - disables this retention
+      --retention.resolution-1h=0d  
+                               How long to retain samples of resolution 2 (1
+                               hour) in bucket. 0d - disables this retention
+  -w, --wait                   Do not exit after all compactions have been
+                               processed and wait for new work.
+      --block-sync-concurrency=20  
+                               Number of goroutines to use when syncing block
+                               metadata from object storage.
+      --compact.concurrency=1  Number of goroutines to use when compacting
+                               group.
 
 ```

--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -36,38 +36,38 @@ Flags:
       --version                Show application version.
       --log.level=info         Log filtering level.
       --log.format=logfmt      Log format to use.
-      --gcloudtrace.project=GCLOUDTRACE.PROJECT  
+      --gcloudtrace.project=GCLOUDTRACE.PROJECT
                                GCP project to send Google Cloud Trace tracings
                                to. If empty, tracing will be disabled.
-      --gcloudtrace.sample-factor=1  
+      --gcloudtrace.sample-factor=1
                                How often we send traces (1/<sample-factor>). If
                                0 no trace will be sent periodically, unless
                                forced by baggage item. See
                                `pkg/tracing/tracing.go` for details.
-      --http-address="0.0.0.0:10902"  
+      --http-address="0.0.0.0:10902"
                                Listen host:port for HTTP endpoints.
       --data-dir="./data"      Data directory in which to cache blocks and
                                process compactions.
-      --objstore.config-file=<bucket.config-yaml-path>  
+      --objstore.config-file=<bucket.config-yaml-path>
                                Path to YAML file that contains object store
                                configuration.
-      --objstore.config=<bucket.config-yaml>  
+      --objstore.config=<bucket.config-yaml>
                                Alternative to 'objstore.config-file' flag.
                                Object store configuration in YAML.
       --sync-delay=30m         Minimum age of fresh (non-compacted) blocks
                                before they are being processed.
-      --retention.resolution-raw=0d  
+      --retention.resolution-raw=0d
                                How long to retain raw samples in bucket. 0d -
                                disables this retention
-      --retention.resolution-5m=0d  
+      --retention.resolution-5m=0d
                                How long to retain samples of resolution 1 (5
                                minutes) in bucket. 0d - disables this retention
-      --retention.resolution-1h=0d  
+      --retention.resolution-1h=0d
                                How long to retain samples of resolution 2 (1
                                hour) in bucket. 0d - disables this retention
   -w, --wait                   Do not exit after all compactions have been
                                processed and wait for new work.
-      --block-sync-concurrency=20  
+      --block-sync-concurrency=20
                                Number of goroutines to use when syncing block
                                metadata from object storage.
       --compact.concurrency=1  Number of goroutines to use when compacting

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -23,7 +23,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/tsdb"
 	"github.com/prometheus/tsdb/labels"
-
 	"golang.org/x/sync/errgroup"
 )
 

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -890,6 +890,10 @@ type BucketCompactor struct {
 
 // NewBucketCompactor creates a new bucket compactor.
 func NewBucketCompactor(logger log.Logger, sy *Syncer, comp tsdb.Compactor, compactDir string, bkt objstore.Bucket, concurrency int) *BucketCompactor {
+	if concurrency <= 0 {
+		level.Warn(logger).Log("msg", fmt.Sprintf("provided concurrency(%d) is not valid, using the default value (1)", concurrency))
+		concurrency = 1
+	}
 	return &BucketCompactor{
 		logger:      logger,
 		sy:          sy,

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -915,7 +915,6 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 		for i := 0; i < c.concurrency; i++ {
 			errGroup.Go(func() error {
 				for g := range groupChan {
-					level.Info(c.logger).Log("msg", "worker doing some work")
 					shouldRerunGroup, _, err := g.Compact(errGroupCtx, c.compactDir, c.comp)
 					if err == nil {
 						if shouldRerunGroup {

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -890,7 +890,7 @@ type BucketCompactor struct {
 // NewBucketCompactor creates a new bucket compactor.
 func NewBucketCompactor(logger log.Logger, sy *Syncer, comp tsdb.Compactor, compactDir string, bkt objstore.Bucket, concurrency int) (*BucketCompactor, error) {
 	if concurrency <= 0 {
-		return nil, errors.New("invalid concurrency level (%d), concurrency level must be >= 0")
+		return nil, errors.New("invalid concurrency level (%d), concurrency level must be > 0")
 	}
 	return &BucketCompactor{
 		logger:      logger,

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -897,7 +897,7 @@ func NewBucketCompactor(logger log.Logger, sy *Syncer, comp tsdb.Compactor, comp
 }
 
 // Compact runs compaction over bucket.
-func (c *BucketCompactor) Compact(ctx context.Context) error {
+func (c *BucketCompactor) Compact(ctx context.Context, groupCompactConcurrency int) error {
 	// Loop over bucket and compact until there's no work left.
 	for {
 		// Clean up the compaction temporary directory at the beginning of every compaction loop.
@@ -926,10 +926,18 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 		finishedAllGroups := true
 		var wg sync.WaitGroup
 		errChan := make(chan error, len(groups))
+		groupChan := make(chan struct{}, groupCompactConcurrency)
+		defer close(groupChan)
+		for i := 0; i < groupCompactConcurrency; i++ {
+			groupChan <- struct{}{}
+		}
 		for _, g := range groups {
-			wg.Add(1)
+			<-groupChan
 			go func(g *Group) {
-				defer wg.Done()
+				defer func() {
+					wg.Done()
+					groupChan <- struct{}{}
+				}()
 				shouldRerunGroup, _, err := g.Compact(ctx, c.compactDir, c.comp)
 				if err == nil {
 					if shouldRerunGroup {

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -908,7 +908,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 		var (
 			errGroup, errGroupCtx = errgroup.WithContext(ctx)
 			groupChan             = make(chan *Group)
-			finishedAllGroups     bool
+			finishedAllGroups     = true
 			mtx                   sync.Mutex
 		)
 
@@ -964,8 +964,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 			return errors.Wrap(err, "build compaction groups")
 		}
 
-		// Send all groups found during this pass to the compaction workers, the workers will update finishedAllGroups.
-		finishedAllGroups = true
+		// Send all groups found during this pass to the compaction workers.
 		for _, g := range groups {
 			select {
 			case <-errGroupCtx.Done():

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -933,6 +933,7 @@ func (c *BucketCompactor) Compact(ctx context.Context, groupCompactConcurrency i
 		}
 		for _, g := range groups {
 			<-groupChan
+			wg.Add(1)
 			go func(g *Group) {
 				defer func() {
 					wg.Done()

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -924,22 +924,33 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 			return errors.Wrap(err, "build compaction groups")
 		}
 		finishedAllGroups := true
+		var wg sync.WaitGroup
+		errChan := make(chan error, len(groups))
 		for _, g := range groups {
-			shouldRerunGroup, _, err := g.Compact(ctx, c.compactDir, c.comp)
-			if err == nil {
-				if shouldRerunGroup {
-					finishedAllGroups = false
+			wg.Add(1)
+			go func(g *Group) {
+				defer wg.Done()
+				shouldRerunGroup, _, err := g.Compact(ctx, c.compactDir, c.comp)
+				if err == nil {
+					if shouldRerunGroup {
+						finishedAllGroups = false
+					}
+					return
 				}
-				continue
-			}
 
-			if IsIssue347Error(err) {
-				if err := RepairIssue347(ctx, c.logger, c.bkt, err); err == nil {
-					finishedAllGroups = false
-					continue
+				if IsIssue347Error(err) {
+					if err := RepairIssue347(ctx, c.logger, c.bkt, err); err == nil {
+						finishedAllGroups = false
+						return
+					}
 				}
-			}
-			return errors.Wrap(err, "compaction")
+				errChan <- errors.Wrap(err, "compaction")
+			}(g)
+		}
+		wg.Wait()
+		close(errChan)
+		if err := <-errChan; err != nil {
+			return err
 		}
 		if finishedAllGroups {
 			break

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -889,10 +889,9 @@ type BucketCompactor struct {
 }
 
 // NewBucketCompactor creates a new bucket compactor.
-func NewBucketCompactor(logger log.Logger, sy *Syncer, comp tsdb.Compactor, compactDir string, bkt objstore.Bucket, concurrency int) *BucketCompactor {
+func NewBucketCompactor(logger log.Logger, sy *Syncer, comp tsdb.Compactor, compactDir string, bkt objstore.Bucket, concurrency int) (*BucketCompactor, error) {
 	if concurrency <= 0 {
-		level.Warn(logger).Log("msg", fmt.Sprintf("provided concurrency(%d) is not valid, using the default value (1)", concurrency))
-		concurrency = 1
+		return nil, errors.New("invalid concurrency level (%d), concurrency level must be >= 0")
 	}
 	return &BucketCompactor{
 		logger:      logger,
@@ -901,7 +900,7 @@ func NewBucketCompactor(logger log.Logger, sy *Syncer, comp tsdb.Compactor, comp
 		compactDir:  compactDir,
 		bkt:         bkt,
 		concurrency: concurrency,
-	}
+	}, nil
 }
 
 // Compact runs compaction over bucket.

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -967,7 +967,8 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 		finishedAllGroups = true
 		for _, g := range groups {
 			select {
-			case <-ctx.Done():
+			case <-errGroupCtx.Done():
+				break
 			case groupChan <- g:
 			}
 		}

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -908,7 +908,6 @@ func NewBucketCompactor(logger log.Logger, sy *Syncer, comp tsdb.Compactor, comp
 func (c *BucketCompactor) Compact(ctx context.Context) error {
 	// Loop over bucket and compact until there's no work left.
 	for {
-		// Set up workers who will compact the groups when the groups are ready.
 		var (
 			errGroup, errGroupCtx = errgroup.WithContext(ctx)
 			groupChan             = make(chan *Group)
@@ -916,6 +915,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 			mtx                   sync.Mutex
 		)
 
+		// Set up workers who will compact the groups when the groups are ready.
 		for i := 0; i < c.concurrency; i++ {
 			errGroup.Go(func() error {
 				for g := range groupChan {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

This adds an concurrency parameter to the compact command which controls how many groups are compacted in parallel.

Builds on https://github.com/improbable-eng/thanos/pull/898

## Verification

<!-- How you tested it? How do you know it works? -->

Ran the compactor against a test bucket.