### PR TITLE
query: set default evaluation interval

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -97,6 +97,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 	enablePartialResponse := cmd.Flag("query.partial-response", "Enable partial response for queries if no partial_response param is specified.").
 		Default("true").Bool()
 
+	defaultEvaluationInterval := modelDuration(cmd.Flag("query.default-evaluation-interval", "Set default evaluation interval for sub queries.").Default("1m"))
+
 	storeResponseTimeout := modelDuration(cmd.Flag("store.response-timeout", "If a Store doesn't send any data in this specified duration then a Store will be ignored and partial data will be returned if it's enabled. 0 disables timeout.").Default("0ms"))
 
 	m[name] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, tracer opentracing.Tracer, _ bool) error {
@@ -126,6 +128,8 @@ func registerQuery(m map[string]setupFunc, app *kingpin.Application, name string
 			}
 			fileSD = file.NewDiscovery(conf, logger)
 		}
+
+		promql.SetDefaultEvaluationInterval(time.Duration(*defaultEvaluationInterval))
 
 		return runQuery(
 			g,

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -301,6 +301,9 @@ Flags:
                                  if no max_source_resolution param is specified.
       --query.partial-response   Enable partial response for queries if no
                                  partial_response param is specified.
+      --query.default-evaluation-interval=1m
+                                 Set default evaluation interval for sub
+                                 queries.
       --store.response-timeout=0ms
                                  If a Store doesn't send any data in this
                                  specified duration then a Store will be ignored


### PR DESCRIPTION
Subqueries allows request with no [specified resolution](https://prometheus.io/blog/2019/01/28/subquery-support/).
Set it up and allow to configure default evaluation interval.

Fixes https://github.com/improbable-eng/thanos/issues/1023