### PR TITLE
correct service-discovery.md bullet points

### DIFF
--- a/docs/service-discovery.md
+++ b/docs/service-discovery.md
@@ -10,6 +10,7 @@ slug: /service-discovery.md
 Service discovery has a vital place in Thanos components. It allows Thanos to discover different set API targets required to perform certain operations.
 
 Currently places that uses Thanos SD:
+
 * `Thanos Query` needs to know about [StoreAPI](https://github.com/improbable-eng/thanos/blob/d3fb337da94d11c78151504b1fccb1d7e036f394/pkg/store/storepb/rpc.proto#L14) servers in order to query metrics from them.
 * `Thanos Rule` needs to know about `QueryAPI` servers in order to evaluate recording and alerting rules.
 * (Only static option with DNS discovery): `Thanos Rule` needs to know about `Alertmanagers` HA replicas in order to send alerts.


### PR DESCRIPTION
## Changes
The site is rendering the bullet points incorrectly.  Adding a space before them should correct the issue.

## Verification
I am unable to verify this directly, but it appears you are using Hugo, and this is a known issue for Hugo.