### PR TITLE
Test that metadata is written and readable after downsampling #1065

### DIFF
--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -177,6 +177,9 @@ func testDownsample(t *testing.T, data []*downsampleTestSet, meta *metadata.Meta
 	testutil.Ok(t, err)
 	defer func() { testutil.Ok(t, chunkr.Close()) }()
 
+	_, err = metadata.Read(filepath.Join(dir, id.String()))
+	testutil.Ok(t, err)
+
 	pall, err := indexr.Postings(index.AllPostingsKey())
 	testutil.Ok(t, err)
 


### PR DESCRIPTION
Additional check to downsample test, checking that meta.json file is readable in a new block directory

## Changes

Trying to read meta.json file after downsample complete

## Verification

This test will fail until issue #1065 is fixed