### PR TITLE
Revert "query/api: properly pass downsampling param (#1144)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,6 @@ We use *breaking* word for marking changes that are not backward compatible (rel
     - [ENHANCEMENT] Improve rule views by wrapping lines [PR #4702](https://github.com/prometheus/prometheus/pull/4702)
     - [ENHANCEMENT] Show rule evaluation errors on rules page [PR #4457](https://github.com/prometheus/prometheus/pull/4457)
     
-### Fixed
-
-- [#1144](https://github.com/improbable-eng/thanos/pull/1144) Query/API: properly pass the downsampling parameter. Before this, wrong max resolution of the metrics data might have been selected.
-
 ## [v0.4.0](https://github.com/improbable-eng/thanos/releases/tag/v0.4.0) - 2019.05.3
 
 :warning: **IMPORTANT** :warning: This is the last release that supports gossip. From Thanos v0.5.0, gossip will be completely removed.

--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -223,9 +223,6 @@ func (api *API) parseDownsamplingParam(r *http.Request, step time.Duration) (max
 		return 0, &ApiError{errorBadData, errors.Errorf("negative '%s' is not accepted. Try a positive integer", maxSourceResolutionParam)}
 	}
 
-	/// We need this in milliseconds.
-	maxSourceResolution = maxSourceResolution / (1000 * 1000)
-
 	return maxSourceResolution, nil
 }
 

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/improbable-eng/thanos/pkg/compact"
 	"github.com/improbable-eng/thanos/pkg/query"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -714,74 +713,6 @@ func TestParseTime(t *testing.T) {
 		if !test.fail && !ts.Equal(test.result) {
 			t.Errorf("Expected time %v for input %q but got %v", test.result, test.input, ts)
 		}
-	}
-}
-
-func TestParseDownsamplingParam(t *testing.T) {
-	var tests = []struct {
-		maxSourceResolution    string
-		result                 time.Duration
-		step                   time.Duration
-		fail                   bool
-		enableAutodownsampling bool
-	}{
-		{
-			maxSourceResolution:    "0s",
-			enableAutodownsampling: false,
-			step:                   time.Hour,
-			result:                 time.Duration(compact.ResolutionLevelRaw),
-			fail:                   false,
-		},
-		{
-			maxSourceResolution:    "5m",
-			step:                   time.Hour,
-			enableAutodownsampling: false,
-			result:                 time.Duration(compact.ResolutionLevel5m),
-			fail:                   false,
-		},
-		{
-			maxSourceResolution:    "1h",
-			step:                   time.Hour,
-			enableAutodownsampling: false,
-			result:                 time.Duration(compact.ResolutionLevel1h),
-			fail:                   false,
-		},
-		{
-			maxSourceResolution:    "",
-			enableAutodownsampling: true,
-			step:                   time.Hour,
-			result:                 time.Duration(time.Hour / (5 * 1000 * 1000)),
-			fail:                   false,
-		},
-		{
-			maxSourceResolution:    "",
-			enableAutodownsampling: true,
-			step:                   time.Hour,
-			result:                 time.Duration((1 * time.Hour) / 6),
-			fail:                   true,
-		},
-		{
-			maxSourceResolution:    "",
-			enableAutodownsampling: true,
-			step:                   time.Hour,
-			result:                 time.Duration((1 * time.Hour) / 6),
-			fail:                   true,
-		},
-	}
-
-	for i, test := range tests {
-		api := API{enableAutodownsampling: test.enableAutodownsampling}
-		v := url.Values{}
-		v.Set("max_source_resolution", test.maxSourceResolution)
-		r := http.Request{PostForm: v}
-
-		maxSourceRes, _ := api.parseDownsamplingParam(&r, test.step)
-		if test.fail == false {
-			testutil.Assert(t, maxSourceRes == test.result, "case %v: expected %v to be equal to %v", i, maxSourceRes, test.result)
-		} else {
-			testutil.Assert(t, maxSourceRes != test.result, "case %v: expected %v not to be equal to %v", i, maxSourceRes, test.result)
-		}
-
 	}
 }
 


### PR DESCRIPTION
If I am not wrong downsampling on master is broken for 2days.

This reverts commit 7a767eff3c7ecf55acbdc9d15a505207b2a0a7a2.

See: https://github.com/improbable-eng/thanos/pull/1144#issuecomment-493263066

Reason: 
* It has to be in in milisecond but we already do that underneath in Querier: https://github.com/improbable-eng/thanos/blob/3b9afb435215e761ecd34b3ccfd69d9946f6f725/pkg/query/querier.go#L58
* Conversion does not make sense here as time.Duration is unit agnostic type, so we should do conversion in the moment of transformation to `int64` only.

Tests are nice but they are assuming no-one converts resolution in further stack. Let's revert this and fix the getFor as it's done here: https://github.com/improbable-eng/thanos/pull/1146 
