### PR TITLE
Moved CI to build Thanos with golang 1.12.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     docker:
       # Available from https://hub.docker.com/r/circleci/golang/
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12.5
     working_directory: /go/src/github.com/improbable-eng/thanos
     environment:
       GO111MODULE: 'on'
@@ -62,7 +62,7 @@ jobs:
   publish_master:
     docker:
       # Available from https://hub.docker.com/r/circleci/golang/
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12.5
     working_directory: /go/src/github.com/improbable-eng/thanos
     environment:
       GOBIN: "/go/bin"
@@ -81,7 +81,7 @@ jobs:
   publish_release:
     docker:
       # Available from https://hub.docker.com/r/circleci/golang/
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12.5
     working_directory: /go/src/github.com/improbable-eng/thanos
     environment:
       GOBIN: "/go/bin"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
     - [ENHANCEMENT] Improve rule views by wrapping lines [PR #4702](https://github.com/prometheus/prometheus/pull/4702)
     - [ENHANCEMENT] Show rule evaluation errors on rules page [PR #4457](https://github.com/prometheus/prometheus/pull/4457)
     
+- [#1156](https://github.com/improbable-eng/thanos/pull/1156) Moved CI and docker multistage to Golang 1.12.5 for latest mem alloc improvements. 
+
 ## [v0.4.0](https://github.com/improbable-eng/thanos/releases/tag/v0.4.0) - 2019.05.3
 
 :warning: **IMPORTANT** :warning: This is the last release that supports gossip. From Thanos v0.5.0, gossip will be completely removed.

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine3.9 as builder
+FROM golang:1.12.5-alpine3.9 as builder
 
 ADD . $GOPATH/src/github.com/improbable-eng/thanos
 WORKDIR $GOPATH/src/github.com/improbable-eng/thanos


### PR DESCRIPTION
This is to mitigate potential memory allocation latency bugs: https://github.com/prometheus/prometheus/issues/5524

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>
