### PR TITLE
feat: added prober package to generalize readiness probes

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -6,6 +6,11 @@ import (
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 )
 
+// Component is a generic component interface
+type Component interface {
+	String() string
+}
+
 // StoreAPI is a component that implements Thanos' gRPC StoreAPI.
 type StoreAPI interface {
 	implementsStoreAPI()

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -6,7 +6,7 @@ import (
 	"github.com/improbable-eng/thanos/pkg/store/storepb"
 )
 
-// Component is a generic component interface
+// Component is a generic component interface.
 type Component interface {
 	String() string
 }

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -1,0 +1,158 @@
+package prober
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/improbable-eng/thanos/pkg/component"
+	"github.com/prometheus/common/route"
+)
+
+const (
+	healthyEndpointPath  = "/-/healthy"
+	readyEndpointPath    = "/-/ready"
+	okProbeText          = "thanos %v is %v"
+	errorProbeText       = "thanos %v is not %v. Reason: %v"
+	probeErrorHTTPStatus = 503
+	initialErrorText     = "thanos %s is initializing"
+)
+
+// Prober represents health and readriness status of given compoent.
+type Prober struct {
+	logger       log.Logger
+	componentMtx sync.Mutex
+	component    component.Component
+	readyMtx     sync.Mutex
+	readiness    error
+	healthyMtx   sync.Mutex
+	healthiness  error
+}
+
+// SetLogger sets logger used by the Prober.
+func (p *Prober) SetLogger(logger log.Logger) {
+	p.logger = logger
+}
+
+func (p *Prober) getLogger() log.Logger {
+	return p.logger
+}
+
+// SetComponent sets component name of the Prober displayed in responses.
+func (p *Prober) SetComponent(component component.Component) {
+	p.componentMtx.Lock()
+	defer p.componentMtx.Unlock()
+	p.component = component
+}
+
+func (p *Prober) getComponent() component.Component {
+	p.componentMtx.Lock()
+	defer p.componentMtx.Unlock()
+	return p.component
+}
+
+// NewProber returns Prober representing readiness and healthiness of given component.
+func NewProber(component component.Component, logger log.Logger) *Prober {
+	initialErr := fmt.Errorf(initialErrorText, component)
+	prober := &Prober{}
+	prober.SetComponent(component)
+	prober.SetLogger(logger)
+	prober.SetNotHealthy(initialErr)
+	prober.SetNotReady(initialErr)
+	return prober
+}
+
+// RegisterInRouter registers readiness and liveness probes to mux.
+func (p *Prober) RegisterInRouter(router *route.Router) {
+	router.Get(healthyEndpointPath, p.probeHandlerFunc(p.IsHealthy, "healthy"))
+	router.Get(readyEndpointPath, p.probeHandlerFunc(p.IsReady, "ready"))
+}
+
+// RegisterInMux registers readiness and liveness probes to mux.
+func (p *Prober) RegisterInMux(mux *http.ServeMux) {
+	mux.HandleFunc(healthyEndpointPath, p.probeHandlerFunc(p.IsHealthy, "healthy"))
+	mux.HandleFunc(readyEndpointPath, p.probeHandlerFunc(p.IsReady, "ready"))
+}
+
+func (p *Prober) writeResponse(w http.ResponseWriter, probeFunc func() error, probeType string) {
+	err := probeFunc()
+	if err != nil {
+		http.Error(w, fmt.Sprintf(errorProbeText, p.getComponent(), probeType, err), probeErrorHTTPStatus)
+		return
+	}
+	if _, e := io.WriteString(w, fmt.Sprintf(okProbeText, p.getComponent(), probeType)); e == nil {
+		level.Error(p.getLogger()).Log("msg", "failed to write probe response", "probe type", probeType, "err", err)
+	}
+}
+
+func (p *Prober) probeHandlerFunc(probeFunc func() error, probeType string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		p.writeResponse(w, probeFunc, probeType)
+	}
+}
+
+// IsReady returns error if component is not ready and nil if it is.
+func (p *Prober) IsReady() error {
+	p.readyMtx.Lock()
+	defer p.readyMtx.Unlock()
+	return p.readiness
+}
+
+// SetReady sets components status to ready.
+func (p *Prober) SetReady() {
+	if p.IsReady() != nil {
+		level.Info(p.getLogger()).Log("msg", "changing probe status", "status", "ready")
+	}
+	p.SetNotReady(nil)
+}
+
+// SetNotReady sets components status to not ready with given error as a cause.
+func (p *Prober) SetNotReady(err error) {
+	if err != nil && p.IsReady() == nil {
+		level.Warn(p.getLogger()).Log("msg", "changing probe status", "status", "not-ready", "reason", err)
+	}
+	p.readyMtx.Lock()
+	defer p.readyMtx.Unlock()
+	p.readiness = err
+}
+
+// IsHealthy returns error if component is not healthy and nil if it is.
+func (p *Prober) IsHealthy() error {
+	p.healthyMtx.Lock()
+	defer p.healthyMtx.Unlock()
+	return p.healthiness
+}
+
+// SetHealthy sets components status to healthy.
+func (p *Prober) SetHealthy() {
+	if p.IsHealthy() != nil {
+		level.Info(p.getLogger()).Log("msg", "changing probe status", "status", "healthy")
+	}
+	p.SetNotHealthy(nil)
+}
+
+// SetNotHealthy sets components status to not healthy with given error as a cause.
+func (p *Prober) SetNotHealthy(err error) {
+	if err != nil && p.IsHealthy() == nil {
+		level.Warn(p.getLogger()).Log("msg", "changing probe status", "status", "unhealthy", "reason", err)
+	}
+	p.healthyMtx.Lock()
+	defer p.healthyMtx.Unlock()
+	p.healthiness = err
+}
+
+// HandleIfReady if probe is ready calls the function otherwise returns 503.
+func (p *Prober) HandleIfReady(f http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p.readyMtx.Lock()
+		defer p.readyMtx.Unlock()
+		if p.readiness == nil {
+			f(w, r)
+			return
+		}
+		p.writeResponse(w, func() error { return p.readiness }, "ready")
+	}
+}

--- a/pkg/prober/prober_test.go
+++ b/pkg/prober/prober_test.go
@@ -1,0 +1,172 @@
+package prober
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/improbable-eng/thanos/pkg/runutil"
+	"github.com/improbable-eng/thanos/pkg/testutil"
+	"github.com/oklog/run"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/route"
+)
+
+func queryHTTPGetEndpoint(ctx context.Context, t *testing.T, logger log.Logger, url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s", url), nil)
+	testutil.Ok(t, err)
+	return http.DefaultClient.Do(req.WithContext(ctx))
+}
+
+type TestComponent struct {
+	name string
+}
+
+func (c TestComponent) String() string {
+	return c.name
+}
+
+func TestProberHealthInitialState(t *testing.T) {
+	component := TestComponent{name: "test"}
+	expectedErrorMessage := fmt.Sprintf(initialErrorText, component)
+	p := NewProber(component, log.NewNopLogger())
+
+	err := p.IsHealthy()
+	testutil.NotOk(t, err)
+	testutil.Equals(t, err.Error(), expectedErrorMessage)
+}
+
+func TestProberReadinessInitialState(t *testing.T) {
+	component := TestComponent{name: "test"}
+	expectedErrorMessage := fmt.Sprintf(initialErrorText, component)
+	p := NewProber(component, log.NewNopLogger())
+
+	err := p.IsReady()
+	testutil.NotOk(t, err)
+	testutil.Equals(t, err.Error(), expectedErrorMessage)
+}
+
+func TestProberReadyStatusSetting(t *testing.T) {
+	component := TestComponent{name: "test"}
+	testError := fmt.Errorf("test error")
+	p := NewProber(component, log.NewNopLogger())
+
+	p.SetReady()
+	err := p.IsReady()
+	testutil.Equals(t, err, nil)
+	p.SetNotReady(testError)
+	err = p.IsReady()
+	testutil.NotOk(t, err)
+}
+
+func TestProberHeatlthyStatusSetting(t *testing.T) {
+	component := TestComponent{name: "test"}
+	testError := fmt.Errorf("test error")
+	p := NewProber(component, log.NewNopLogger())
+
+	p.SetHealthy()
+	err := p.IsHealthy()
+	testutil.Equals(t, err, nil)
+	p.SetNotHealthy(testError)
+	err = p.IsHealthy()
+	testutil.NotOk(t, err)
+}
+
+func TestProberMuxRegistering(t *testing.T) {
+	component := TestComponent{name: "test"}
+	ctx := context.Background()
+	var g run.Group
+	mux := http.NewServeMux()
+
+	freePort, err := testutil.FreePort()
+	testutil.Ok(t, err)
+	serverAddress := fmt.Sprintf("localhost:%d", freePort)
+
+	l, err := net.Listen("tcp", serverAddress)
+	testutil.Ok(t, err)
+	g.Add(func() error {
+		return errors.Wrap(http.Serve(l, mux), "serve probes")
+	}, func(error) {})
+
+	p := NewProber(component, log.NewNopLogger())
+	p.RegisterInMux(mux)
+
+	go func() { _ = g.Run() }()
+
+	testutil.Ok(t, runutil.Retry(time.Second, ctx.Done(), func() error {
+		resp, err := queryHTTPGetEndpoint(ctx, t, log.NewNopLogger(), path.Join(serverAddress, healthyEndpointPath))
+		testutil.Ok(t, err)
+		testutil.Equals(t, probeErrorHTTPStatus, resp.StatusCode)
+		return err
+	}))
+
+	testutil.Ok(t, runutil.Retry(time.Second, ctx.Done(), func() error {
+		resp, err := queryHTTPGetEndpoint(ctx, t, log.NewNopLogger(), path.Join(serverAddress, readyEndpointPath))
+		testutil.Ok(t, err)
+		testutil.Equals(t, probeErrorHTTPStatus, resp.StatusCode)
+		return err
+	}))
+
+	p.SetHealthy()
+
+	testutil.Ok(t, runutil.Retry(time.Second, ctx.Done(), func() error {
+		resp, err := queryHTTPGetEndpoint(ctx, t, log.NewNopLogger(), path.Join(serverAddress, healthyEndpointPath))
+		testutil.Ok(t, err)
+		testutil.Equals(t, 200, resp.StatusCode)
+		return err
+	}))
+
+}
+
+func TestProberRouterRegistering(t *testing.T) {
+	component := TestComponent{name: "test"}
+	router := route.New()
+	ctx := context.Background()
+	var g run.Group
+	mux := http.NewServeMux()
+
+	freePort, err := testutil.FreePort()
+	testutil.Ok(t, err)
+	serverAddress := fmt.Sprintf("localhost:%d", freePort)
+
+	l, err := net.Listen("tcp", serverAddress)
+	testutil.Ok(t, err)
+	g.Add(func() error {
+		return errors.Wrap(http.Serve(l, mux), "serve probes")
+	}, func(error) {})
+
+	p := NewProber(component, log.NewNopLogger())
+	p.RegisterInRouter(router)
+	mux.Handle("/", router)
+
+	go func() { _ = g.Run() }()
+
+	testutil.Ok(t, runutil.Retry(time.Second, ctx.Done(), func() error {
+		resp, err := queryHTTPGetEndpoint(ctx, t, log.NewNopLogger(), path.Join(serverAddress, healthyEndpointPath))
+		testutil.Ok(t, err)
+		testutil.Equals(t, probeErrorHTTPStatus, resp.StatusCode)
+		return err
+	}))
+
+	testutil.Ok(t, runutil.Retry(time.Second, ctx.Done(), func() error {
+		resp, err := queryHTTPGetEndpoint(ctx, t, log.NewNopLogger(), path.Join(serverAddress, readyEndpointPath))
+		testutil.Ok(t, err)
+		testutil.Equals(t, probeErrorHTTPStatus, resp.StatusCode)
+		return err
+	}))
+
+	p.SetHealthy()
+
+	testutil.Ok(t, runutil.Retry(time.Second, ctx.Done(), func() error {
+		resp, err := queryHTTPGetEndpoint(ctx, t, log.NewNopLogger(), path.Join(serverAddress, healthyEndpointPath))
+		testutil.Ok(t, err)
+		testutil.Equals(t, 200, resp.StatusCode)
+		return err
+	}))
+
+}

--- a/pkg/prober/prober_test.go
+++ b/pkg/prober/prober_test.go
@@ -34,7 +34,7 @@ func (c TestComponent) String() string {
 func TestProberHealthInitialState(t *testing.T) {
 	component := TestComponent{name: "test"}
 	expectedErrorMessage := fmt.Sprintf(initialErrorFmt, component)
-	p := NewProber(component, log.NewNopLogger())
+	p := NewProber(component, log.NewNopLogger(), nil)
 
 	err := p.IsHealthy()
 	testutil.NotOk(t, err)
@@ -44,7 +44,7 @@ func TestProberHealthInitialState(t *testing.T) {
 func TestProberReadinessInitialState(t *testing.T) {
 	component := TestComponent{name: "test"}
 	expectedErrorMessage := fmt.Sprintf(initialErrorFmt, component)
-	p := NewProber(component, log.NewNopLogger())
+	p := NewProber(component, log.NewNopLogger(), nil)
 
 	err := p.IsReady()
 	testutil.NotOk(t, err)
@@ -54,7 +54,7 @@ func TestProberReadinessInitialState(t *testing.T) {
 func TestProberReadyStatusSetting(t *testing.T) {
 	component := TestComponent{name: "test"}
 	testError := fmt.Errorf("test error")
-	p := NewProber(component, log.NewNopLogger())
+	p := NewProber(component, log.NewNopLogger(), nil)
 
 	p.SetReady()
 	err := p.IsReady()
@@ -67,7 +67,7 @@ func TestProberReadyStatusSetting(t *testing.T) {
 func TestProberHeatlthyStatusSetting(t *testing.T) {
 	component := TestComponent{name: "test"}
 	testError := fmt.Errorf("test error")
-	p := NewProber(component, log.NewNopLogger())
+	p := NewProber(component, log.NewNopLogger(), nil)
 
 	p.SetHealthy()
 	err := p.IsHealthy()
@@ -93,7 +93,7 @@ func TestProberMuxRegistering(t *testing.T) {
 		return errors.Wrap(http.Serve(l, mux), "serve probes")
 	}, func(error) {})
 
-	p := NewProber(component, log.NewNopLogger())
+	p := NewProber(component, log.NewNopLogger(), nil)
 	p.RegisterInMux(mux)
 
 	go func() { _ = g.Run() }()
@@ -140,7 +140,7 @@ func TestProberRouterRegistering(t *testing.T) {
 		return errors.Wrap(http.Serve(l, mux), "serve probes")
 	}, func(error) {})
 
-	p := NewProber(component, log.NewNopLogger())
+	p := NewProber(component, log.NewNopLogger(), nil)
 	p.RegisterInRouter(router)
 	mux.Handle("/", router)
 

--- a/pkg/prober/prober_test.go
+++ b/pkg/prober/prober_test.go
@@ -33,7 +33,7 @@ func (c TestComponent) String() string {
 
 func TestProberHealthInitialState(t *testing.T) {
 	component := TestComponent{name: "test"}
-	expectedErrorMessage := fmt.Sprintf(initialErrorText, component)
+	expectedErrorMessage := fmt.Sprintf(initialErrorFmt, component)
 	p := NewProber(component, log.NewNopLogger())
 
 	err := p.IsHealthy()
@@ -43,7 +43,7 @@ func TestProberHealthInitialState(t *testing.T) {
 
 func TestProberReadinessInitialState(t *testing.T) {
 	component := TestComponent{name: "test"}
-	expectedErrorMessage := fmt.Sprintf(initialErrorText, component)
+	expectedErrorMessage := fmt.Sprintf(initialErrorFmt, component)
 	p := NewProber(component, log.NewNopLogger())
 
 	err := p.IsReady()


### PR DESCRIPTION
This PR adds prober package/component which will unify readiness and health checks of all thanos components.

For more info please refer to the PR https://github.com/improbable-eng/thanos/pull/656