### PR TITLE
Disabled gossip by default.

### DIFF
--- a/cmd/thanos/flags.go
+++ b/cmd/thanos/flags.go
@@ -46,36 +46,36 @@ func regCommonServerFlags(cmd *kingpin.CmdClause) (
 
 	httpBindAddr = regHTTPAddrFlag(cmd)
 	grpcBindAddr, grpcTLSSrvCert, grpcTLSSrvKey, grpcTLSSrvClientCA = regGRPCFlags(cmd)
-	grpcAdvertiseAddr := cmd.Flag("grpc-advertise-address", "Explicit (external) host:port address to advertise for gRPC StoreAPI in gossip cluster. If empty, 'grpc-address' will be used.").
+	grpcAdvertiseAddr := cmd.Flag("grpc-advertise-address", "Deprecated(gossip will be removed from v0.5.0): Explicit (external) host:port address to advertise for gRPC StoreAPI in gossip cluster. If empty, 'grpc-address' will be used.").
 		String()
 
-	clusterBindAddr := cmd.Flag("cluster.address", "Listen ip:port address for gossip cluster.").
+	clusterBindAddr := cmd.Flag("cluster.address", "Deprecated(gossip will be removed from v0.5.0): Listen ip:port address for gossip cluster.").
 		Default("0.0.0.0:10900").String()
 
-	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "Explicit (external) ip:port address to advertise for gossip in gossip cluster. Used internally for membership only.").
+	clusterAdvertiseAddr := cmd.Flag("cluster.advertise-address", "Deprecated(gossip will be removed from v0.5.0): Explicit (external) ip:port address to advertise for gossip in gossip cluster. Used internally for membership only.").
 		String()
 
-	peers := cmd.Flag("cluster.peers", "Initial peers to join the cluster. It can be either <ip:port>, or <domain:port>. A lookup resolution is done only at the startup.").Strings()
+	peers := cmd.Flag("cluster.peers", "Deprecated(gossip will be removed from v0.5.0): Initial peers to join the cluster. It can be either <ip:port>, or <domain:port>. A lookup resolution is done only at the startup.").Strings()
 
-	gossipInterval := modelDuration(cmd.Flag("cluster.gossip-interval", "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth. Default is used from a specified network-type.").
+	gossipInterval := modelDuration(cmd.Flag("cluster.gossip-interval", "Deprecated(gossip will be removed from v0.5.0): Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth. Default is used from a specified network-type.").
 		PlaceHolder("<gossip interval>"))
 
-	pushPullInterval := modelDuration(cmd.Flag("cluster.pushpull-interval", "Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage. Default is used from a specified network-type.").
+	pushPullInterval := modelDuration(cmd.Flag("cluster.pushpull-interval", "Deprecated(gossip will be removed from v0.5.0): Interval for gossip state syncs. Setting this interval lower (more frequent) will increase convergence speeds across larger clusters at the expense of increased bandwidth usage. Default is used from a specified network-type.").
 		PlaceHolder("<push-pull interval>"))
 
-	refreshInterval := modelDuration(cmd.Flag("cluster.refresh-interval", "Interval for membership to refresh cluster.peers state, 0 disables refresh.").Default(cluster.DefaultRefreshInterval.String()))
+	refreshInterval := modelDuration(cmd.Flag("cluster.refresh-interval", "Deprecated(gossip will be removed from v0.5.0): Interval for membership to refresh cluster.peers state, 0 disables refresh.").Default(cluster.DefaultRefreshInterval.String()))
 
-	secretKey := cmd.Flag("cluster.secret-key", "Initial secret key to encrypt cluster gossip. Can be one of AES-128, AES-192, or AES-256 in hexadecimal format.").HexBytes()
+	secretKey := cmd.Flag("cluster.secret-key", "Deprecated(gossip will be removed from v0.5.0): Initial secret key to encrypt cluster gossip. Can be one of AES-128, AES-192, or AES-256 in hexadecimal format.").HexBytes()
 
 	networkType := cmd.Flag("cluster.network-type",
-		fmt.Sprintf("Network type with predefined peers configurations. Sets of configurations accounting the latency differences between network types: %s.",
+		fmt.Sprintf("Deprecated(gossip will be removed from v0.5.0): Network type with predefined peers configurations. Sets of configurations accounting the latency differences between network types: %s.",
 			strings.Join(cluster.NetworkPeerTypes, ", "),
 		),
 	).
 		Default(cluster.LanNetworkPeerType).
 		Enum(cluster.NetworkPeerTypes...)
 
-	gossipDisabled := cmd.Flag("cluster.disable", "If true gossip will be disabled and no cluster related server will be started.").Default("false").Bool()
+	gossipDisabled := cmd.Flag("cluster.disable", "Deprecated(gossip will be removed from v0.5.0): If true gossip will be disabled and no cluster related server will be started.").Default("true").Bool()
 
 	return grpcBindAddr,
 		httpBindAddr,

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -233,7 +233,7 @@ func runRule(
 			Name: "thanos_rule_loaded_rules",
 			Help: "Loaded rules partitioned by file and group",
 		},
-		[]string{"part_resp_strategy", "file", "group"},
+		[]string{"strategy", "file", "group"},
 	)
 	ruleEvalWarnings := prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -199,44 +199,54 @@ Flags:
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-advertise-address=GRPC-ADVERTISE-ADDRESS
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Explicit (external) host:port address to
                                  advertise for gRPC StoreAPI in gossip cluster.
                                  If empty, 'grpc-address' will be used.
       --cluster.address="0.0.0.0:10900"
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Listen ip:port address for gossip cluster.
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Explicit (external) ip:port address to
                                  advertise for gossip in gossip cluster. Used
                                  internally for membership only.
       --cluster.peers=CLUSTER.PEERS ...
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Initial peers to join the cluster. It can be
                                  either <ip:port>, or <domain:port>. A lookup
                                  resolution is done only at the startup.
       --cluster.gossip-interval=<gossip interval>
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval between sending gossip messages. By
                                  lowering this value (more frequent) gossip
                                  messages are propagated across the cluster more
                                  quickly at the expense of increased bandwidth.
                                  Default is used from a specified network-type.
       --cluster.pushpull-interval=<push-pull interval>
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval for gossip state syncs. Setting this
                                  interval lower (more frequent) will increase
                                  convergence speeds across larger clusters at
                                  the expense of increased bandwidth usage.
                                  Default is used from a specified network-type.
       --cluster.refresh-interval=1m
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval for membership to refresh
                                  cluster.peers state, 0 disables refresh.
       --cluster.secret-key=CLUSTER.SECRET-KEY
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Initial secret key to encrypt cluster gossip.
                                  Can be one of AES-128, AES-192, or AES-256 in
                                  hexadecimal format.
       --cluster.network-type=lan
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Network type with predefined peers
                                  configurations. Sets of configurations
                                  accounting the latency differences between
                                  network types: local, lan, wan.
-      --cluster.disable          If true gossip will be disabled and no cluster
+      --cluster.disable          Deprecated(gossip will be removed from v0.5.0):
+                                 If true gossip will be disabled and no cluster
                                  related server will be started.
       --http-advertise-address=HTTP-ADVERTISE-ADDRESS
                                  Explicit (external) host:port address to

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -181,44 +181,54 @@ Flags:
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-advertise-address=GRPC-ADVERTISE-ADDRESS
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Explicit (external) host:port address to
                                  advertise for gRPC StoreAPI in gossip cluster.
                                  If empty, 'grpc-address' will be used.
       --cluster.address="0.0.0.0:10900"
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Listen ip:port address for gossip cluster.
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Explicit (external) ip:port address to
                                  advertise for gossip in gossip cluster. Used
                                  internally for membership only.
       --cluster.peers=CLUSTER.PEERS ...
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Initial peers to join the cluster. It can be
                                  either <ip:port>, or <domain:port>. A lookup
                                  resolution is done only at the startup.
       --cluster.gossip-interval=<gossip interval>
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval between sending gossip messages. By
                                  lowering this value (more frequent) gossip
                                  messages are propagated across the cluster more
                                  quickly at the expense of increased bandwidth.
                                  Default is used from a specified network-type.
       --cluster.pushpull-interval=<push-pull interval>
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval for gossip state syncs. Setting this
                                  interval lower (more frequent) will increase
                                  convergence speeds across larger clusters at
                                  the expense of increased bandwidth usage.
                                  Default is used from a specified network-type.
       --cluster.refresh-interval=1m
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval for membership to refresh
                                  cluster.peers state, 0 disables refresh.
       --cluster.secret-key=CLUSTER.SECRET-KEY
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Initial secret key to encrypt cluster gossip.
                                  Can be one of AES-128, AES-192, or AES-256 in
                                  hexadecimal format.
       --cluster.network-type=lan
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Network type with predefined peers
                                  configurations. Sets of configurations
                                  accounting the latency differences between
                                  network types: local, lan, wan.
-      --cluster.disable          If true gossip will be disabled and no cluster
+      --cluster.disable          Deprecated(gossip will be removed from v0.5.0):
+                                 If true gossip will be disabled and no cluster
                                  related server will be started.
       --label=<name>="<value>" ...
                                  Labels to be applied to all generated metrics

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -82,44 +82,54 @@ Flags:
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-advertise-address=GRPC-ADVERTISE-ADDRESS
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Explicit (external) host:port address to
                                  advertise for gRPC StoreAPI in gossip cluster.
                                  If empty, 'grpc-address' will be used.
       --cluster.address="0.0.0.0:10900"
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Listen ip:port address for gossip cluster.
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Explicit (external) ip:port address to
                                  advertise for gossip in gossip cluster. Used
                                  internally for membership only.
       --cluster.peers=CLUSTER.PEERS ...
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Initial peers to join the cluster. It can be
                                  either <ip:port>, or <domain:port>. A lookup
                                  resolution is done only at the startup.
       --cluster.gossip-interval=<gossip interval>
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval between sending gossip messages. By
                                  lowering this value (more frequent) gossip
                                  messages are propagated across the cluster more
                                  quickly at the expense of increased bandwidth.
                                  Default is used from a specified network-type.
       --cluster.pushpull-interval=<push-pull interval>
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval for gossip state syncs. Setting this
                                  interval lower (more frequent) will increase
                                  convergence speeds across larger clusters at
                                  the expense of increased bandwidth usage.
                                  Default is used from a specified network-type.
       --cluster.refresh-interval=1m
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval for membership to refresh
                                  cluster.peers state, 0 disables refresh.
       --cluster.secret-key=CLUSTER.SECRET-KEY
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Initial secret key to encrypt cluster gossip.
                                  Can be one of AES-128, AES-192, or AES-256 in
                                  hexadecimal format.
       --cluster.network-type=lan
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Network type with predefined peers
                                  configurations. Sets of configurations
                                  accounting the latency differences between
                                  network types: local, lan, wan.
-      --cluster.disable          If true gossip will be disabled and no cluster
+      --cluster.disable          Deprecated(gossip will be removed from v0.5.0):
+                                 If true gossip will be disabled and no cluster
                                  related server will be started.
       --prometheus.url=http://localhost:9090
                                  URL at which to reach Prometheus's API. For

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -67,44 +67,54 @@ Flags:
                                  CA is specified, there is no client
                                  verification on server side. (tls.NoClientCert)
       --grpc-advertise-address=GRPC-ADVERTISE-ADDRESS
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Explicit (external) host:port address to
                                  advertise for gRPC StoreAPI in gossip cluster.
                                  If empty, 'grpc-address' will be used.
       --cluster.address="0.0.0.0:10900"
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Listen ip:port address for gossip cluster.
       --cluster.advertise-address=CLUSTER.ADVERTISE-ADDRESS
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Explicit (external) ip:port address to
                                  advertise for gossip in gossip cluster. Used
                                  internally for membership only.
       --cluster.peers=CLUSTER.PEERS ...
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Initial peers to join the cluster. It can be
                                  either <ip:port>, or <domain:port>. A lookup
                                  resolution is done only at the startup.
       --cluster.gossip-interval=<gossip interval>
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval between sending gossip messages. By
                                  lowering this value (more frequent) gossip
                                  messages are propagated across the cluster more
                                  quickly at the expense of increased bandwidth.
                                  Default is used from a specified network-type.
       --cluster.pushpull-interval=<push-pull interval>
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval for gossip state syncs. Setting this
                                  interval lower (more frequent) will increase
                                  convergence speeds across larger clusters at
                                  the expense of increased bandwidth usage.
                                  Default is used from a specified network-type.
       --cluster.refresh-interval=1m
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Interval for membership to refresh
                                  cluster.peers state, 0 disables refresh.
       --cluster.secret-key=CLUSTER.SECRET-KEY
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Initial secret key to encrypt cluster gossip.
                                  Can be one of AES-128, AES-192, or AES-256 in
                                  hexadecimal format.
       --cluster.network-type=lan
+                                 Deprecated(gossip will be removed from v0.5.0):
                                  Network type with predefined peers
                                  configurations. Sets of configurations
                                  accounting the latency differences between
                                  network types: local, lan, wan.
-      --cluster.disable          If true gossip will be disabled and no cluster
+      --cluster.disable          Deprecated(gossip will be removed from v0.5.0):
+                                 If true gossip will be disabled and no cluster
                                  related server will be started.
       --data-dir="./data"        Data directory in which to cache remote blocks.
       --index-cache-size=250MB   Maximum size of items held in the index cache.


### PR DESCRIPTION
Since 0.4.0 is last release with gossip available, let's disable it so people will be aware of this.

+ changed small label inconsistency.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>
