### PR TITLE
Propagate retriable/haltable errors from compactor

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -285,9 +285,9 @@ func runCompact(
 			if err == nil {
 				return nil
 			}
+
 			// The HaltError type signals that we hit a critical bug and should block
-			// for investigation.
-			// You should alert on this being halted.
+			// for investigation. You should alert on this being halted.
 			if compact.IsHaltError(err) {
 				if haltOnError {
 					level.Error(logger).Log("msg", "critical error detected; halting", "err", err)
@@ -299,7 +299,7 @@ func runCompact(
 			}
 
 			// The RetryError signals that we hit an retriable error (transient error, no connection).
-			// You should alert on this being triggered to frequently.
+			// You should alert on this being triggered too frequently.
 			if compact.IsRetryError(err) {
 				level.Error(logger).Log("msg", "retriable error", "err", err)
 				retried.Inc()

--- a/pkg/compact/compact.go
+++ b/pkg/compact/compact.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/tsdb"
+	terrors "github.com/prometheus/tsdb/errors"
 	"github.com/prometheus/tsdb/labels"
 )
 
@@ -613,7 +614,7 @@ func (e HaltError) Error() string {
 // IsHaltError returns true if the base error is a HaltError.
 // If a multierror is passed, any halt error will return true.
 func IsHaltError(err error) bool {
-	if multiErr, ok := err.(tsdb.MultiError); ok {
+	if multiErr, ok := err.(terrors.MultiError); ok {
 		for _, err := range multiErr {
 			if _, ok := errors.Cause(err).(HaltError); ok {
 				return true
@@ -646,7 +647,7 @@ func (e RetryError) Error() string {
 // IsRetryError returns true if the base error is a RetryError.
 // If a multierror is passed, all errors must be retriable.
 func IsRetryError(err error) bool {
-	if multiErr, ok := err.(tsdb.MultiError); ok {
+	if multiErr, ok := err.(terrors.MultiError); ok {
 		for _, err := range multiErr {
 			if _, ok := errors.Cause(err).(RetryError); !ok {
 				return false
@@ -1055,7 +1056,7 @@ func (c *BucketCompactor) Compact(ctx context.Context) error {
 		close(errChan)
 		workCtxCancel()
 		if err != nil {
-			errs := tsdb.MultiError{err}
+			errs := terrors.MultiError{err}
 			// Collect any other errors reported by the workers.
 			for e := range errChan {
 				errs.Add(e)

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
-	"github.com/prometheus/tsdb"
+	terrors "github.com/prometheus/tsdb/errors"
 )
 
 func TestHaltError(t *testing.T) {
@@ -32,7 +32,7 @@ func TestHaltMultiError(t *testing.T) {
 	haltErr := halt(errors.New("halt error"))
 	nonHaltErr := errors.New("not a halt error")
 
-	errs := tsdb.MultiError{nonHaltErr}
+	errs := terrors.MultiError{nonHaltErr}
 	testutil.Assert(t, !IsHaltError(errs), "should not be a halt error")
 
 	errs.Add(haltErr)
@@ -43,13 +43,13 @@ func TestRetryMultiError(t *testing.T) {
 	retryErr := retry(errors.New("retry error"))
 	nonRetryErr := errors.New("not a retry error")
 
-	errs := tsdb.MultiError{nonRetryErr}
+	errs := terrors.MultiError{nonRetryErr}
 	testutil.Assert(t, !IsRetryError(errs), "should not be a retry error")
 
-	errs = tsdb.MultiError{retryErr}
+	errs = terrors.MultiError{retryErr}
 	testutil.Assert(t, IsRetryError(errs), "if all errors are retriable this should return true")
 
-	errs = tsdb.MultiError{nonRetryErr, retryErr}
+	errs = terrors.MultiError{nonRetryErr, retryErr}
 	testutil.Assert(t, !IsRetryError(errs), "mixed errors should return false")
 }
 

--- a/pkg/compact/compact_test.go
+++ b/pkg/compact/compact_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/testutil"
 	"github.com/oklog/ulid"
 	"github.com/pkg/errors"
+	"github.com/prometheus/tsdb"
 )
 
 func TestHaltError(t *testing.T) {
@@ -25,6 +26,31 @@ func TestHaltError(t *testing.T) {
 
 	err = errors.Wrap(errors.Wrap(halt(errors.New("test")), "something"), "something2")
 	testutil.Assert(t, IsHaltError(err), "not a halt error")
+}
+
+func TestHaltMultiError(t *testing.T) {
+	haltErr := halt(errors.New("halt error"))
+	nonHaltErr := errors.New("not a halt error")
+
+	errs := tsdb.MultiError{nonHaltErr}
+	testutil.Assert(t, !IsHaltError(errs), "should not be a halt error")
+
+	errs.Add(haltErr)
+	testutil.Assert(t, IsHaltError(errs), "if any halt errors are present this should return true")
+}
+
+func TestRetryMultiError(t *testing.T) {
+	retryErr := retry(errors.New("retry error"))
+	nonRetryErr := errors.New("not a retry error")
+
+	errs := tsdb.MultiError{nonRetryErr}
+	testutil.Assert(t, !IsRetryError(errs), "should not be a retry error")
+
+	errs = tsdb.MultiError{retryErr}
+	testutil.Assert(t, IsRetryError(errs), "if all errors are retriable this should return true")
+
+	errs = tsdb.MultiError{nonRetryErr, retryErr}
+	testutil.Assert(t, !IsRetryError(errs), "mixed errors should return false")
 }
 
 func TestRetryError(t *testing.T) {


### PR DESCRIPTION
## Changes

We observed thanos compactor was exiting on upload errors. Previously, a new 
error was created from all worker errors so the custom type was not propagated.
This introduces `go-multierror` to preserve the error types.

If all errors returned are retriable, it is safe to retry the compaction.

Since the compactor may still return a single error this logic is preserved.

(Happy to refactor out the duplicated logic with individual error checks.)

## Verification

Tests are passing and I'll run this change with real workloads shortly.