### PR TITLE
query/api: properly pass downsampling param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ## Unreleased
 
+### Fixed
+- [#1144](https://github.com/improbable-eng/thanos/pull/1144) Query/API: properly pass the downsampling parameter. Before this, wrong max resolution of the metrics data might have been selected.
+
 ## [v0.4.0](https://github.com/improbable-eng/thanos/releases/tag/v0.4.0) - 2019.05.3
 
 :warning: **IMPORTANT** :warning: This is the last release that supports gossip. From Thanos v0.5.0, gossip will be completely removed.

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -223,6 +223,9 @@ func (api *API) parseDownsamplingParam(r *http.Request, step time.Duration) (max
 		return 0, &ApiError{errorBadData, errors.Errorf("negative '%s' is not accepted. Try a positive integer", maxSourceResolutionParam)}
 	}
 
+	/// We need this in milliseconds.
+	maxSourceResolution = maxSourceResolution / (1000 * 1000)
+
 	return maxSourceResolution, nil
 }
 

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/improbable-eng/thanos/pkg/compact"
 	"github.com/improbable-eng/thanos/pkg/query"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/opentracing/opentracing-go"
@@ -713,6 +714,74 @@ func TestParseTime(t *testing.T) {
 		if !test.fail && !ts.Equal(test.result) {
 			t.Errorf("Expected time %v for input %q but got %v", test.result, test.input, ts)
 		}
+	}
+}
+
+func TestParseDownsamplingParam(t *testing.T) {
+	var tests = []struct {
+		maxSourceResolution    string
+		result                 time.Duration
+		step                   time.Duration
+		fail                   bool
+		enableAutodownsampling bool
+	}{
+		{
+			maxSourceResolution:    "0s",
+			enableAutodownsampling: false,
+			step:                   time.Hour,
+			result:                 time.Duration(compact.ResolutionLevelRaw),
+			fail:                   false,
+		},
+		{
+			maxSourceResolution:    "5m",
+			step:                   time.Hour,
+			enableAutodownsampling: false,
+			result:                 time.Duration(compact.ResolutionLevel5m),
+			fail:                   false,
+		},
+		{
+			maxSourceResolution:    "1h",
+			step:                   time.Hour,
+			enableAutodownsampling: false,
+			result:                 time.Duration(compact.ResolutionLevel1h),
+			fail:                   false,
+		},
+		{
+			maxSourceResolution:    "",
+			enableAutodownsampling: true,
+			step:                   time.Hour,
+			result:                 time.Duration(time.Hour / (5 * 1000 * 1000)),
+			fail:                   false,
+		},
+		{
+			maxSourceResolution:    "",
+			enableAutodownsampling: true,
+			step:                   time.Hour,
+			result:                 time.Duration((1 * time.Hour) / 6),
+			fail:                   true,
+		},
+		{
+			maxSourceResolution:    "",
+			enableAutodownsampling: true,
+			step:                   time.Hour,
+			result:                 time.Duration((1 * time.Hour) / 6),
+			fail:                   true,
+		},
+	}
+
+	for i, test := range tests {
+		api := API{enableAutodownsampling: test.enableAutodownsampling}
+		v := url.Values{}
+		v.Set("max_source_resolution", test.maxSourceResolution)
+		r := http.Request{PostForm: v}
+
+		maxSourceRes, _ := api.parseDownsamplingParam(&r, test.step)
+		if test.fail == false {
+			testutil.Assert(t, maxSourceRes == test.result, "case %v: expected %v to be equal to %v", i, maxSourceRes, test.result)
+		} else {
+			testutil.Assert(t, maxSourceRes != test.result, "case %v: expected %v not to be equal to %v", i, maxSourceRes, test.result)
+		}
+
 	}
 }
 


### PR DESCRIPTION
As compact.ResolutionLevel{Raw,5m,1h} says the resolution levels are
expressed in milliseconds. Currently, parseDownsamplingParam() calls
parseDuration() and friends which express this value in nanoseconds.
Thus, we need to divide the value by 1000*1000 to have them in
milliseconds.

Add test cases to check all of this.

