### PR TITLE
Create jsonnet based kubernetes manifests

### DIFF
--- a/jsonnet/.gitignore
+++ b/jsonnet/.gitignore
@@ -1,0 +1,1 @@
+thanos/vendor/

--- a/jsonnet/thanos/jsonnetfile.json
+++ b/jsonnet/thanos/jsonnetfile.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        {
+            "name": "ksonnet",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/ksonnet/ksonnet-lib",
+                    "subdir": ""
+                }
+            },
+            "version": "master"
+        }
+    ]
+}

--- a/jsonnet/thanos/jsonnetfile.lock.json
+++ b/jsonnet/thanos/jsonnetfile.lock.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        {
+            "name": "ksonnet",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/ksonnet/ksonnet-lib",
+                    "subdir": ""
+                }
+            },
+            "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f"
+        }
+    ]
+}

--- a/jsonnet/thanos/kubernetes-pvc.libsonnet
+++ b/jsonnet/thanos/kubernetes-pvc.libsonnet
@@ -1,0 +1,48 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+
+{
+  _config+:: {
+    store+: {
+      pvc+: {
+        class: 'standard',
+        size: '10Gi',
+      },
+    },
+  },
+
+  thanos+:: {
+    store+: {
+      statefulSet+:
+        local sts = k.apps.v1.statefulSet;
+        local pvc = sts.mixin.spec.volumeClaimTemplatesType;
+
+        {
+          spec+: {
+            template+: {
+              spec+: {
+                volumes: [],
+              },
+            },
+            volumeClaimTemplates: [
+              {
+                metadata: {
+                  name: 'data',
+                },
+                spec: {
+                  accessModes: [
+                    'ReadWriteOnce',
+                  ],
+                  storageClassName: $._config.store.pvc.class,
+                  resources: {
+                    requests: {
+                      storage: $._config.store.pvc.size,
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+    },
+  },
+}

--- a/jsonnet/thanos/kubernetes-querier.libsonnet
+++ b/jsonnet/thanos/kubernetes-querier.libsonnet
@@ -1,0 +1,59 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+
+{
+  _config+:: {
+    querier+: {
+      name: 'thanos-querier',
+      labels: { app: $._config.querier.name },
+      ports: {
+        grpc: 10901,
+        http: 10902,
+      },
+    },
+  },
+
+  thanos+:: {
+    querier+: {
+      service:
+        local service = k.core.v1.service;
+        local ports = service.mixin.spec.portsType;
+
+        service.new(
+          $._config.querier.name,
+          $._config.querier.labels,
+          [
+            ports.newNamed('grpc', $._config.querier.ports.grpc, $._config.querier.ports.grpc),
+            ports.newNamed('http', 9090, $._config.querier.ports.http),
+          ]
+        ) +
+        service.mixin.metadata.withNamespace($._config.namespace) +
+        service.mixin.metadata.withLabels($._config.querier.labels),
+
+      deployment:
+        local deployment = k.apps.v1.deployment;
+        local container = deployment.mixin.spec.template.spec.containersType;
+
+        local args = [
+          'query',
+          '--query.replica-label=replica',
+        ] + [
+          '--store=%s-%d.%s.svc.cluster.local:%d' % [
+            $.thanos.store.service.metadata.name,
+            i,
+            $._config.namespace,
+            $._config.store.ports.grpc,
+          ]
+          for i in std.range(0, $._config.store.replicas - 1)
+        ];
+
+
+        local c =
+          container.new($._config.querier.name, $._config.images.thanos) +
+          container.withArgs(args);
+
+        deployment.new($._config.querier.name, 1, c, $._config.querier.labels) +
+        deployment.mixin.metadata.withNamespace($._config.namespace) +
+        deployment.mixin.spec.selector.withMatchLabels($._config.querier.labels),
+    },
+  },
+}

--- a/jsonnet/thanos/kubernetes-store.libsonnet
+++ b/jsonnet/thanos/kubernetes-store.libsonnet
@@ -1,0 +1,72 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+
+{
+  _config+:: {
+    store+: {
+      name: 'thanos-store',
+      replicas: 1,
+      labels: { app: $._config.store.name },
+      ports: {
+        grpc: 10901,
+      },
+    },
+  },
+
+  thanos+:: {
+    store: {
+      service:
+        local service = k.core.v1.service;
+        local ports = service.mixin.spec.portsType;
+
+        service.new(
+          $._config.store.name,
+          $._config.store.labels,
+          [
+            ports.newNamed('grpc', $._config.store.ports.grpc, $._config.store.ports.grpc),
+          ]
+        ) +
+        service.mixin.metadata.withNamespace($._config.namespace) +
+        service.mixin.metadata.withLabels($._config.store.labels) +
+        service.mixin.spec.withClusterIp('None'),
+
+      statefulSet:
+        local sts = k.apps.v1.statefulSet;
+        local volume = sts.mixin.spec.template.spec.volumesType;
+        local container = sts.mixin.spec.template.spec.containersType;
+        local containerEnv = container.envType;
+        local containerVolumeMount = container.volumeMountsType;
+
+
+        local c =
+          container.new($._config.store.name, $._config.images.thanos) +
+          container.withArgs([
+            'store',
+            '--data-dir=/var/thanos/store',
+            '--objstore.config=$(OBJSTORE_CONFIG)',
+          ]) +
+          container.withEnv([
+            containerEnv.fromSecretRef(
+              'OBJSTORE_CONFIG',
+              $._config.thanos.objectStorageConfig.name,
+              $._config.thanos.objectStorageConfig.key,
+            ),
+          ]) +
+          container.withPorts([
+            { name: 'grpc', containerPort: 10901 },
+            { name: 'http', containerPort: 10902 },
+          ]) +
+          container.withVolumeMounts([
+            containerVolumeMount.new('data', '/var/thanos/store', false),
+          ]);
+
+        sts.new($._config.store.name, $._config.store.replicas, c, [], $._config.store.labels) +
+        sts.mixin.metadata.withNamespace($._config.namespace) +
+        sts.mixin.metadata.withLabels($._config.store.labels) +
+        sts.mixin.spec.withServiceName($.thanos.store.service.metadata.name) +
+        sts.mixin.spec.selector.withMatchLabels($._config.store.labels) +
+        sts.mixin.spec.template.spec.withVolumes([
+          volume.fromEmptyDir('data'),
+        ]),
+    },
+  },
+}

--- a/jsonnet/thanos/kubernetes.libsonnet
+++ b/jsonnet/thanos/kubernetes.libsonnet
@@ -1,0 +1,34 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+
+local thanos =
+  (import 'kubernetes-querier.libsonnet') +
+  (import 'kubernetes-store.libsonnet') +
+  (import 'kubernetes-pvc.libsonnet') +
+  {
+    _config+:: {
+      namespace: 'thanos',
+
+      images+: {
+        thanos: 'improbable/thanos:v0.5.0-rc.0',
+      },
+
+      thanos+: {
+        // MAKE SURE TO CREATE THE SECRET FIRST
+        objectStorageConfig+: {
+          name: 'thanos-objectstorage',
+          key: 'thanos.yaml',
+        },
+      },
+
+      store+:{
+        replicas: 3,
+      },
+    },
+  };
+
+k.core.v1.list.new([
+  thanos.thanos.querier.service,
+  thanos.thanos.querier.deployment,
+  thanos.thanos.store.service,
+  thanos.thanos.store.statefulSet,
+])

--- a/jsonnet/thanos/kubernetes.yaml
+++ b/jsonnet/thanos/kubernetes.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: thanos-querier
+    name: thanos-querier
+    namespace: thanos
+  spec:
+    ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    - name: http
+      port: 9090
+      targetPort: 10902
+    selector:
+      app: thanos-querier
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: thanos-querier
+    namespace: thanos
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: thanos-querier
+    template:
+      metadata:
+        labels:
+          app: thanos-querier
+      spec:
+        containers:
+        - args:
+          - query
+          - --query.replica-label=replica
+          - --store=thanos-store-0.thanos.svc.cluster.local:10901
+          - --store=thanos-store-1.thanos.svc.cluster.local:10901
+          - --store=thanos-store-2.thanos.svc.cluster.local:10901
+          image: improbable/thanos:v0.5.0-rc.0
+          name: thanos-querier
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: thanos-store
+    name: thanos-store
+    namespace: thanos
+  spec:
+    clusterIP: None
+    ports:
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    selector:
+      app: thanos-store
+- apiVersion: apps/v1
+  kind: StatefulSet
+  metadata:
+    labels:
+      app: thanos-store
+    name: thanos-store
+    namespace: thanos
+  spec:
+    replicas: 3
+    selector:
+      matchLabels:
+        app: thanos-store
+    serviceName: thanos-store
+    template:
+      metadata:
+        labels:
+          app: thanos-store
+      spec:
+        containers:
+        - args:
+          - store
+          - --data-dir=/var/thanos/store
+          - --objstore.config=$(OBJSTORE_CONFIG)
+          env:
+          - name: OBJSTORE_CONFIG
+            valueFrom:
+              secretKeyRef:
+                key: thanos.yaml
+                name: thanos-objectstorage
+          image: improbable/thanos:v0.5.0-rc.0
+          name: thanos-store
+          ports:
+          - containerPort: 10901
+            name: grpc
+          - containerPort: 10902
+            name: http
+          volumeMounts:
+          - mountPath: /var/thanos/store
+            name: data
+            readOnly: false
+        volumes: []
+    volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+        storageClassName: standard
+kind: List


### PR DESCRIPTION
This is an extensible approach to configuration management. You start
off with a querier only. Then you can add stores and PVCs as you like.

I've also added a generate YAML file containing everything to deploy:
`jsonnet/thanos/kubernetes.yaml`. This should probably be removed before we want to merge.

TODOs:
* [ ] Make the headless service for Thanos Store actually work
* [ ] Maybe add example Prometheus so that we could see data

/cc @bwplotka @brancz @gouthamve @aditya-konarde @squat