### PR TITLE
store,compact,sidecar: replace all usage of json.Decoder with json.Unmarshal

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -364,7 +364,7 @@ func genMissingIndexCacheFiles(ctx context.Context, logger log.Logger, bkt objst
 			return errors.Wrap(err, "read meta")
 		}
 
-		if err = json.Unmarshal(obj, meta); err != nil {
+		if err = json.Unmarshal(obj, &meta); err != nil {
 			return errors.Wrap(err, "unmarshal meta")
 		}
 

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -357,8 +358,14 @@ func genMissingIndexCacheFiles(ctx context.Context, logger log.Logger, bkt objst
 		defer runutil.CloseWithLogOnErr(logger, rc, "block reader")
 
 		var meta metadata.Meta
-		if err := json.NewDecoder(rc).Decode(&meta); err != nil {
-			return errors.Wrap(err, "decode meta")
+
+		obj, err := ioutil.ReadAll(rc)
+		if err != nil {
+			return errors.Wrap(err, "read meta")
+		}
+
+		if err = json.Unmarshal(obj, meta); err != nil {
+			return errors.Wrap(err, "unmarshal meta")
 		}
 
 		// New version of compactor pushes index cache along with data block.

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -127,7 +127,7 @@ func downsampleBucket(
 			return errors.Wrap(err, "read meta")
 		}
 
-		if err := json.Unmarshal(obj, m); err != nil {
+		if err = json.Unmarshal(obj, m); err != nil {
 			return errors.Wrap(err, "unmarshal meta")
 		}
 

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -120,9 +121,16 @@ func downsampleBucket(
 		defer runutil.CloseWithLogOnErr(logger, rc, "block reader")
 
 		var m metadata.Meta
-		if err := json.NewDecoder(rc).Decode(&m); err != nil {
-			return errors.Wrap(err, "decode meta")
+
+		obj, err := ioutil.ReadAll(rc)
+		if err != nil {
+			return errors.Wrap(err, "read meta")
 		}
+
+		if err := json.Unmarshal(obj, m); err != nil {
+			return errors.Wrap(err, "unmarshal meta")
+		}
+
 		metas = append(metas, &m)
 
 		return nil

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -5,6 +5,7 @@ package block
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -135,9 +136,16 @@ func DownloadMeta(ctx context.Context, logger log.Logger, bkt objstore.Bucket, i
 	defer runutil.CloseWithLogOnErr(logger, rc, "download meta bucket client")
 
 	var m metadata.Meta
-	if err := json.NewDecoder(rc).Decode(&m); err != nil {
-		return metadata.Meta{}, errors.Wrapf(err, "decode meta.json for block %s", id.String())
+
+	obj, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return metadata.Meta{}, errors.Wrapf(err, "read meta.json for block %s", id.String())
 	}
+
+	if err = json.Unmarshal(obj, m); err != nil {
+		return metadata.Meta{}, errors.Wrapf(err, "unmarshal meta.json for block %s", id.String())
+	}
+
 	return m, nil
 }
 

--- a/pkg/block/block.go
+++ b/pkg/block/block.go
@@ -142,7 +142,7 @@ func DownloadMeta(ctx context.Context, logger log.Logger, bkt objstore.Bucket, i
 		return metadata.Meta{}, errors.Wrapf(err, "read meta.json for block %s", id.String())
 	}
 
-	if err = json.Unmarshal(obj, m); err != nil {
+	if err = json.Unmarshal(obj, &m); err != nil {
 		return metadata.Meta{}, errors.Wrapf(err, "unmarshal meta.json for block %s", id.String())
 	}
 

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -186,9 +187,16 @@ func ReadIndexCache(logger log.Logger, fn string) (
 	defer runutil.CloseWithLogOnErr(logger, f, "index reader")
 
 	var v indexCache
-	if err := json.NewDecoder(f).Decode(&v); err != nil {
-		return 0, nil, nil, nil, errors.Wrap(err, "decode file")
+
+	bytes, err := ioutil.ReadFile(fn)
+	if err != nil {
+		return 0, nil, nil, nil, errors.Wrap(err, "read file")
 	}
+
+	if err = json.Unmarshal(bytes, v); err != nil {
+		return 0, nil, nil, nil, errors.Wrap(err, "unmarshal index cache")
+	}
+
 	strs := map[string]string{}
 	lvals = make(map[string][]string, len(v.LabelValues))
 	postings = make(map[labels.Label]index.Range, len(v.Postings))

--- a/pkg/block/index.go
+++ b/pkg/block/index.go
@@ -193,7 +193,7 @@ func ReadIndexCache(logger log.Logger, fn string) (
 		return 0, nil, nil, nil, errors.Wrap(err, "read file")
 	}
 
-	if err = json.Unmarshal(bytes, v); err != nil {
+	if err = json.Unmarshal(bytes, &v); err != nil {
 		return 0, nil, nil, nil, errors.Wrap(err, "unmarshal index cache")
 	}
 

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -328,8 +328,13 @@ func QueryInstant(ctx context.Context, logger log.Logger, base *url.URL, query s
 		Warnings []string `json:"warnings"`
 	}
 
-	if err = json.NewDecoder(resp.Body).Decode(&m); err != nil {
-		return nil, nil, errors.Wrap(err, "decode query instant response")
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "read query instant response")
+	}
+
+	if err = json.Unmarshal(body, m); err != nil {
+		return nil, nil, errors.Wrap(err, "unmarshal query instant response")
 	}
 
 	var vectorResult model.Vector

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -333,7 +333,7 @@ func QueryInstant(ctx context.Context, logger log.Logger, base *url.URL, query s
 		return nil, nil, errors.Wrap(err, "read query instant response")
 	}
 
-	if err = json.Unmarshal(body, m); err != nil {
+	if err = json.Unmarshal(body, &m); err != nil {
 		return nil, nil, errors.Wrap(err, "unmarshal query instant response")
 	}
 

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -384,7 +384,7 @@ func (p *PrometheusStore) LabelNames(ctx context.Context, _ *storepb.LabelNamesR
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if err = json.Unmarshal(body, m); err != nil {
+	if err = json.Unmarshal(body, &m); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -443,7 +443,7 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	if err = json.Unmarshal(body, m); err != nil {
+	if err = json.Unmarshal(body, &m); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -377,7 +378,13 @@ func (p *PrometheusStore) LabelNames(ctx context.Context, _ *storepb.LabelNamesR
 		Status string   `json:"status"`
 		Error  string   `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if err = json.Unmarshal(body, m); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -431,7 +438,12 @@ func (p *PrometheusStore) LabelValues(ctx context.Context, r *storepb.LabelValue
 		Status string   `json:"status"`
 		Error  string   `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if err = json.Unmarshal(body, m); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -463,7 +463,7 @@ func queryAlertmanagerAlerts(ctx context.Context, url string) ([]*model.Alert, e
 		return nil, err
 	}
 
-	if err = json.Unmarshal(body, m); err != nil {
+	if err = json.Unmarshal(body, &v); err != nil {
 		return nil, err
 	}
 

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -457,9 +457,16 @@ func queryAlertmanagerAlerts(ctx context.Context, url string) ([]*model.Alert, e
 	var v struct {
 		Data []*model.Alert `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
 		return nil, err
 	}
+
+	if err = json.Unmarshal(body, m); err != nil {
+		return nil, err
+	}
+
 	sort.Slice(v.Data, func(i, j int) bool {
 		return v.Data[i].Labels.Before(v.Data[j].Labels)
 	})


### PR DESCRIPTION
fixes issue #1160 

## Changes

replaced usages of json.NewDecoder Decode, with ioutil.ReadAll/File and json.Unmarshal

## Verification

been running in production for a few days, memory graphs appear marginally better fixes 