### PR TITLE
feat: added thanos check rules command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This version moved tarballs to Golang 1.12.5 from 1.11 as well, so same warning 
 ### Added
 
 - [#1094](https://github.com/improbable-eng/thanos/pull/1094) Allow configuring the response header timeout for the S3 client.
+- [#1097](https://github.com/improbable-eng/thanos/pull/1097) Added `thanos check rules` linter for Thanos rule rules files.
+
 
 ### Changed
 
@@ -105,28 +107,28 @@ Using cadvisor `container_memory_usage_bytes` metric could be misleading e.g: ht
 New options:
 
   New Store flags:
-  
+
     * `--store.grpc.series-sample-limit` limits the amount of samples that might be retrieved on a single Series() call. By default it is 0. Consider enabling it by setting it to more than 0 if you are running on limited resources.
     * `--store.grpc.series-max-concurrency` limits the number of concurrent Series() calls in Thanos Store. By default it is 20. Considering making it lower or bigger depending on the scale of your deployment.
 
   New Store metrics:
-  
+
     * `thanos_bucket_store_queries_dropped_total` shows how many queries were dropped due to the samples limit;
     * `thanos_bucket_store_queries_concurrent_max` is a constant metric which shows how many Series() calls can concurrently be executed by Thanos Store;
     * `thanos_bucket_store_queries_in_flight` shows how many queries are currently "in flight" i.e. they are being executed;
     * `thanos_bucket_store_gate_duration_seconds` shows how many seconds it took for queries to pass through the gate in both cases - when that fails and when it does not.
-    
+
   New Store tracing span:
     * `store_query_gate_ismyturn` shows how long it took for a query to pass (or not) through the gate.
-    
-- [#1016](https://github.com/improbable-eng/thanos/pull/1016) Added option for another DNS resolver (miekg/dns client). 
+
+- [#1016](https://github.com/improbable-eng/thanos/pull/1016) Added option for another DNS resolver (miekg/dns client).
 Note that this is required to have SRV resolution working on [Golang 1.11+ with KubeDNS below v1.14](https://github.com/golang/go/issues/27546)
 
    New Querier and Ruler flag: `-- store.sd-dns-resolver` which allows to specify resolver to use. Either `golang` or `miekgdns`
-   
+
 - [#986](https://github.com/improbable-eng/thanos/pull/986) Allow to save some startup & sync time in store gateway as it is no longer needed to compute index-cache from block index on its own for larger blocks.
-  The store Gateway still can do it, but it first checks bucket if there is index-cached uploaded already. 
-  In the same time, compactor precomputes the index cache file on every compaction. 
+  The store Gateway still can do it, but it first checks bucket if there is index-cached uploaded already.
+  In the same time, compactor precomputes the index cache file on every compaction.
 
   New Compactor flag: `--index.generate-missing-cache-file` was added to allow quicker addition of index cache files. If enabled it precomputes missing files on compactor startup. Note that it will take time and it's only one-off step per bucket.
 
@@ -143,31 +145,31 @@ Note that this is required to have SRV resolution working on [Golang 1.11+ with 
 - [#1021](https://github.com/improbable-eng/thanos/pull/1021) Query API `series` now supports POST method.
 - [#939](https://github.com/improbable-eng/thanos/pull/939) Query API `query_range` now supports POST method.
 
-### Changed 
+### Changed
 
 - [#970](https://github.com/improbable-eng/thanos/pull/970) Deprecated `partial_response_disabled` proto field. Added `partial_response_strategy` instead. Both in gRPC and Query API.
   No `PartialResponseStrategy` field for `RuleGroups` by default means `abort` strategy (old PartialResponse disabled) as this is recommended option for Rules and alerts.
 
   Metrics:
-    
+
     * Added `thanos_rule_evaluation_with_warnings_total` to Ruler.
     * DNS `thanos_ruler_query_apis*` are now `thanos_ruler_query_apis_*` for consistency.
     * DNS `thanos_querier_store_apis*` are now `thanos_querier_store_apis__*` for consistency.
     * Query Gate `thanos_bucket_store_series*` are now `thanos_bucket_store_series_*` for consistency.
     * Most of thanos ruler metris related to rule manager has `strategy` label.
-  
+
   Ruler tracing spans:
-  
+
     * `/rule_instant_query HTTP[client]` is now `/rule_instant_query_part_resp_abort HTTP[client]"` if request is for abort strategy.
-    
+
 - [#1009](https://github.com/improbable-eng/thanos/pull/1009): Upgraded Prometheus (~v2.7.0-rc.0 to v2.8.1)  and TSDB (`v0.4.0` to `v0.6.1`) deps.
-  
+
   Changes that affects Thanos:
-   * query: 
-     * [ENHANCEMENT] In histogram_quantile merge buckets with equivalent le values. #5158.   
-     * [ENHANCEMENT] Show list of offending labels in the error message in many-to-many scenarios. #5189   
+   * query:
+     * [ENHANCEMENT] In histogram_quantile merge buckets with equivalent le values. #5158.
+     * [ENHANCEMENT] Show list of offending labels in the error message in many-to-many scenarios. #5189
      * [BUGFIX] Fix panic when aggregator param is not a literal. #5290
-   * ruler: 
+   * ruler:
      * [ENHANCEMENT] Reduce time that Alertmanagers are in flux when reloaded. #5126
      * [BUGFIX] prometheus_rule_group_last_evaluation_timestamp_seconds is now a unix timestamp. #5186
      * [BUGFIX] prometheus_rule_group_last_duration_seconds now reports seconds instead of nanoseconds. Fixes our [issue #1027](https://github.com/improbable-eng/thanos/issues/1027)
@@ -179,26 +181,26 @@ Note that this is required to have SRV resolution working on [Golang 1.11+ with 
       * [CHANGE] *breaking* Renamed flag `--sync-delay` to `--consistency-delay` [#1053](https://github.com/improbable-eng/thanos/pull/1053)
   
   For ruler essentially whole TSDB CHANGELOG applies beween v0.4.0-v0.6.1: https://github.com/prometheus/tsdb/blob/master/CHANGELOG.md
-  
+
   Note that this was added on TSDB and Prometheus: [FEATURE] Time-ovelapping blocks are now allowed. #370
   Whoever due to nature of Thanos compaction (distributed systems), for safety reason this is disabled for Thanos compactor for now.
 
 - [#868](https://github.com/improbable-eng/thanos/pull/868) Go has been updated to 1.12.
-- [#1055](https://github.com/improbable-eng/thanos/pull/1055) Gossip flags are now disabled by default and deprecated. 
+- [#1055](https://github.com/improbable-eng/thanos/pull/1055) Gossip flags are now disabled by default and deprecated.
 - [#964](https://github.com/improbable-eng/thanos/pull/964) repair: Repair process now sorts the series and labels within block.
 - [#1073](https://github.com/improbable-eng/thanos/pull/1073) Store: index cache for requests. It now calculates the size properly (includes slice header), has anti-deadlock safeguard and reports more metrics.
 
 ### Fixed
 
 - [#921](https://github.com/improbable-eng/thanos/pull/921) `thanos_objstore_bucket_last_successful_upload_time` now does not appear when no blocks have been uploaded so far.
-- [#966](https://github.com/improbable-eng/thanos/pull/966) Bucket: verify no longer warns about overlapping blocks, that overlap `0s` 
+- [#966](https://github.com/improbable-eng/thanos/pull/966) Bucket: verify no longer warns about overlapping blocks, that overlap `0s`
 - [#848](https://github.com/improbable-eng/thanos/pull/848) Compact: now correctly works with time series with duplicate labels.
 - [#894](https://github.com/improbable-eng/thanos/pull/894) Thanos Rule: UI now correctly shows evaluation time.
 - [#865](https://github.com/improbable-eng/thanos/pull/865) Query: now properly parses DNS SRV Service Discovery.
 - [#889](https://github.com/improbable-eng/thanos/pull/889) Store: added safeguard against merging posting groups segfault
 - [#941](https://github.com/improbable-eng/thanos/pull/941) Sidecar: added better handling of intermediate restarts.
 - [#933](https://github.com/improbable-eng/thanos/pull/933) Query: Fixed 30 seconds lag of adding new store to query.
-- [#962](https://github.com/improbable-eng/thanos/pull/962) Sidecar: Make config reloader file writes atomic. 
+- [#962](https://github.com/improbable-eng/thanos/pull/962) Sidecar: Make config reloader file writes atomic.
 - [#982](https://github.com/improbable-eng/thanos/pull/982) Query: now advertises Min & Max Time accordingly to the nodes.
 - [#1041](https://github.com/improbable-eng/thanos/issues/1038) Ruler is now able to return long time range queries.
 - [#904](https://github.com/improbable-eng/thanos/pull/904) Compact: Skip compaction for blocks with no samples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased.
 
+### Added
+ 
+- [#1097](https://github.com/improbable-eng/thanos/pull/1097) Added `thanos check rules` linter for Thanos rule rules files.
+
 ## [v0.5.0](https://github.com/improbable-eng/thanos/releases/tag/v0.5.0) - 2019.06.05
 
 TL;DR: Store LRU cache is no longer leaking, Upgraded Thanos UI to Prometheus 2.9, Fixed auto-downsampling, Moved to Go 1.12.5 and more.
@@ -29,8 +33,6 @@ This version moved tarballs to Golang 1.12.5 from 1.11 as well, so same warning 
 ### Added
 
 - [#1094](https://github.com/improbable-eng/thanos/pull/1094) Allow configuring the response header timeout for the S3 client.
-- [#1097](https://github.com/improbable-eng/thanos/pull/1097) Added `thanos check rules` linter for Thanos rule rules files.
-
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ## Unreleased.
 
 ### Added
- 
+
 - [#1097](https://github.com/improbable-eng/thanos/pull/1097) Added `thanos check rules` linter for Thanos rule rules files.
 
 ## [v0.5.0](https://github.com/improbable-eng/thanos/releases/tag/v0.5.0) - 2019.06.05

--- a/cmd/thanos/check.go
+++ b/cmd/thanos/check.go
@@ -55,15 +55,14 @@ func checkRulesFiles(logger log.Logger, files *[]string) error {
 	return nil
 }
 
-type ThanosRuleGroup struct{
-    PartialResponseStrategy string `yaml:"partial_response_strategy"`
-    rulefmt.RuleGroup `yaml:",inline"`
+type ThanosRuleGroup struct {
+	PartialResponseStrategy string `yaml:"partial_response_strategy"`
+	rulefmt.RuleGroup       `yaml:",inline"`
 }
 
 type ThanosRuleGroups struct {
 	Groups []ThanosRuleGroup `yaml:"groups"`
 }
-
 
 func checkRules(logger log.Logger, filename string) (int, tsdb.MultiError) {
 	level.Info(logger).Log("msg", "checking", "filename", filename)

--- a/cmd/thanos/check.go
+++ b/cmd/thanos/check.go
@@ -9,7 +9,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
-	"github.com/prometheus/tsdb"
+	"github.com/prometheus/tsdb/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v2"
 )
@@ -34,7 +34,7 @@ func registerCheckRules(m map[string]setupFunc, root *kingpin.CmdClause, name st
 }
 
 func checkRulesFiles(logger log.Logger, files *[]string) error {
-	failed := tsdb.MultiError{}
+	failed := errors.MultiError{}
 
 	for _, f := range *files {
 		n, errs := checkRules(logger, f)
@@ -64,9 +64,9 @@ type ThanosRuleGroups struct {
 	Groups []ThanosRuleGroup `yaml:"groups"`
 }
 
-func checkRules(logger log.Logger, filename string) (int, tsdb.MultiError) {
+func checkRules(logger log.Logger, filename string) (int, errors.MultiError) {
 	level.Info(logger).Log("msg", "checking", "filename", filename)
-	checkErrors := tsdb.MultiError{}
+	checkErrors := errors.MultiError{}
 
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/cmd/thanos/check.go
+++ b/cmd/thanos/check.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"io/ioutil"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	thanosrule "github.com/improbable-eng/thanos/pkg/rule"
+	"github.com/oklog/run"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/prometheus/tsdb"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/yaml.v2"
+)
+
+func registerChecks(m map[string]setupFunc, app *kingpin.Application, name string) {
+	cmd := app.Command(name, "Linting tools for Thanos")
+	registerCheckRules(m, cmd, name)
+}
+
+func registerCheckRules(m map[string]setupFunc, root *kingpin.CmdClause, name string) {
+	checkRulesCmd := root.Command("rules", "Check if the rule files are valid or not.")
+	ruleFiles := checkRulesCmd.Arg(
+		"rule-files",
+		"The rule files to check.",
+	).Required().ExistingFiles()
+
+	m[name+" rules"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ bool) error {
+		// Dummy actor to immediately kill the group after the run function returns.
+		g.Add(func() error { return nil }, func(error) {})
+		return checkRulesFiles(logger, ruleFiles)
+	}
+}
+
+func checkRulesFiles(logger log.Logger, files *[]string) error {
+	failed := tsdb.MultiError{}
+
+	for _, f := range *files {
+		n, errs := checkRules(logger, f)
+		if errs.Err() != nil {
+			level.Error(logger).Log("result", "FAILED")
+			for _, e := range errs {
+				level.Error(logger).Log("error", e.Error())
+				failed.Add(e)
+			}
+			level.Info(logger).Log()
+			continue
+		}
+		level.Info(logger).Log("result", "SUCCESS", "rules found", n)
+	}
+	if failed.Err() != nil {
+		return failed
+	}
+	return nil
+}
+
+func checkRules(logger log.Logger, filename string) (int, tsdb.MultiError) {
+	level.Info(logger).Log("msg", "checking", "filename", filename)
+	checkErrors := tsdb.MultiError{}
+
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		checkErrors.Add(err)
+		return 0, checkErrors
+	}
+
+	var rgs thanosrule.RuleGroups
+	if err := yaml.Unmarshal(b, &rgs); err != nil {
+		checkErrors.Add(err)
+		return 0, checkErrors
+	}
+
+	// We need to convert Thanos rules to Prometheus rules so we can use their validation.
+	promRgs := thanosRuleGroupsToPromRuleGroups(rgs)
+	if errs := promRgs.Validate(); errs != nil {
+		for _, e := range errs {
+			checkErrors.Add(e)
+		}
+		return 0, checkErrors
+	}
+
+	numRules := 0
+	for _, rg := range rgs.Groups {
+		numRules += len(rg.Rules)
+	}
+
+	return numRules, checkErrors
+}
+
+func thanosRuleGroupsToPromRuleGroups(ruleGroups thanosrule.RuleGroups) rulefmt.RuleGroups {
+	promRuleGroups := rulefmt.RuleGroups{Groups: []rulefmt.RuleGroup{}}
+	for _, g := range ruleGroups.Groups {
+		group := rulefmt.RuleGroup{
+			Name:     g.Name,
+			Interval: g.Interval,
+			Rules:    []rulefmt.Rule{},
+		}
+		for _, r := range g.Rules {
+			group.Rules = append(
+				group.Rules,
+				rulefmt.Rule{
+					Record:      r.Record,
+					Alert:       r.Alert,
+					Expr:        r.Expr,
+					For:         r.For,
+					Labels:      r.Labels,
+					Annotations: r.Annotations,
+				},
+			)
+		}
+		promRuleGroups.Groups = append(
+			promRuleGroups.Groups,
+			group,
+		)
+	}
+	return promRuleGroups
+}

--- a/cmd/thanos/check_test.go
+++ b/cmd/thanos/check_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/improbable-eng/thanos/pkg/testutil"
+)
+
+func Test_checkRules(t *testing.T) {
+
+	validFiles := []string{
+		"./testdata/rules-files/valid.yaml",
+	}
+
+	invalidFiles := [][]string{
+		[]string{"./testdata/rules-files/non-existing-file.yaml"},
+		[]string{"./testdata/rules-files/invalid-yaml-format.yaml"},
+		[]string{"./testdata/rules-files/invalid-rules-data.yaml"},
+	}
+
+	logger := log.NewNopLogger()
+
+	testutil.Ok(t, checkRulesFiles(logger, &validFiles))
+
+	for _, fn := range invalidFiles {
+		testutil.NotOk(t, checkRulesFiles(logger, &fn))
+	}
+}

--- a/cmd/thanos/check_test.go
+++ b/cmd/thanos/check_test.go
@@ -17,6 +17,7 @@ func Test_checkRules(t *testing.T) {
 		[]string{"./testdata/rules-files/non-existing-file.yaml"},
 		[]string{"./testdata/rules-files/invalid-yaml-format.yaml"},
 		[]string{"./testdata/rules-files/invalid-rules-data.yaml"},
+		[]string{"./testdata/rules-files/invalid-unknown-field.yaml"},
 	}
 
 	logger := log.NewNopLogger()

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -177,7 +177,7 @@ func main() {
 	}
 
 	if err := cmds[cmd](&g, logger, metrics, tracer, *logLevel == "debug"); err != nil {
-		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "%s command failed", cmd))
+		level.Error(logger).Log("err", errors.Wrapf(err, "%s command failed", cmd))
 		os.Exit(1)
 	}
 

--- a/cmd/thanos/main.go
+++ b/cmd/thanos/main.go
@@ -77,6 +77,7 @@ func main() {
 	registerBucket(cmds, app, "bucket")
 	registerDownsample(cmds, app, "downsample")
 	registerReceive(cmds, app, "receive")
+	registerChecks(cmds, app, "check")
 
 	cmd, err := app.Parse(os.Args[1:])
 	if err != nil {

--- a/cmd/thanos/testdata/rules-files/invalid-rules-data.yaml
+++ b/cmd/thanos/testdata/rules-files/invalid-rules-data.yaml
@@ -1,0 +1,12 @@
+groups:
+  - name: null
+    partial_response_strategy: "warn"
+    interval: 2m
+    rules:
+      - alert: TestAlert
+        partial_response_strategy: "warn"
+        expr: 1
+        labels:
+          key: value
+        annotations:
+          key: value

--- a/cmd/thanos/testdata/rules-files/invalid-unknown-field.yaml
+++ b/cmd/thanos/testdata/rules-files/invalid-unknown-field.yaml
@@ -1,7 +1,7 @@
 groups:
   - name: test-alert-group
     partial_response_strategy: "warn"
-    interval: 2m
+    interrrrrrrrval: 2m
     rules:
       - alert: TestAlert
         expr: 1

--- a/cmd/thanos/testdata/rules-files/invalid-yaml-format.yaml
+++ b/cmd/thanos/testdata/rules-files/invalid-yaml-format.yaml
@@ -1,0 +1,3 @@
+groups:
+  - name: test
+  invalid_yaml_reason

--- a/cmd/thanos/testdata/rules-files/valid.yaml
+++ b/cmd/thanos/testdata/rules-files/valid.yaml
@@ -1,0 +1,20 @@
+groups:
+  - name: test-alert-group
+    partial_response_strategy: "warn"
+    interval: 2m
+    rules:
+      - alert: TestAlert
+        partial_response_strategy: "warn"
+        expr: 1
+        labels:
+          key: value
+        annotations:
+          key: value
+
+  - name: test-rule-group
+    partial_response_strategy: "warn"
+    interval: 2m
+    rules:
+      - record: test_metric
+        expr: 1
+        partial_response_strategy: "warn"

--- a/docs/components/check.md
+++ b/docs/components/check.md
@@ -1,0 +1,82 @@
+---
+title: Check
+type: docs
+menu: components
+---
+
+# Check
+
+The check component contains tools for validation of Prometheus rules.
+
+## Deployment
+## Flags
+
+[embedmd]:# (flags/check.txt $)
+```$
+usage: thanos check <command> [<args> ...]
+
+Linting tools for Thanos
+
+Flags:
+  -h, --help               Show context-sensitive help (also try --help-long and
+                           --help-man).
+      --version            Show application version.
+      --log.level=info     Log filtering level.
+      --log.format=logfmt  Log format to use.
+      --gcloudtrace.project=GCLOUDTRACE.PROJECT
+                           GCP project to send Google Cloud Trace tracings to.
+                           If empty, tracing will be disabled.
+      --gcloudtrace.sample-factor=1
+                           How often we send traces (1/<sample-factor>). If 0 no
+                           trace will be sent periodically, unless forced by
+                           baggage item. See `pkg/tracing/tracing.go` for
+                           details.
+
+Subcommands:
+  check rules <rule-files>...
+    Check if the rule files are valid or not.
+
+
+```
+
+
+### Verify
+
+`check rules` checks the Prometheus rules, used by the Thanos rule node, if they are valid.
+The check should be equivalent for the `promtool check rules` but that cannot be used because
+Thanos rule has extended rules file syntax, which includes `partial_response_strategy` field
+which `promtool` does not allow.
+
+If the check fails the command fails with exit code `1`, otherwise `0`.
+
+Example:
+
+```
+$ ./thanos check rules cmd/thanos/testdata/rules-files/*.yaml
+```
+
+[embedmd]:# (flags/check_rules.txt)
+```txt
+usage: thanos check rules <rule-files>...
+
+Check if the rule files are valid or not.
+
+Flags:
+  -h, --help               Show context-sensitive help (also try --help-long and
+                           --help-man).
+      --version            Show application version.
+      --log.level=info     Log filtering level.
+      --log.format=logfmt  Log format to use.
+      --gcloudtrace.project=GCLOUDTRACE.PROJECT
+                           GCP project to send Google Cloud Trace tracings to.
+                           If empty, tracing will be disabled.
+      --gcloudtrace.sample-factor=1
+                           How often we send traces (1/<sample-factor>). If 0 no
+                           trace will be sent periodically, unless forced by
+                           baggage item. See `pkg/tracing/tracing.go` for
+                           details.
+
+Args:
+  <rule-files>  The rule files to check.
+
+```

--- a/docs/components/check.md
+++ b/docs/components/check.md
@@ -23,14 +23,12 @@ Flags:
       --version            Show application version.
       --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use.
-      --gcloudtrace.project=GCLOUDTRACE.PROJECT
-                           GCP project to send Google Cloud Trace tracings to.
-                           If empty, tracing will be disabled.
-      --gcloudtrace.sample-factor=1
-                           How often we send traces (1/<sample-factor>). If 0 no
-                           trace will be sent periodically, unless forced by
-                           baggage item. See `pkg/tracing/tracing.go` for
-                           details.
+      --tracing.config-file=<tracing.config-yaml-path>
+                           Path to YAML file that contains tracing
+                           configuration.
+      --tracing.config=<tracing.config-yaml>
+                           Alternative to 'tracing.config-file' flag. Tracing
+                           configuration in YAML.
 
 Subcommands:
   check rules <rule-files>...
@@ -67,14 +65,12 @@ Flags:
       --version            Show application version.
       --log.level=info     Log filtering level.
       --log.format=logfmt  Log format to use.
-      --gcloudtrace.project=GCLOUDTRACE.PROJECT
-                           GCP project to send Google Cloud Trace tracings to.
-                           If empty, tracing will be disabled.
-      --gcloudtrace.sample-factor=1
-                           How often we send traces (1/<sample-factor>). If 0 no
-                           trace will be sent periodically, unless forced by
-                           baggage item. See `pkg/tracing/tracing.go` for
-                           details.
+      --tracing.config-file=<tracing.config-yaml-path>
+                           Path to YAML file that contains tracing
+                           configuration.
+      --tracing.config=<tracing.config-yaml>
+                           Alternative to 'tracing.config-file' flag. Tracing
+                           configuration in YAML.
 
 Args:
   <rule-files>  The rule files to check.

--- a/scripts/genflagdocs.sh
+++ b/scripts/genflagdocs.sh
@@ -33,7 +33,7 @@ fi
 
 CHECK=${1:-}
 
-commands=("compact" "query" "rule" "sidecar" "store" "bucket")
+commands=("compact" "query" "rule" "sidecar" "store" "bucket" "check")
 
 for x in "${commands[@]}"; do
     ./thanos "${x}" --help &> "docs/components/flags/${x}.txt"
@@ -42,6 +42,11 @@ done
 bucketCommands=("verify" "ls" "inspect")
 for x in "${bucketCommands[@]}"; do
     ./thanos bucket "${x}" --help &> "docs/components/flags/bucket_${x}.txt"
+done
+
+checkCommands=("rules")
+for x in "${checkCommands[@]}"; do
+    ./thanos check "${x}" --help &> "docs/components/flags/check_${x}.txt"
 done
 
 # remove white noise


### PR DESCRIPTION
Resolves #1096 
This adds `thanos check rules` command to check Prometheus rules.

We cannot use the `promtool check rules` since Thanos-rule allows the additional field `partial_response_strategy`

## Changes

- [x] added the check rules cmd
- [x] changelog entry TBD
- [x] docs update?

## Verification

Tested it on different types of invalid rule files even valid. Works fine.