### PR TITLE
Add note to CHANGELOG: Renamed flag --sync-delay to --consistency-delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,13 +102,15 @@ Note that this is required to have SRV resolution working on [Golang 1.11+ with 
      * [BUGFIX] Fix sorting of rule groups. #5260
    * store: [ENHANCEMENT] Fast path for EmptyPostings cases in Merge, Intersect and Without.
    * tooling: [FEATURE] New dump command to tsdb tool to dump all samples.
-   * compactor: [ENHANCEMENT] When closing the db any running compaction will be cancelled so it doesn't block.
+   * compactor: 
+      * [ENHANCEMENT] When closing the db any running compaction will be cancelled so it doesn't block.
+      * [CHANGE] Renamed flag `--sync-delay` to `--consistency-delay` [#1053](https://github.com/improbable-eng/thanos/pull/1053)
   
   For ruler essentially whole TSDB CHANGELOG applies beween v0.4.0-v0.6.1: https://github.com/prometheus/tsdb/blob/master/CHANGELOG.md
   
   Note that this was added on TSDB and Prometheus: [FEATURE] Time-ovelapping blocks are now allowed. #370
   Whoever due to nature of Thanos compaction (distributed systems), for safety reason this is disabled for Thanos compactor for now.
- 
+
 - [#868](https://github.com/improbable-eng/thanos/pull/868) Go has been updated to 1.12.
 - [#1055](https://github.com/improbable-eng/thanos/pull/1055) Gossip flags are now disabled by default and deprecated. 
 - [#964](https://github.com/improbable-eng/thanos/pull/964) repair: Repair process now sorts the series and labels within block.


### PR DESCRIPTION
Just got the error when starting release v0.4.0:

`Error parsing commandline arguments: unknown long flag '--sync-delay'`

A note in the CHANGELOG would be nice :-)