### PR TITLE
objstore: Expose S3 region attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+### Added
+
+- [#1060](https://github.com/improbable-eng/thanos/pull/1060) Allow specifying region attribute in S3 storage configuration
 
 ### Fixed
 
 - [#1070](https://github.com/improbable-eng/thanos/pull/1070) Downsampling works back again. Deferred closer errors are now properly captured.
-
 
 ## [v0.4.0-rc.0](https://github.com/improbable-eng/thanos/releases/tag/v0.4.0-rc.0) - 2019.04.18
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -49,6 +49,7 @@ type: S3
 config:
   bucket: ""
   endpoint: ""
+  region: ""
   access_key: ""
   insecure: false
   signature_version2: false
@@ -62,7 +63,7 @@ config:
     enable: false
 ```
 
-AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+The attribute `region` is optional. AWS region to endpoint mapping can be found in this [link](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
 
 Make sure you use a correct signature version.
 Currently AWS require signature v4, so it needs `signature-version2: false`, otherwise, you will get Access Denied error, but several other S3 compatible use `signature-version2: true`

--- a/pkg/objstore/s3/s3.go
+++ b/pkg/objstore/s3/s3.go
@@ -37,6 +37,7 @@ const DirDelim = "/"
 type Config struct {
 	Bucket          string            `yaml:"bucket"`
 	Endpoint        string            `yaml:"endpoint"`
+	Region        	string            `yaml:"region"`
 	AccessKey       string            `yaml:"access_key"`
 	Insecure        bool              `yaml:"insecure"`
 	SignatureV2     bool              `yaml:"signature_version2"`
@@ -122,7 +123,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		}
 	}
 
-	client, err := minio.NewWithCredentials(config.Endpoint, credentials.NewChainCredentials(chain), !config.Insecure, "")
+	client, err := minio.NewWithCredentials(config.Endpoint, credentials.NewChainCredentials(chain), !config.Insecure, config.Region)
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize s3 client")
 	}


### PR DESCRIPTION
Minio is able to autodetect the region for cloud providers like AWS but the logic fails with Scaleway Object Storage solution.

Related issue on Minio: https://github.com/minio/mc/issues/2570

Independently of this issue, I think it's preferable for users to have the possibility to define the region explicitly rather than depends on code that is hard to test with all S3-compatible tools (e.g., https://github.com/minio/minio-go/blob/93e12e097cf3aec86c28ceeb7a960a29b2302a3a/pkg/s3utils/utils.go#L99)

## Changes

Expose an optional `region` attribute in bucket configuration file. The change is backward compatible. When the region is not defined, the code still depends on Minio client to deduce the region.  

## Verification

Manually tested after having created a bucket on Scaleway Object Storage (https://www.scaleway.com/en/object-storage/). Thanos sidecar was correctly pushing blocks into the bucket and Thanos Store Gateway was correctly retrieving the metrics from it.