### PR TITLE
pkg/receive: remove deadlock on interrupt

### DIFF
--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -233,16 +233,12 @@ func runReceive(
 
 	level.Debug(logger).Log("msg", "setting up receive http handler")
 	{
-		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(
 			func() error {
-				if err := webHandler.Run(ctx); err != nil {
-					return fmt.Errorf("error starting web server: %s", err)
-				}
-				return nil
+				return errors.Wrap(webHandler.Run(), "error starting web server")
 			},
 			func(err error) {
-				cancel()
+				webHandler.Close()
 			},
 		)
 	}


### PR DESCRIPTION
## Changes

Currently, the receive component blocks indefinitely when the Thanos
process is interrupted because the given context is not actually used
to stop the server.

* This change adjusts the receive Handler struct to quit on context done.
* Remove unused quit chan

## Verification

* start the receive component;
* send SIGINT
* verify that before the change the process does not exit
* verify that after fix process does exit

cc @brancz @bwplotka 