### PR TITLE
promclient: drop version check

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -314,7 +314,7 @@ func validatePrometheus(ctx context.Context, logger log.Logger, m *promMetadata)
 
 		var err error
 		if flags, err = promclient.ConfiguredFlags(ctx, logger, m.promURL); err != nil {
-			if err == promclient.NotFoundFlags { // saw 404
+			if err == promclient.ErrFlagEndpointNotFound { // saw 404
 				level.Warn(logger).Log("msg", "failed to check Promteheus flags endpoint. No extra validation is done: %s", err)
 				return nil
 			}

--- a/pkg/promclient/promclient_e2e_test.go
+++ b/pkg/promclient/promclient_e2e_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	version "github.com/hashicorp/go-version"
 	"github.com/improbable-eng/thanos/pkg/runutil"
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/oklog/ulid"
@@ -147,37 +146,4 @@ func TestRule_UnmarshalScalarResponse(t *testing.T) {
 	// Test invalid format of scalar data.
 	vectorResult, err = convertScalarJSONToVector(invalidDataScalarJSONResult)
 	testutil.NotOk(t, err)
-}
-
-func TestParseVersion(t *testing.T) {
-	promVersions := map[string]string{
-		"":           promVersionResp(""),
-		"2.2.0":      promVersionResp("2.2.0"),
-		"2.3.0":      promVersionResp("2.3.0"),
-		"2.3.0-rc.0": promVersionResp("2.3.0-rc.0"),
-	}
-
-	promMalformedVersions := map[string]string{
-		"foo": promVersionResp("foo"),
-		"bar": promVersionResp("bar"),
-	}
-
-	for v, resp := range promVersions {
-		gotVersion, err := parseVersion([]byte(resp))
-		testutil.Ok(t, err)
-		expectVersion, _ := version.NewVersion(v)
-		testutil.Equals(t, gotVersion, expectVersion)
-	}
-
-	for v, resp := range promMalformedVersions {
-		gotVersion, err := parseVersion([]byte(resp))
-		testutil.NotOk(t, err)
-		expectVersion, _ := version.NewVersion(v)
-		testutil.Equals(t, gotVersion, expectVersion)
-	}
-}
-
-// promVersionResp returns the response of Prometheus /version endpoint.
-func promVersionResp(ver string) string {
-	return fmt.Sprintf(`{"version":"%s","revision":"","branch":"","buildUser":"","buildDate":"","goVersion":""}`, ver)
 }


### PR DESCRIPTION
The version check would check the prometheus version and if > 2.2.0
would query the flags endpoint to do some extra validation.

Remove this for just checking the flags endpoints and if it responds do
the validation; otherwise log the failure, but continue the startup.

Signed-off-by: Miek Gieben <miek@miek.nl>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->