### PR TITLE
thanos/downsample: pass pointer-to-struct to Unmarshal

### DIFF
--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -127,7 +127,7 @@ func downsampleBucket(
 			return errors.Wrap(err, "read meta")
 		}
 
-		if err = json.Unmarshal(obj, m); err != nil {
+		if err = json.Unmarshal(obj, &m); err != nil {
 			return errors.Wrap(err, "unmarshal meta")
 		}
 


### PR DESCRIPTION
`json.Unmarshal` expects a pointer as the second argument. Fix it by
adding a missing '&'.

Fixes #1181.