### PR TITLE
compact:  group concurrency improvements

### DIFF
--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -932,8 +932,8 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 		// Set up workers who will compact the groups when the groups are ready.
 		// They will compact available groups until they encounter an error, after which they will stop.
 		for i := 0; i < c.concurrency; i++ {
+			wg.Add(1)
 			go func() {
-				wg.Add(1)
 				defer wg.Done()
 				for g := range groupChan {
 					shouldRerunGroup, _, err := g.Compact(workCtx, c.compactDir, c.comp)

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -989,9 +989,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 		for _, g := range groups {
 			select {
 			case err = <-errChan:
-				if err != nil {
-					break groupLoop
-				}
+				break groupLoop
 			case groupChan <- g:
 			}
 		}


### PR DESCRIPTION
Follow on from https://github.com/improbable-eng/thanos/pull/1010

https://github.com/improbable-eng/thanos/pull/1010 added group-level concurrency to compaction.  It used an `errGroup` to manage the concurrency, which errors out all the concurrent tasks as soon as one fails, which can mean wasted resources and partial uploads.

This PR changes the behaviour so that once an error is encountered, we wait before all the active goroutines finish before erroring out the compaction.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->