### PR TITLE
 scripts/websitepreprocess.sh,docs/*: Fix broken links

### DIFF
--- a/docs/components/compact.md
+++ b/docs/components/compact.md
@@ -26,8 +26,6 @@ config:
 The compactor needs local disk space to store intermediate data for its processing. Generally, about 100GB are recommended for it to keep working as the compacted time ranges grow over time.
 On-disk data is safe to delete between restarts and should be the first attempt to get crash-looping compactors unstuck.
 
-## Deployment
-
 ## Flags
 
 [embedmd]:# (flags/compact.txt $)

--- a/docs/components/query.md
+++ b/docs/components/query.md
@@ -66,7 +66,7 @@ However, for additional Thanos features, Thanos, on top of Prometheus adds
 
 ### Partial Response
 
-QueryAPI and StoreAPI has additional behaviour controlled via query parameter called [PartialResponseStrategy](../../pkg/store/storepb/rpc.pb.go).
+QueryAPI and StoreAPI has additional behaviour controlled via query parameter called [PartialResponseStrategy](/pkg/store/storepb/rpc.pb.go).
 
 This parameter controls tradeoff between accuracy and availability.
 
@@ -74,11 +74,11 @@ Partial response is a potentially missed result within query against QueryAPI or
 of StoreAPIs is returning error or timeout whereas couple of others returns success. It does not mean you are missing data,
 you might lucky enough that you actually get the correct data as the broken StoreAPI did not have anything for your query.
 
-If partial response happen QueryAPI returns human readable warnings explained [here](query.md#CustomResponseFields)
+If partial response happen QueryAPI returns human readable warnings explained [here](query.md#custom-response-fields).
 
-NOTE that having warning does not necessary means partial response (e.g no store matched query warning)
+NOTE: Having warning does not necessary means partial response (e.g no store matched query warning).
 
-See [this](query.md#PartialResponseStrategy) on how to control this behaviour.
+See [this](query.md#partial-response) on how to control this behaviour.
 
 Querier also allows to configure different timeouts:
 * `--query.timeout`
@@ -110,7 +110,7 @@ Max source resolution is max resolution in seconds we want to use for data we qu
 
 ### Partial Response Strategy
 
-// TODO(bwplotka): Update. This will change to "strategy" soon as [PartialResponseStrategy enum here](../../pkg/store/storepb/rpc.proto)
+// TODO(bwplotka): Update. This will change to "strategy" soon as [PartialResponseStrategy enum here](/pkg/store/storepb/rpc.proto)
 
 | HTTP URL/FORM parameter | Type | Default | Example |
 |----|----|----|----|

--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -6,7 +6,7 @@ menu: components
 
 # Rule (aka Ruler)
 
-_**NOTE:** It is recommended to keep deploying rules inside the relevant Prometheus servers locally. Use ruler only on specific cases. Read details [below](rule.md#Risk) why._
+_**NOTE:** It is recommended to keep deploying rules inside the relevant Prometheus servers locally. Use ruler only on specific cases. Read details [below](rule.md#risk) why._
 
 _The rule component should in particular not be used to circumvent solving rule deployment properly at the configuration management level._
 
@@ -17,7 +17,7 @@ Rule results are written back to disk in the Prometheus 2.0 storage format. Rule
 You can think of Rule as a simplified Prometheus that does not require a sidecar and does not scrape and do PromQL evaluation (no QueryAPI).
 
 The data of each Rule node can be labeled to satisfy the clusters labeling scheme. High-availability pairs can be run in parallel and should be distinguished by the designated replica label, just like regular Prometheus servers.
-Read more about Ruler in HA [here](rule.md#Ruler_HA)
+Read more about Ruler in HA [here](rule.md#ruler-ha)
 
 ```bash
 $ thanos rule \
@@ -45,7 +45,7 @@ unavailability is the key.
 
 ## Partial Response
 
-See [this](query.md#PartialResponse) on initial info.
+See [this](query.md#partial-response) on initial info.
 
 Rule allows you to specify rule groups with additional fields that control PartialResponseStrategy e.g:
 
@@ -82,20 +82,21 @@ indicate connection, incompatibility or misconfiguration problems.
 
 * `prometheus_rule_evaluation_failures_total`. If greater than 0, it means that that rule failed to be evaluated, which results in
 either gap in rule or potentially ignored alert. Alert heavily on this if this happens for longer than your alert thresholds.
-`strategy` label will tell you if failures comes from rules that tolerate [partial response](rule.md#PartialResponse) or not.
+`strategy` label will tell you if failures comes from rules that tolerate [partial response](rule.md#partial-response) or not.
 
 * `prometheus_rule_group_last_duration_seconds < prometheus_rule_group_interval_seconds`  If the difference is large, it means 
 that rule evaluation took more time than the scheduled interval. It can indicate that your query backend (e.g Querier) takes too much time 
 to evaluate the query, i.e. that it is not fast enough to fill the rule. This might indicate other problems like slow StoreAPis or 
 too complex query expression in rule. 
 
-* `thanos_rule_evaluation_with_warnings_total`. If you choose to use Rules and Alerts with [partial response strategy's](rule.md#PartialResponse)
+* `thanos_rule_evaluation_with_warnings_total`. If you choose to use Rules and Alerts with [partial response strategy's](rule.md#partial-response)
 value as "warn", this metric will tell you how many evaluation ended up with some kind of warning. To see the actual warnings
 see WARN log level. This might suggest that those evaluations return partial response and might not be accurate.
 
 Those metrics are important for vanilla Prometheus as well, but even more important when we rely on (sometimes WAN) network.
 
 // TODO(bwplotka): Rereview them after recent changes in metrics.
+
 See [alerts](/examples/alerts/alerts.md#Ruler) for more example alerts for ruler. 
 
 NOTE: It is also recommended to set a mocked Alert on Ruler that checks if Query is up. This might be something simple like `vector(1)` query, just

--- a/docs/components/sidecar.md
+++ b/docs/components/sidecar.md
@@ -42,8 +42,6 @@ config:
   bucket: example-bucket
 ```
 
-## Deployment
-
 ## Flags
 
 [embedmd]:# (flags/sidecar.txt $)
@@ -151,7 +149,6 @@ Flags:
                                  Object store configuration in YAML.
 
 ```
-
 
 ## Reloader Configuration
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -26,7 +26,6 @@ config:
 
 In general about 1MB of local disk space is required per TSDB block stored in the object storage bucket.
 
-## Deployment
 ## Flags
 
 [embedmd]:# (flags/store.txt $)

--- a/docs/contributing/how-to-contribute-to-docs.md
+++ b/docs/contributing/how-to-contribute-to-docs.md
@@ -26,7 +26,6 @@ type: ...
 weight: <weight>
 menu: <where to link files in>  # This also is refered in permalinks.
 ---
-
 ```
 
 ## Links
@@ -34,15 +33,13 @@ menu: <where to link files in>  # This also is refered in permalinks.
 Aim is to match linking behavior in website being THE SAME as Github. This means:
 
 * For files in Hugo <content> dir (so `./docs`). Put `slug: /<filename with extension>`
-* For any sub dir add to `website/hugo.yaml` new dir as key  `permalinks:` with `<dir>: /<dir>/:filname.md`
+* For any sub dir add to `website/hugo.yaml` new dir as key `permalinks:` with `<dir>: /<dir>/:filename.md`
 
-Then everywhere use native markdown *relative* symbolic links if you want to reference some mardkown file from `docs`:
+Then everywhere use native markdown absolute path to the project repository if you want to link to exact commit e.g:
 
-`[title]( relative path to .md file )`
-
-Or absolute path to the project repository if you want to link to exact commit e.g:
-
-`[title]( /Makefile )`
+```
+[title](/Makefile)
+```
 
 Small [post processing script](/scripts/websitepreprocess.sh) adjusts link for Hugo rendering.
 
@@ -72,13 +69,14 @@ Requirements for the company:
 * it is happy to announce that you use Thanos publicly
 
 If all those are met, add yourself in [`website/data/sponsors.yml`](/website/data/sponsors.yml) like so:
+
 ```yml
 - name: My Awesome Company
   url: https://wwww.company.com
   logo: company.png
 ```
 
-Copy your company's logo in [`/website/static/logos`](/website/static/logos), make sure it follows these rules:
+Copy your company's logo in [`website/static/logos`](/website/static/logos), make sure it follows these rules:
 
 * Rectangle shape
 * Greyscale is preferred but color is fine
@@ -88,14 +86,25 @@ and create PR against Thanos `master` branch.
 
 ## Testing
 
-Every PR is building website and on success it shows the link to preview.
+### PR testing
 
-## Deployment.
+On every PR we build the website and on success display the link to the preview under the checks at the bottom of the github PR.
+
+### Local testing
+
+To test the changes to the docs locally just start serving the website by running the following command and you will be able to access the website on `localhost:1313` by default:
+
+```bash
+make web-serve
+```
+
+## Deployment
 
 We use [Netlify](https://www.netlify.com/) for hosting. We are using Open Source license (PRO). Thanks Netlify for this!
 
-On every commit to `master` netlify runs CI that invokes `make web` (defined in [netlify.toml](https://github.com/improbable-eng/thanos/blob/master/netlify.toml)))
+On every commit to `master` netlify runs CI that invokes `make web` (defined in [netlify.toml](/netlify.toml))
 
 NOTE: Check for status badge in README for build status on the page.
 
 If master build for netlify succeed, the new content is published automatically.
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,7 @@ The `thanos` binary should now be in your `$PATH` and is the only thing required
 
 You may meet below error:
 
-```
+```bash
 go: verifying github.com/grpc-ecosystem/go-grpc-middleware@v1.0.0: checksum mismatch
     downloaded: h1:BWIsLfhgKhV5g/oF34aRjniBHLTZe5DNekSjbAjIS6c=
     go.sum:     h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
@@ -63,9 +63,7 @@ If your `golang` version is below `1.11.4`, highly recommend you upgrade to `1.1
 
 Thanos bases itself on vanilla [Prometheus](https://prometheus.io/) (v2.2.1+).
 
-Here's the Prometheus' versions Thanos is tested against:
-
-[Makefile](/Makefile#35)
+To find out the Prometheus' versions Thanos is tested against, look at the value of the `PROM_VERSIONS` variable in the [Makefile](/Makefile).
 
 ## Components
 
@@ -103,14 +101,14 @@ Rolling this out has little to zero impact on the running Prometheus instance. I
 
 If you are not interested in backing up any data, the `--objstore.config-file` flag can simply be omitted.
 
-* _[Example Kubernetes manifest](https://github.com/improbable-eng/thanos/tree/master/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml)_
-* _[Example Kubernetes manifest with Minio upload](https://github.com/improbable-eng/thanos/tree/master/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml)_
-* _[Example Deploying sidecar using official Prometheus Helm Chart](https://github.com/improbable-eng/thanos/tree/master/tutorials/kubernetes-helm/README.md)_
+* _[Example Kubernetes manifest](/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml)_
+* _[Example Kubernetes manifest with Minio upload](/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml)_
+* _[Example Deploying sidecar using official Prometheus Helm Chart](/tutorials/kubernetes-helm/README.md)_
 * _[Details & Config for other object stores](storage.md)_
 
 #### Store API
 
-The Sidecar component implements and exposes a gRPC _[Store API](https://github.com/improbable-eng/thanos/tree/master/pkg/store/storepb/rpc.proto#L19)_. The sidecar implementation allows you to query the metric data stored in Prometheus.
+The Sidecar component implements and exposes a gRPC _[Store API](/pkg/store/storepb/rpc.proto#L19)_. The sidecar implementation allows you to query the metric data stored in Prometheus.
 
 Let's extend the Sidecar in the previous section to connect to a Prometheus server, and expose the Store API.
 
@@ -123,8 +121,8 @@ thanos sidecar \
     --grpc-address              0.0.0.0:19090              # GRPC endpoint for StoreAPI
 ```
 
-* _[Example Kubernetes manifest](https://github.com/improbable-eng/thanos/tree/master/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml)_
-* _[Example Kubernetes manifest with GCS upload](https://github.com/improbable-eng/thanos/tree/master/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml)_
+* _[Example Kubernetes manifest](/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml)_
+* _[Example Kubernetes manifest with GCS upload](/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml)_
 
 #### External Labels
 
@@ -189,7 +187,7 @@ thanos query \
 
 Go to the configured HTTP address, and you should now be able to query across all Prometheus instances and receive de-duplicated data.
 
-* _[Example Kubernetes manifest](https://github.com/improbable-eng/thanos/tree/master/tutorials/kubernetes-demo/manifests/thanos-querier.yaml)_
+* _[Example Kubernetes manifest](/tutorials/kubernetes-demo/manifests/thanos-querier.yaml)_
 
 #### Communication Between Components
 
@@ -210,8 +208,8 @@ thanos query \
 
 Read more details [here](service-discovery.md).
 
-* _[Example Kubernetes manifest](https://github.com/improbable-eng/thanos/tree/master/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml)_
-* _[Example Kubernetes manifest with GCS upload](https://github.com/improbable-eng/thanos/tree/master/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml)_
+* _[Example Kubernetes manifest](/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar.yaml)_
+* _[Example Kubernetes manifest with GCS upload](/tutorials/kubernetes-demo/manifests/prometheus-ha-sidecar-lts.yaml)_
 
 ### [Store Gateway](components/store.md)
 
@@ -229,7 +227,7 @@ thanos store \
 
 The store gateway occupies small amounts of disk space for caching basic information about data in the object storage. This will rarely exceed more than a few gigabytes and is used to improve restart times. It is useful but not required to preserve it across restarts.
 
-* _[Example Kubernetes manifest](https://github.com/improbable-eng/thanos/tree/master/tutorials/kubernetes-demo/manifests/thanos-store-gateway.yaml)_
+* _[Example Kubernetes manifest](/tutorials/kubernetes-demo/manifests/thanos-store-gateway.yaml)_
 
 ### [Compactor](components/compact.md)
 
@@ -261,4 +259,4 @@ TBD
 
 Thanos also has a tutorial on deploying it to Kubernetes. We have a full page describing a standard deployment here.
 
-We also have example Grafana dashboards [here](https://github.com/improbable-eng/thanos/tree/master/examples/grafana/monitoring.md) and some [alerts](https://github.com/improbable-eng/thanos/tree/master/examples/alerts/alerts.md) to get you started.
+We also have example Grafana dashboards [here](/examples/grafana/monitoring.md) and some [alerts](/examples/alerts/alerts.md) to get you started.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -7,7 +7,7 @@ slug: /storage.md
 
 # Object Storage
 
-Thanos supports any object stores that can be implemented against Thanos [objstore.Bucket interface](https://github.com/improbable-eng/thanos/pkg/objstore/objstore.go)
+Thanos supports any object stores that can be implemented against Thanos [objstore.Bucket interface](/pkg/objstore/objstore.go)
 
 All clients are configured using `--objstore.config-file` to reference to the configuration file or `--objstore.config` to put yaml config directly.
 
@@ -28,14 +28,14 @@ NOTE: Currently Thanos requires strong consistency (write-read) for object store
 ## How to add a new client?
 
 1. Create new directory under `pkg/objstore/<provider>`
-2. Implement [objstore.Bucket interface](https://github.com/improbable-eng/thanos/pkg/objstore/objstore.go)
+2. Implement [objstore.Bucket interface](/pkg/objstore/objstore.go)
 3. Add `NewTestBucket` constructor for testing purposes, that creates and deletes temporary bucket.
-4. Use created `NewTestBucket` in [ForeachStore method](https://github.com/improbable-eng/thanos/pkg/objstore/objtesting/foreach.go) to ensure we can run tests against new provider. (In PR)
-5. RUN the [TestObjStoreAcceptanceTest](https://github.com/improbable-eng/thanos/pkg/objstore/objtesting/acceptance_e2e_test.go) against your provider to ensure it fits. Fix any found error until test passes. (In PR)
-6. Add client implementation to the factory in [factory](https://github.com/improbable-eng/thanos/pkg/objstore/client/factory.go) code. (Using as small amount of flags as possible in every command)
-7. Add client struct config to [bucketcfggen](https://github.com/improbable-eng/thanos/scripts/bucketcfggen/main.go) to allow config auto generation.
+4. Use created `NewTestBucket` in [ForeachStore method](/pkg/objstore/objtesting/foreach.go) to ensure we can run tests against new provider. (In PR)
+5. RUN the [TestObjStoreAcceptanceTest](/pkg/objstore/objtesting/acceptance_e2e_test.go) against your provider to ensure it fits. Fix any found error until test passes. (In PR)
+6. Add client implementation to the factory in [factory](/pkg/objstore/client/factory.go) code. (Using as small amount of flags as possible in every command)
+7. Add client struct config to [bucketcfggen](/scripts/bucketcfggen/main.go) to allow config auto generation.
 
-At that point, anyone can use your provider by spec
+At that point, anyone can use your provider by spec.
 
 ## AWS S3 configuration
 

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,7 @@ github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c h1:Ho+uVpke
 github.com/smartystreets/goconvey v0.0.0-20181108003508-044398e4856c/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/scripts/websitepreprocess.sh
+++ b/scripts/websitepreprocess.sh
@@ -64,8 +64,8 @@ EOT
 
 done
 
-# 3. All the absolute links needs are directly linking github with the given commit.
-perl -pi -e 's/]\(\//]\(https:\/\/github.com\/improbable-eng\/thanos\/tree\/'${COMMIT_SHA}'\/docs\//' ${ALL_DOC_CONTENT_FILES}
+# 3. All the absolute links are replaced with a direct link to the file on github, including the current commit SHA.
+perl -pi -e 's/]\(\//]\(https:\/\/github.com\/improbable-eng\/thanos\/tree\/'${COMMIT_SHA}'\//' ${ALL_DOC_CONTENT_FILES}
 
 # 4. All the relative links needs to have ../  This is because Hugo is missing: https://github.com/gohugoio/hugo/pull/3934
 perl -pi -e 's/]\(\.\//]\(..\//' ${ALL_DOC_CONTENT_FILES}


### PR DESCRIPTION


## Changes:

- Up to now, all the relative links were replaced in the `scripts/websitepreprocess.sh` by generating the URL for the website to correctly parse the links, that always added the `/docs/` dir in the path, which did not work for some of them (e.g. Makefile link below) as they were located outside of that directory. 
- Added small doc note on how to run the website locally, let me know if that is useful? Saves a small amount of time for not needing to go look at the Makefile :)
- Some other small cleanups.
- The `go.sum` change was automatic when I ran `go mod vendor`, but can remove it if you are getting a different result. 🤷‍♀ 

## Verification

Tested all the links and they resolve both in markdown on github and by running the website locally. 

As a side note/question, there are some tools out there that can be added as part of the CI process to test the links and make sure they are valid.

---
p.s. Great docs! <3 