### PR TITLE
storage docs: add detail about GCS policies and testing

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -208,13 +208,27 @@ config:
 
 ### GCS Policies
 
+__Note:__ GCS Policies should be applied at the project level, not at the bucket level
+
 For deployment:
 
-`Storage Object Creator` and ` Storage Object Viewer`
+`Storage Object Creator` and `Storage Object Viewer`
 
 For testing:
 
 `Storage Object Admin` for ability to create and delete temporary buckets.
+
+To test the policy is working as expected, exec into the sidecar container, eg:
+
+```sh
+kubectl exec -it -n monitoring prometheus-prometheus-operator-prometheus-0 -c thanos-sidecar -- /bin/sh
+```
+
+Then test that you can at least list objects in the bucket, eg:
+
+```sh
+thanos bucket ls --objstore.config="${OBJSTORE_CONFIG}"
+```
 
 ## Azure Configuration
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -221,7 +221,7 @@ For testing:
 To test the policy is working as expected, exec into the sidecar container, eg:
 
 ```sh
-kubectl exec -it -n monitoring prometheus-prometheus-operator-prometheus-0 -c thanos-sidecar -- /bin/sh
+kubectl exec -it -n <namespace> <prometheus with sidecar pod name> -c <sidecar container name> -- /bin/sh
 ```
 
 Then test that you can at least list objects in the bucket, eg:


### PR DESCRIPTION


## Changes

After struggling to get permissions correct with Thanos sidecar + GCS storage, this PR updates the storage docs to reflect that GCS permissions should be set on the project level, not the bucket level. It also details some steps to troubleshoot the GCS policies.

## Verification

Checked that the Markdown looks clean and meaningful