### PR TITLE
Object Storage: Support Alibaba cloud OSS provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
             echo "Skipping Azure tests."
             export THANOS_SKIP_SWIFT_TESTS="true"
             echo "Skipping SWIFT tests."
+            export THANOS_SKIP_ALIBABA_OSS_TESTS="true"
+            echo "Skipping ALIBABA OSS tests."
             export THANOS_SKIP_TENCENT_COS_TESTS="true"
             echo "Skipping TENCENT COS tests."
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,11 @@ $ git push origin <your_branch_for_new_pr>
 - THANOS_SKIP_S3_AWS_TESTS to skip AWS tests.
 - THANOS_SKIP_AZURE_TESTS to skip Azure tests.
 - THANOS_SKIP_SWIFT_TESTS to skip SWIFT tests.
+- THANOS_SKIP_ALIBABA_OSS_TESTS to skip Alibaba OSS tests.
 - THANOS_SKIP_TENCENT_COS_TESTS to skip Tencent COS tests.
 
 If you skip all of these, the store specific tests will be run against memory object storage only.
-CI runs GCS and inmem tests only for now. Not having these variables will produce auth errors against GCS, AWS, Azure or COS tests.
+CI runs GCS and inmem tests only for now. Not having these variables will produce auth errors against GCS, AWS, Azure, OSS or COS tests.
 
 6. If your change affects users (adds or removes feature) consider adding the item to [CHANGELOG](CHANGELOG.md)
 7. You may merge the Pull Request in once you have the sign-off of at least one developers with write access, or if you

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ tarballs-release: $(PROMU)
 # test runs all Thanos golang tests against each supported version of Prometheus.
 .PHONY: test
 test: check-git test-deps
-	@echo ">> running all tests. Do export THANOS_SKIP_GCS_TESTS='true' or/and THANOS_SKIP_S3_AWS_TESTS='true' or/and THANOS_SKIP_AZURE_TESTS='true' and/or THANOS_SKIP_SWIFT_TESTS='true' and/or THANOS_SKIP_TENCENT_COS_TESTS='true' if you want to skip e2e tests against real store buckets"
+	@echo ">> running all tests. Do export THANOS_SKIP_GCS_TESTS='true' or/and THANOS_SKIP_S3_AWS_TESTS='true' or/and THANOS_SKIP_ALIBABA_OSS_TESTS='true' or/and THANOS_SKIP_AZURE_TESTS='true' and/or THANOS_SKIP_SWIFT_TESTS='true' and/or THANOS_SKIP_TENCENT_COS_TESTS='true' if you want to skip e2e tests against real store buckets"
 	THANOS_TEST_PROMETHEUS_VERSIONS="$(PROM_VERSIONS)" THANOS_TEST_ALERTMANAGER_PATH="alertmanager-$(ALERTMANAGER_VERSION)" go test $(shell go list ./... | grep -v /vendor/ | grep -v /benchmark/);
 
 # test-deps installs dependency for e2e tets.

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -22,7 +22,7 @@ import (
 
 // registerStore registers a store command.
 func registerStore(m map[string]setupFunc, app *kingpin.Application, name string) {
-	cmd := app.Command(name, "store node giving access to blocks in a bucket provider. Now supported GCS, S3, Azure, Swift and Tencent COS.")
+	cmd := app.Command(name, "store node giving access to blocks in a bucket provider. Now supported GCS, S3, Azure, Swift, Alibaba OSS and Tencent COS.")
 
 	grpcBindAddr, httpBindAddr, cert, key, clientCA := regCommonServerFlags(cmd)
 

--- a/docs/components/store.md
+++ b/docs/components/store.md
@@ -33,7 +33,7 @@ In general about 1MB of local disk space is required per TSDB block stored in th
 usage: thanos store [<flags>]
 
 store node giving access to blocks in a bucket provider. Now supported GCS, S3,
-Azure, Swift and Tencent COS.
+Azure, Swift, Alibaba OSS and Tencent COS.
 
 Flags:
   -h, --help                     Show context-sensitive help (also try

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -302,11 +302,24 @@ Config file format is the following:
 ```yaml
 type: OSS
 config:
-  bucket: "<Your bucket name>"
-  endpoint: "<Endpoint to connect to>"
-  access_key: "Your access key id"
-  secret_key: "Your secret key id"
+  bucket: ""
+  endpoint: ""
+  access_key: ""
+  secret_key: ""
+  http_config:
+    enable_crc: false
+    connection_timeout: 0
+    read_write_timeout: 0
+    max_idle_connections: 0
+    max_idle_connections_per_host: 0
+  log_level: 0
 ```
+
+* `http_config.connection_timeout` Default value is 30, in seconds.
+* `http_config.read_write_timeout` Default value is 60, in seconds.
+* `http_config.max_idle_connections` Default value is 100.
+* `http_config.max_idle_connections_per_host` Default value is 100.
+* `log_level` Used for wrap log of oss go sdk. Error(1), Warn(2), Info(3), Debug(4), please view oss go sdk for more details.
 
 ## Tencent COS Configuration
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -21,6 +21,7 @@ Current object storage client implementations:
 | AWS S3               | Stable  (production usage)               | yes        | @bwplotka          |
 | Azure Storage Account | Stable  (production usage) | yes       | @vglafirov   |
 | OpenStack Swift      | Beta  (working PoCs, testing usage)               | no        | @sudhi-vm   |
+| Alibaba OSS          | Beta  (working PoCs, testing usage)               | no        | @wujinhu    |
 | Tencent COS          | Beta  (testing usage)                   | no        | @jojohappy          |
 
 NOTE: Currently Thanos requires strong consistency (write-read) for object store implementation.
@@ -288,6 +289,24 @@ config:
 ## Other minio supported S3 object storages
 
 Minio client used for AWS S3 can be potentially configured against other S3-compatible object storages.
+
+## Alibaba OSS Configuration
+
+Now, Thanos can use Alibaba Object Storage Service(OSS, [https://www.aliyun.com/product/oss](https://www.aliyun.com/product/oss)) as an storage store for Prometheus.
+
+You can configure an OSS bucket as an object store with YAML, either by passing the configuration directly to the `--objstore.config` parameter, or (preferably) by passing the path to a configuration file to the `--objstore.config-file` option.
+
+Config file format is the following:
+
+[embedmd]:# (flags/config_oss.txt yaml)
+```yaml
+type: OSS
+config:
+  bucket: "<Your bucket name>"
+  endpoint: "<Endpoint to connect to>"
+  access_key: "Your access key id"
+  secret_key: "Your secret key id"
+```
 
 ## Tencent COS Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ require (
 	cloud.google.com/go v0.34.0
 	github.com/Azure/azure-storage-blob-go v0.0.0-20181022225951-5152f14ace1c
 	github.com/NYTimes/gziphandler v1.1.1
+	github.com/aliyun/aliyun-oss-go-sdk v1.9.8
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
+	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/cespare/xxhash v1.1.0
 	github.com/fatih/structtag v1.0.0
 	github.com/fortytw2/leaktest v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -23,12 +23,16 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/aliyun/aliyun-oss-go-sdk v1.9.8 h1:BOflvK0Zs/zGmoabyFIzTg5c3kguktWTXEwewwbuba0=
+github.com/aliyun/aliyun-oss-go-sdk v1.9.8/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZFFEjBj46YV4rDjvGrNxb0KMWYkL2I=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v0.0.0-20180507225419-00862f899353/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
+github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
+github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -261,6 +265,7 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20161028232340-1d7be4effb13/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sasha-s/go-deadlock v0.0.0-20161201235124-341000892f3d/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
@@ -344,6 +349,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.0.0-20170424234030-8be79e1e0910 h1:bCMaBn7ph495H+x72gEvgcv+mDRd9dElbzo/mVCMxX4=
 golang.org/x/time v0.0.0-20170424234030-8be79e1e0910/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/objstore/client/factory.go
+++ b/pkg/objstore/client/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/objstore/azure"
 	"github.com/improbable-eng/thanos/pkg/objstore/cos"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
+	"github.com/improbable-eng/thanos/pkg/objstore/oss"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
 	"github.com/improbable-eng/thanos/pkg/objstore/swift"
 	"github.com/pkg/errors"
@@ -25,6 +26,7 @@ const (
 	S3    ObjProvider = "S3"
 	AZURE ObjProvider = "AZURE"
 	SWIFT ObjProvider = "SWIFT"
+	OSS   ObjProvider = "OSS"
 	COS   ObjProvider = "COS"
 )
 
@@ -57,6 +59,8 @@ func NewBucket(logger log.Logger, confContentYaml []byte, reg prometheus.Registe
 		bucket, err = azure.NewBucket(logger, config, component)
 	case string(SWIFT):
 		bucket, err = swift.NewContainer(logger, config)
+	case string(OSS):
+		bucket, err = oss.NewBucket(logger, config, component)
 	case string(COS):
 		bucket, err = cos.NewBucket(logger, config, component)
 	default:

--- a/pkg/objstore/objtesting/foreach.go
+++ b/pkg/objstore/objtesting/foreach.go
@@ -11,6 +11,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/objstore/cos"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
 	"github.com/improbable-eng/thanos/pkg/objstore/inmem"
+	"github.com/improbable-eng/thanos/pkg/objstore/oss"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
 	"github.com/improbable-eng/thanos/pkg/objstore/swift"
 	"github.com/improbable-eng/thanos/pkg/testutil"
@@ -100,6 +101,22 @@ func ForeachStore(t *testing.T, testFn func(t testing.TB, bkt objstore.Bucket)) 
 		}
 	} else {
 		t.Log("THANOS_SKIP_SWIFT_TESTS envvar present. Skipping test against swift.")
+	}
+
+	// Optional OSS.
+	if _, ok := os.LookupEnv("THANOS_SKIP_ALIBABA_OSS_TESTS"); !ok {
+		bkt, closeFn, err := oss.NewTestBucket(t)
+		testutil.Ok(t, err)
+
+		ok := t.Run("Alibaba OSS", func(t *testing.T) {
+			testFn(t, bkt)
+		})
+		closeFn()
+		if !ok {
+			return
+		}
+	} else {
+		t.Log("THANOS_SKIP_ALIBABA_OSS_TESTS envvar present. Skipping test against ALIBABA OSS.")
 	}
 
 	// Optional COS.

--- a/pkg/objstore/oss/oss.go
+++ b/pkg/objstore/oss/oss.go
@@ -1,0 +1,349 @@
+// Package OSS implements common object storage abstractions against Alibaba object storage service(OSS).
+package oss
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	slog "log"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/improbable-eng/thanos/pkg/runutil"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/improbable-eng/thanos/pkg/objstore"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// DirDelim is the delimiter used to model a directory structure in an object store bucket.
+const DirDelim = "/"
+
+// Config stores the configuration for OSS bucket.
+type Config struct {
+	Bucket     string     `yaml:"bucket"`
+	Endpoint   string     `yaml:"endpoint"`
+	AccessKey  string     `yaml:"access_key"`
+	SecretKey  string     `yaml:"secret_key"`
+	HTTPConfig HTTPConfig `yaml:"http_config"`
+	LogLevel   int        `yaml:"log_level"`
+}
+
+type Bucket struct {
+	logger log.Logger
+	name   string
+	client *oss.Client
+}
+
+type HTTPConfig struct {
+	EnableCRC                 bool  `yaml:"enable_crc"`
+	ConnectionTimeout         int64 `yaml:"connection_timeout"`
+	ReadWriteTimeout          int64 `yaml:"read_write_timeout"`
+	MaxIdleConnections        int   `yaml:"max_idle_connections"`
+	MaxIdleConnectionsPerHost int   `yaml:"max_idle_connections_per_host"`
+}
+
+func parseConfig(conf []byte) (Config, error) {
+	defaultHTTPConfig := getDefaultHTTPConfig()
+
+	config := Config{HTTPConfig: defaultHTTPConfig, LogLevel: oss.Info}
+	if err := yaml.Unmarshal(conf, &config); err != nil {
+		return Config{}, err
+	}
+
+	return config, nil
+}
+
+func getDefaultHTTPConfig() HTTPConfig {
+	defaultHTTPConfig := HTTPConfig{
+		EnableCRC:                 true,
+		ConnectionTimeout:         30,
+		ReadWriteTimeout:          60,
+		MaxIdleConnections:        100,
+		MaxIdleConnectionsPerHost: 100,
+	}
+	return defaultHTTPConfig
+}
+
+func NewBucket(logger log.Logger, conf []byte, component string) (*Bucket, error) {
+	config, err := parseConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewBucketWithConfig(logger, config, component)
+}
+
+func HTTPMaxConnections(httpMaxConnections oss.HTTPMaxConns) oss.ClientOption {
+	return func(client *oss.Client) {
+		client.Config.HTTPMaxConns = httpMaxConnections
+	}
+}
+
+func NewBucketWithConfig(logger log.Logger, config Config, component string) (*Bucket, error) {
+	if err := validate(config); err != nil {
+		return nil, err
+	}
+
+	userAgent := fmt.Sprintf("thanos-%s", component)
+	httpConnections := oss.HTTPMaxConns{}
+	httpConnections.MaxIdleConns = config.HTTPConfig.MaxIdleConnections
+	httpConnections.MaxIdleConnsPerHost = config.HTTPConfig.MaxIdleConnectionsPerHost
+	var ossLogger log.Logger
+	switch config.LogLevel {
+	case oss.LogOff, oss.Info:
+		ossLogger = level.Info(logger)
+	case oss.Debug:
+		ossLogger = level.Debug(logger)
+	case oss.Error:
+		ossLogger = level.Error(logger)
+	case oss.Warn:
+		ossLogger = level.Warn(logger)
+	}
+
+	client, err := oss.New(
+		config.Endpoint,
+		config.AccessKey,
+		config.SecretKey,
+		oss.UserAgent(userAgent),
+		oss.EnableCRC(config.HTTPConfig.EnableCRC),
+		oss.SetLogLevel(config.LogLevel),
+		oss.Timeout(config.HTTPConfig.ConnectionTimeout, config.HTTPConfig.ReadWriteTimeout),
+		HTTPMaxConnections(httpConnections),
+		oss.SetLogger(slog.New(log.NewStdlibAdapter(ossLogger, log.MessageKey("ossLogger")), "", slog.LstdFlags)))
+	if err != nil {
+		return nil, errors.Wrap(err, "initialize OSS client")
+	}
+
+	bucket := &Bucket{
+		logger: logger,
+		name:   config.Bucket,
+		client: client,
+	}
+	return bucket, nil
+}
+
+func (b *Bucket) Name() string {
+	return b.name
+}
+
+func validate(conf Config) error {
+	if conf.Endpoint == "" {
+		return errors.New("OSS endpoint is empty in config file, please check!")
+	}
+
+	if conf.AccessKey == "" || conf.SecretKey == "" {
+		return errors.New("Access key or secret key is empty in config file, please check!")
+	}
+
+	return nil
+}
+
+func (b *Bucket) Delete(ctx context.Context, name string) error {
+	bucket, err := b.client.Bucket(b.name)
+	if err != nil {
+		return errors.Wrap(err, "delete oss object: "+name)
+	}
+
+	return bucket.DeleteObject(name)
+}
+
+func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
+	bucket, err := b.client.Bucket(b.name)
+	if err != nil {
+		return false, errors.Wrap(err, "exists oss object: "+name)
+	}
+
+	res, err := bucket.IsObjectExist(name)
+	if err != nil {
+		return false, errors.Wrap(err, "exists oss object")
+	}
+
+	return res, nil
+}
+
+func (b *Bucket) Close() error {
+	return nil
+}
+
+func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error) error {
+	if dir != "" {
+		dir = strings.TrimSuffix(dir, DirDelim) + DirDelim
+	}
+
+	bucket, err := b.client.Bucket(b.name)
+	if err != nil {
+		return errors.Wrap(err, "iterate oss objects")
+	}
+
+	var marker = oss.Marker("")
+	for {
+		lsRes, err := bucket.ListObjects(oss.Prefix(dir), oss.Delimiter(DirDelim), marker)
+		if err != nil {
+			return errors.Wrap(err, "iterate oss objects")
+		}
+
+		for _, object := range lsRes.Objects {
+			if object.Key == "" {
+				continue
+			}
+			if err := f(object.Key); err != nil {
+				return errors.Wrap(err, "iterate oss objects")
+			}
+		}
+
+		for _, commonPrefixes := range lsRes.CommonPrefixes {
+			if err := f(commonPrefixes); err != nil {
+				return errors.Wrap(err, "iterate oss objects")
+			}
+		}
+
+		marker = oss.Marker(lsRes.NextMarker)
+		if !lsRes.IsTruncated {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (b *Bucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	return b.GetRange(ctx, name, 0, -1)
+}
+
+func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	if name == "" {
+		return nil, errors.Errorf("object name should not empty")
+	}
+
+	bucket, err := b.client.Bucket(b.name)
+	if err != nil {
+		return nil, errors.Wrap(err, "get oss object: "+name)
+	}
+
+	var r io.ReadCloser
+	if length != -1 {
+		r, err = bucket.GetObject(name, oss.Range(off, off+length-1))
+	} else {
+		r, err = bucket.GetObject(name)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := r.Read(nil); err != nil {
+		runutil.CloseWithLogOnErr(b.logger, r, "oss get range obj close")
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (b *Bucket) IsObjNotFoundErr(err error) bool {
+	switch err.(type) {
+	case oss.ServiceError:
+		if err.(oss.ServiceError).StatusCode == 404 {
+			return true
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
+	bucket, err := b.client.Bucket(b.name)
+	if err != nil {
+		return errors.Wrap(err, "upload oss object")
+	}
+
+	rc := ioutil.NopCloser(r)
+	err = bucket.PutObject(name, rc)
+	if err != nil {
+		return errors.Wrap(err, "upload oss object")
+	}
+	return err
+}
+
+func configFromEnv() Config {
+	c := Config{
+		Bucket:     os.Getenv("OSS_BUCKET"),
+		Endpoint:   os.Getenv("OSS_ENDPOINT"),
+		AccessKey:  os.Getenv("OSS_ACCESS_KEY"),
+		SecretKey:  os.Getenv("OSS_SECRET_KEY"),
+		HTTPConfig: getDefaultHTTPConfig(),
+		LogLevel:   oss.Debug,
+	}
+	return c
+}
+
+func NewTestBucket(t testing.TB) (objstore.Bucket, func(), error) {
+	c := configFromEnv()
+
+	if c.Endpoint == "" || c.AccessKey == "" || c.SecretKey == "" {
+		return nil, nil, errors.New("insufficient OSS test configuration information")
+	}
+
+	if c.Bucket != "" && os.Getenv("THANOS_ALLOW_EXISTING_BUCKET_USE") == "" {
+		return nil, nil, errors.New("OSS_BUCKET is defined. Normally this tests will create temporary bucket " +
+			"and delete it after test. Unset OSS_BUCKET env variable to use default logic. If you really want to run " +
+			"tests against provided (NOT USED!) bucket, set THANOS_ALLOW_EXISTING_BUCKET_USE=true. WARNING: That bucket " +
+			"needs to be manually cleared. This means that it is only useful to run one test in a time. This is due " +
+			"to safety.")
+	}
+
+	return NewTestBucketFromConfig(t, c, true)
+}
+
+func NewTestBucketFromConfig(t testing.TB, c Config, reuseBucket bool) (objstore.Bucket, func(), error) {
+	bc, err := yaml.Marshal(c)
+	if err != nil {
+		return nil, nil, err
+	}
+	b, err := NewBucket(log.NewNopLogger(), bc, "thanos-e2e-with-oss-test")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bktToCreate := c.Bucket
+	if c.Bucket != "" && reuseBucket {
+		if err := b.Iter(context.Background(), "", func(f string) error {
+			return errors.Errorf("bucket %s is not empty", c.Bucket)
+		}); err != nil {
+			return nil, nil, errors.Wrapf(err, "OSS check bucket %s", c.Bucket)
+		}
+
+		t.Log("WARNING. Reusing", c.Bucket, "OSS bucket for OSS tests. Manual cleanup afterwards is required")
+		return b, func() {}, nil
+	}
+
+	if c.Bucket == "" {
+		src := rand.NewSource(time.Now().UnixNano())
+
+		bktToCreate = strings.Replace(fmt.Sprintf("test_%s_%x", strings.ToLower(t.Name()), src.Int63()), "_", "-", -1)
+		if len(bktToCreate) >= 63 {
+			bktToCreate = bktToCreate[:63]
+		}
+	}
+
+	if err := b.client.CreateBucket(bktToCreate); err != nil {
+		return nil, nil, err
+	}
+	b.name = bktToCreate
+	t.Log("created temporary OSS bucket for OSS tests with name", bktToCreate)
+
+	return b, func() {
+		objstore.EmptyBucket(t, context.Background(), b)
+		if err := b.client.DeleteBucket(bktToCreate); err != nil {
+			t.Logf("deleting bucket %s failed: %s", bktToCreate, err)
+		}
+	}, nil
+}

--- a/scripts/bucketcfggen/main.go
+++ b/scripts/bucketcfggen/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/objstore/client"
 	"github.com/improbable-eng/thanos/pkg/objstore/cos"
 	"github.com/improbable-eng/thanos/pkg/objstore/gcs"
+	"github.com/improbable-eng/thanos/pkg/objstore/oss"
 	"github.com/improbable-eng/thanos/pkg/objstore/s3"
 	"github.com/improbable-eng/thanos/pkg/objstore/swift"
 	"github.com/pkg/errors"
@@ -28,6 +29,7 @@ var (
 		client.GCS:   gcs.Config{},
 		client.S3:    s3.Config{},
 		client.SWIFT: swift.SwiftConfig{},
+		client.OSS:   oss.Config{},
 		client.COS:   cos.Config{},
 	}
 )


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->


## Changes
Alibaba cloud OSS(Object Storage Service) is widely used among China’s cloud users. This PR adds supports of OSS for thanos.

## Verification

- To run tests against this provider, you should set environment variables like below:
    export OSS_ENDPOINT='OSS endpoint to connect to'
    export OSS_ACCESS_KEY='Your access key'
    export OSS_SECRET_KEY='Your secret key'
- To use it in POC or production, you should add below to configuration file
**type**: OSS
**config**:
&emsp;**bucket**: "Your bucket name"
&emsp;**endpoint**: "OSS endpoint to connect to"
&emsp;**access_key**: "Your access key"
&emsp;**secret_key**: "Your secret key"

I'm from Alibaba Cloud and would love to become the maintainer for the OSS provider. :)
