### PR TITLE
Fixed fetching go-bindata failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Fixed
 
 - [#1070](https://github.com/improbable-eng/thanos/pull/1070) Downsampling works back again. Deferred closer errors are now properly captured.
-- [#1074](https://github.com/improbable-eng/thanos/pull/1074) Fixed fetching go-bindata failed.
 
 ## [v0.4.0-rc.0](https://github.com/improbable-eng/thanos/releases/tag/v0.4.0-rc.0) - 2019.04.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Fixed
 
 - [#1070](https://github.com/improbable-eng/thanos/pull/1070) Downsampling works back again. Deferred closer errors are now properly captured.
+- [#1074](https://github.com/improbable-eng/thanos/pull/1074) Fixed fetching go-bindata failed.
 
 ## [v0.4.0-rc.0](https://github.com/improbable-eng/thanos/releases/tag/v0.4.0-rc.0) - 2019.04.18
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ PROTOC_VERSION    ?= 3.4.0
 # v0.54.0
 HUGO_VERSION      ?= b1a82c61aba067952fdae2f73b826fe7d0f3fc2f
 HUGO              ?= $(GOBIN)/hugo-$(HUGO_VERSION)
+# v3.1.1
+GOBINDATA_VERSION ?= a9c83481b38ebb1c4eb8f0168fd4b10ca1d3c523
+GOBINDATA         ?= $(GOBIN)/go-bindata-$(GOBINDATA_VERSION)
 GIT               ?= $(shell which git)
 BZR               ?= $(shell which bzr)
 
@@ -90,12 +93,11 @@ all: format build
 
 # assets repacks all statis assets into go file for easier deploy.
 .PHONY: assets
-assets:
+assets: $(GOBINDATA)
 	@echo ">> deleting asset file"
 	@rm pkg/ui/bindata.go || true
 	@echo ">> writing assets"
-	@go get -u github.com/jteeuwen/go-bindata/...
-	@go-bindata $(bindata_flags) -pkg ui -o pkg/ui/bindata.go -ignore '(.*\.map|bootstrap\.js|bootstrap-theme\.css|bootstrap\.css)'  pkg/ui/templates/... pkg/ui/static/...
+	@$(GOBINDATA) $(bindata_flags) -pkg ui -o pkg/ui/bindata.go -ignore '(.*\.map|bootstrap\.js|bootstrap-theme\.css|bootstrap\.css)'  pkg/ui/templates/... pkg/ui/static/...
 	@go fmt ./pkg/ui
 
 
@@ -277,6 +279,9 @@ $(PROMU):
 
 $(HUGO):
 	$(call fetch_go_bin_version,github.com/gohugoio/hugo,$(HUGO_VERSION))
+
+$(GOBINDATA):
+	$(call fetch_go_bin_version,github.com/go-bindata/go-bindata/go-bindata,$(GOBINDATA_VERSION))
 
 $(PROTOC):
 	@mkdir -p $(TMP_GOPATH)


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->
Fixed bug:
- fetching go-bindata failed.
- change the repo of go-bindata to github.com/go-bindata/go-bindata,
because old repo has been archived.
- pin the `go-bindata` as v3.3.1.

When I run `make assets` in golang container, it would be failed with follow message:
```console
# make assets
>> deleting asset file
>> writing assets
go: finding github.com/jteeuwen/go-bindata/... latest
go get github.com/jteeuwen/go-bindata/...: no matching versions for query "latest"
Makefile:94: recipe for target 'assets' failed
make: *** [assets] Error 1
```

On the other hand, the `github.com/jteeuwen/go-bindata` had been archived, use `github.com/go-bindata/go-bindata` now.

## Verification
Run `make assets`.

<!-- How you tested it? How do you know it works? -->