### PR TITLE
Add downsampling metrics

### DIFF
--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -166,6 +166,11 @@ func runCompact(
 	reg.MustRegister(halted)
 	reg.MustRegister(retried)
 
+	downsampleMetrics, err := newDownsampleMetrics(reg)
+	if err != nil {
+		return err
+	}
+
 	confContentYaml, err := objStoreConfig.Content()
 	if err != nil {
 		return err
@@ -245,13 +250,13 @@ func runCompact(
 			// for 5m downsamplings created in the first run.
 			level.Info(logger).Log("msg", "start first pass of downsampling")
 
-			if err := downsampleBucket(ctx, logger, bkt, downsamplingDir); err != nil {
+			if err := downsampleBucket(ctx, logger, downsampleMetrics, bkt, downsamplingDir); err != nil {
 				return errors.Wrap(err, "first pass of downsampling failed")
 			}
 
 			level.Info(logger).Log("msg", "start second pass of downsampling")
 
-			if err := downsampleBucket(ctx, logger, bkt, downsamplingDir); err != nil {
+			if err := downsampleBucket(ctx, logger, downsampleMetrics, bkt, downsamplingDir); err != nil {
 				return errors.Wrap(err, "second pass of downsampling failed")
 			}
 			level.Info(logger).Log("msg", "downsampling iterations done")

--- a/cmd/thanos/compact.go
+++ b/cmd/thanos/compact.go
@@ -166,10 +166,7 @@ func runCompact(
 	reg.MustRegister(halted)
 	reg.MustRegister(retried)
 
-	downsampleMetrics, err := newDownsampleMetrics(reg)
-	if err != nil {
-		return err
-	}
+	downsampleMetrics := newDownsampleMetrics(reg)
 
 	confContentYaml, err := objStoreConfig.Content()
 	if err != nil {

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -221,7 +221,6 @@ func downsampleBucket(
 			if m.MaxTime-m.MinTime < 40*60*60*1000 {
 				continue
 			}
-
 			if err := processDownsampling(ctx, logger, bkt, m, dir, 5*60*1000); err != nil {
 				metrics.downsampleFailures.WithLabelValues(compact.GroupKey(*m))
 				return errors.Wrap(err, "downsampling to 5 min")

--- a/cmd/thanos/downsample.go
+++ b/cmd/thanos/downsample.go
@@ -49,7 +49,7 @@ type DownsampleMetrics struct {
 	downsampleFailures        *prometheus.CounterVec
 }
 
-func newDownsampleMetrics(reg *prometheus.Registry) (*DownsampleMetrics, error) {
+func newDownsampleMetrics(reg *prometheus.Registry) *DownsampleMetrics {
 	m := new(DownsampleMetrics)
 
 	m.downsamples = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -61,14 +61,10 @@ func newDownsampleMetrics(reg *prometheus.Registry) (*DownsampleMetrics, error) 
 		Help: "Total number of failed downsampling attempts.",
 	}, []string{"group"})
 
-	if err := reg.Register(m.downsamples); err != nil {
-		return nil, err
-	}
-	if err := reg.Register(m.downsampleFailures); err != nil {
-		return nil, err
-	}
+	reg.MustRegister(m.downsamples)
+	reg.MustRegister(m.downsampleFailures)
 
-	return m, nil
+	return m
 }
 
 func runDownsample(
@@ -96,10 +92,7 @@ func runDownsample(
 		}
 	}()
 
-	metrics, err := newDownsampleMetrics(reg)
-	if err != nil {
-		return err
-	}
+	metrics := newDownsampleMetrics(reg)
 
 	// Start cycle of syncing blocks from the bucket and garbage collecting the bucket.
 	{


### PR DESCRIPTION
When `compact` goes into its downsampling step, no app metrics are reported, which makes our dashboard look a bit bare for several hours (sometimes days if we have a backlog). Adding a couple of metrics means we can alert if no compactions or downsamples have happened in x period.

This is a little less clean than I'd like due to the two callers of `downsampleBucket` having slightly different contexts, however I think it's a reasonable compromise. Let me know what you think!

The metrics are labelled in the same way as compact metrics for ease of comparison.

## Changes

Add `thanos_compact_downsample_total` and `thanos_compact_downsample_failures_total` downsampling metrics.

## Verification

Tests are passing, will run with real workloads.