### PR TITLE
Use go proxy to fasten building at first build (useful for docker & ci)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ TMP_GOPATH        ?= /tmp/thanos-go
 GOBIN             ?= ${GOPATH}/bin
 GO111MODULE       ?= on
 export GO111MODULE
+GOPROXY           ?= https://proxy.golang.org
+export GOPROXY
 
 # Tools.
 EMBEDMD           ?= $(GOBIN)/embedmd-$(EMBEDMD_VERSION)


### PR DESCRIPTION
```
sylvain@ubuntu-1604-dev:~/gopath/src/github.com/improbable-eng/thanos[master]$ time make docker-multi-stage DOCKER_IMAGE_NAME=quay.io/sylr/thanos:test
...
...

real    6m58.813s
user    0m0.372s
sys     0m0.352s
```

```
sylvain@ubuntu-1604-dev:~/gopath/src/github.com/improbable-eng/thanos[goproxy]$ time make docker-multi-stage DOCKER_IMAGE_NAME=quay.io/sylr/thanos:test
...
...

real    2m10.127s
user    0m0.376s
sys     0m0.268s
```