### PR TITLE
bucket: inspect help message

### DIFF
--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -236,8 +236,8 @@ func registerBucketLs(m map[string]setupFunc, root *kingpin.CmdClause, name stri
 
 func registerBucketInspect(m map[string]setupFunc, root *kingpin.CmdClause, name string, objStoreConfig *pathOrContent) {
 	cmd := root.Command("inspect", "Inspect all blocks in the bucket in detailed, table-like way")
-	selector := cmd.Flag("selector", "Selects blocks based on label, e.g. '-l key1=\"value1\" -l key2=\"value2\"'. All key value pairs must match.").Short('l').
-		PlaceHolder("<name>=\"<value>\"").Strings()
+	selector := cmd.Flag("selector", "Selects blocks based on label, e.g. '-l key1=\\\"value1\\\" -l key2=\\\"value2\\\"'. All key value pairs must match.").Short('l').
+		PlaceHolder("<name>=\\\"<value>\\\"").Strings()
 	sortBy := cmd.Flag("sort-by", "Sort by columns. It's also possible to sort by multiple columns, e.g. '--sort-by FROM --sort-by UNTIL'. I.e., if the 'FROM' value is equal the rows are then further sorted by the 'UNTIL' value.").
 		Default("FROM", "UNTIL").Enums(inspectColumns...)
 

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -196,9 +196,9 @@ Flags:
       --objstore.config=<bucket.config-yaml>
                              Alternative to 'objstore.config-file' flag. Object
                              store configuration in YAML.
-  -l, --selector=<name>="<value>" ...
+  -l, --selector=<name>=\"<value>\" ...
                              Selects blocks based on label, e.g. '-l
-                             key1="value1" -l key2="value2"'. All key value
+                             key1=\"value1\" -l key2=\"value2\"'. All key value
                              pairs must match.
       --sort-by=FROM... ...  Sort by columns. It's also possible to sort by
                              multiple columns, e.g. '--sort-by FROM --sort-by


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
thanos bucket inspect --help
```
  -l, --selector=<name>="<value>" ...
                             Selects blocks based on label, e.g. '-l key1="value1" -l key2="value2"'. All key value pairs must match.
```
must be:
```
  -l, --selector=<name>=\"<value>\" ...
                             Selects blocks based on label, e.g. '-l key1=\"value1\" -l key2=\"value2\"'. All key value pairs must match.
```

I also updated the docs.

## Changes
* add backslashes to bucket inspect help message
* add backslashes to bucket inspect docs 

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->