### PR TITLE
Add web UI to display the state of Thanos bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#1253](https://github.com/improbable-eng/thanos/pull/1253) Add support for specifying a maximum amount of retries when using Azure Blob storage (default: no retries).
 
+- [#1248](https://github.com/improbable-eng/thanos/pull/1248) Add a web UI to show the state of remote storage.
+
 ## [v0.5.0](https://github.com/improbable-eng/thanos/releases/tag/v0.5.0) - 2019.06.05
 
 TL;DR: Store LRU cache is no longer leaking, Upgraded Thanos UI to Prometheus 2.9, Fixed auto-downsampling, Moved to Go 1.12.5 and more.

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -359,7 +359,7 @@ func refresh(ctx context.Context, logger log.Logger, bucketUI *ui.Bucket, durati
 
 	defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
-	return runutil.Repeat(duration, ctx.Done(), func() error {
+	runutil.Forever(logger, duration, ctx.Done(), func() error {
 		iterCtx, iterCancel := context.WithTimeout(ctx, 5*time.Minute)
 		defer iterCancel()
 
@@ -379,6 +379,8 @@ func refresh(ctx context.Context, logger log.Logger, bucketUI *ui.Bucket, durati
 			return nil
 		})
 	})
+
+	return nil
 }
 
 func download(ctx context.Context, logger log.Logger, bkt objstore.Bucket) (blocks []metadata.Meta, err error) {

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -309,13 +309,14 @@ func registerBucketWeb(m map[string]setupFunc, root *kingpin.CmdClause, name str
 	cmd := root.Command("web", "Web interface for remote storage bucket")
 	bind := cmd.Flag("listen", "HTTP host:port to listen on").Default("0.0.0.0:8080").String()
 	interval := cmd.Flag("refresh", "Refresh interval").Default("30m").Duration()
+	label := cmd.Flag("label", "Prometheus label to use as timeline title").String()
 
 	m[name+" web"] = func(g *run.Group, logger log.Logger, reg *prometheus.Registry, _ opentracing.Tracer, _ bool) error {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		router := route.New()
 
-		bucketUI := ui.NewBucketUI(logger)
+		bucketUI := ui.NewBucketUI(logger, *label)
 		bucketUI.Register(router)
 
 		if *interval < 5*time.Minute {

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -360,7 +360,7 @@ func refresh(ctx context.Context, logger log.Logger, bucketUI *ui.Bucket, durati
 
 	defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
-	runutil.Forever(logger, duration, ctx.Done(), func() error {
+	return runutil.Repeat(duration, ctx.Done(), func() error {
 		iterCtx, iterCancel := context.WithTimeout(ctx, 5*time.Minute)
 		defer iterCancel()
 
@@ -380,8 +380,6 @@ func refresh(ctx context.Context, logger log.Logger, bucketUI *ui.Bucket, durati
 			return nil
 		})
 	})
-
-	return nil
 }
 
 func download(ctx context.Context, logger log.Logger, bkt objstore.Bucket) (blocks []metadata.Meta, err error) {

--- a/cmd/thanos/bucket.go
+++ b/cmd/thanos/bucket.go
@@ -361,10 +361,11 @@ func refresh(ctx context.Context, logger log.Logger, bucketUI *ui.Bucket, durati
 	defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
 	return runutil.Repeat(duration, ctx.Done(), func() error {
-		iterCtx, iterCancel := context.WithTimeout(ctx, 5*time.Minute)
-		defer iterCancel()
 
-		return runutil.RetryWithLog(logger, time.Minute, iterCtx.Done(), func() error {
+		return runutil.RetryWithLog(logger, time.Minute, ctx.Done(), func() error {
+			iterCtx, iterCancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer iterCancel()
+
 			blocks, err := download(iterCtx, logger, bkt)
 			if err != nil {
 				bucketUI.Set("[]", err)

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -66,7 +66,7 @@ Subcommands:
     Inspect all blocks in the bucket in detailed, table-like way
 
   bucket web [<flags>]
-    Web interface for remote storage bucket.
+    Web interface for remote storage bucket
 
 
 ```

--- a/docs/components/bucket.md
+++ b/docs/components/bucket.md
@@ -65,6 +65,9 @@ Subcommands:
   bucket inspect [<flags>]
     Inspect all blocks in the bucket in detailed, table-like way
 
+  bucket web [<flags>]
+    Web interface for remote storage bucket.
+
 
 ```
 

--- a/pkg/runutil/runutil.go
+++ b/pkg/runutil/runutil.go
@@ -70,24 +70,6 @@ func Repeat(interval time.Duration, stopc <-chan struct{}, f func() error) error
 	}
 }
 
-// Forever executes f every interval seconds until stopc is closed. Errors are logged and ignored.
-// It executes f once right after being called.
-func Forever(logger log.Logger, interval time.Duration, stopc <-chan struct{}, f func() error) {
-	tick := time.NewTicker(interval)
-	defer tick.Stop()
-
-	for {
-		if err := f(); err != nil {
-			level.Error(logger).Log("msg", "function failed. Retrying in next tick", "err", err)
-		}
-		select {
-		case <-stopc:
-			return
-		case <-tick.C:
-		}
-	}
-}
-
 // Retry executes f every interval seconds until timeout or no error is returned from f.
 func Retry(interval time.Duration, stopc <-chan struct{}, f func() error) error {
 	return RetryWithLog(log.NewNopLogger(), interval, stopc, f)

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -13,15 +13,19 @@ import (
 // Bucket is a web UI representing state of buckets as a timeline.
 type Bucket struct {
 	*BaseUI
+	// Unique Prometheus label that identifies each shard, used as the title. If
+	// not present, all labels are displayed externally as a legend.
+	Label       string
 	Blocks      template.JS
 	RefreshedAt time.Time
 	Err         error
 }
 
-func NewBucketUI(logger log.Logger) *Bucket {
+func NewBucketUI(logger log.Logger, label string) *Bucket {
 	return &Bucket{
 		BaseUI: NewBaseUI(logger, "bucket_menu.html", queryTmplFuncs()),
 		Blocks: "[]",
+		Label:  label,
 	}
 }
 

--- a/pkg/ui/bucket.go
+++ b/pkg/ui/bucket.go
@@ -1,0 +1,45 @@
+package ui
+
+import (
+	"html/template"
+	"net/http"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/route"
+)
+
+// Bucket is a web UI representing state of buckets as a timeline.
+type Bucket struct {
+	*BaseUI
+	Blocks      template.JS
+	RefreshedAt time.Time
+	Err         error
+}
+
+func NewBucketUI(logger log.Logger) *Bucket {
+	return &Bucket{
+		BaseUI: NewBaseUI(logger, "bucket_menu.html", queryTmplFuncs()),
+		Blocks: "[]",
+	}
+}
+
+// Register registers http routes for bucket UI.
+func (b *Bucket) Register(r *route.Router) {
+	instrf := prometheus.InstrumentHandlerFunc
+
+	r.Get("/", instrf("root", b.root))
+	r.Get("/static/*filepath", instrf("static", b.serveStaticAsset))
+}
+
+// Handle / of bucket UIs
+func (b *Bucket) root(w http.ResponseWriter, r *http.Request) {
+	b.executeTemplate(w, "bucket.html", "", b)
+}
+
+func (b *Bucket) Set(data string, err error) {
+	b.RefreshedAt = time.Now()
+	b.Blocks = template.JS(string(data))
+	b.Err = err
+}

--- a/pkg/ui/static/js/bucket.js
+++ b/pkg/ui/static/js/bucket.js
@@ -4,12 +4,12 @@ google.charts.load('current', {
 google.charts.setOnLoadCallback(draw);
 
 function draw() {
-    if (window.refreshedAt == "0001-01-01T00:00:00Z") {
-        window.err = "Synchronizing blocks from remote storage";
+    if (thanos.refreshedAt == "0001-01-01T00:00:00Z") {
+        thanos.err = "Synchronizing blocks from remote storage";
     }
 
-    if (window.err != null) {
-        $("#err").show().find('.alert').text(JSON.stringify(window.err, null, 4));
+    if (thanos.err != null) {
+        $("#err").show().find('.alert').text(JSON.stringify(thanos.err, null, 4));
         setTimeout(function() {
             location.reload();
         }, 10000);
@@ -20,18 +20,59 @@ function draw() {
         var container = document.getElementById('Compactions');
         var chart = new google.visualization.Timeline(container);
         var dataTable = new google.visualization.DataTable();
+        var titles = {};
 
         dataTable.addColumn({type: 'string', id: 'Replica'});
         dataTable.addColumn({type: 'string', id: 'Label'});
         dataTable.addColumn({type: 'date', id: 'Start'});
         dataTable.addColumn({type: 'date', id: 'End'});
 
-        dataTable.addRows(blocks
+        dataTable.addRows(thanos.blocks
             .map(function(d) {
-                label = "l: " + d.compaction.level + ", res: " + d.thanos.downsample.resolution;
-                return [d.thanos.labels.prometheus_replica, label, new Date(d.minTime), new Date(d.maxTime)];
+                // Title is the first column of the timeline.
+                //
+                // A unique Prometheus label that identifies each shard is used
+                // as the title if present, otherwise all labels are displayed
+                // externally as a legend.
+                title = function() {
+                    if (thanos.label != "") {
+                        var key = d.thanos.labels[thanos.label];
+                        if (key == undefined) {
+                            throw `Label ${thanos.label} not found in ${Object.keys(d.thanos.labels)}`;
+                        } else {
+                            return key;
+                        }
+                    } else {
+                        title = titles[stringify(d.thanos.labels)];
+                        if (title == undefined) {
+                            title = String(Object.keys(titles).length + 1);
+                            titles[stringify(d.thanos.labels)] = title;
+                        }
+                        return title;
+                    }
+                }();
+
+                label = `l: ${d.compaction.level}, res: ${d.thanos.downsample.resolution}`;
+                return [title, label, new Date(d.minTime), new Date(d.maxTime)];
             }));
 
         chart.draw(dataTable);
+
+        // Show external legend if no external labels were set.
+        if (thanos.label == "") {
+            $("#legend").show();
+            for (let [key, value] of Object.entries(titles)) {
+                row = `<tr> <th scope="row">${value}</th> <td>${key}</td> </tr>`;
+                $("#legend table tbody").append(row);
+            }
+        }
     }
+}
+
+function stringify(map) {
+    var t = "";
+    for (let [key, value] of Object.entries(map)) {
+        t += `${key}: ${value} `;
+    }
+    return t;
 }

--- a/pkg/ui/static/js/bucket.js
+++ b/pkg/ui/static/js/bucket.js
@@ -1,0 +1,37 @@
+google.charts.load('current', {
+    'packages': ['timeline']
+});
+google.charts.setOnLoadCallback(draw);
+
+function draw() {
+    if (window.refreshedAt == "0001-01-01T00:00:00Z") {
+        window.err = "Synchronizing blocks from remote storage";
+    }
+
+    if (window.err != null) {
+        $("#err").show().find('.alert').text(JSON.stringify(window.err, null, 4));
+        setTimeout(function() {
+            location.reload();
+        }, 10000);
+
+    } else {
+        $("#err").hide();
+
+        var container = document.getElementById('Compactions');
+        var chart = new google.visualization.Timeline(container);
+        var dataTable = new google.visualization.DataTable();
+
+        dataTable.addColumn({type: 'string', id: 'Replica'});
+        dataTable.addColumn({type: 'string', id: 'Label'});
+        dataTable.addColumn({type: 'date', id: 'Start'});
+        dataTable.addColumn({type: 'date', id: 'End'});
+
+        dataTable.addRows(blocks
+            .map(function(d) {
+                label = "l: " + d.compaction.level + ", res: " + d.thanos.downsample.resolution;
+                return [d.thanos.labels.prometheus_replica, label, new Date(d.minTime), new Date(d.maxTime)];
+            }));
+
+        chart.draw(dataTable);
+    }
+}

--- a/pkg/ui/templates/bucket.html
+++ b/pkg/ui/templates/bucket.html
@@ -1,0 +1,44 @@
+{{define "head"}}
+    <meta http-equiv="refresh" content="300"/>
+
+    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/rickshaw/rickshaw.min.css?v={{ buildVersion }}">
+    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.css?v={{ buildVersion }}">
+
+    <script src="{{ pathPrefix }}/static/vendor/rickshaw/vendor/d3.v3.js?v={{ buildVersion }}"></script>
+    <script src="{{ pathPrefix }}/static/vendor/rickshaw/vendor/d3.layout.min.js?v={{ buildVersion }}"></script>
+    <script src="{{ pathPrefix }}/static/vendor/rickshaw/rickshaw.min.js?v={{ buildVersion }}"></script>
+    <script src="{{ pathPrefix }}/static/vendor/moment/moment.min.js?v={{ buildVersion }}"></script>
+    <script src="{{ pathPrefix }}/static/vendor/moment/moment-timezone-with-data.min.js?v={{ buildVersion }}"></script>
+    <script src="{{ pathPrefix }}/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.js?v={{ buildVersion }}"></script>
+    <script src="{{ pathPrefix }}/static/vendor/bootstrap3-typeahead/bootstrap3-typeahead.min.js?v={{ buildVersion }}"></script>
+    <script src="{{ pathPrefix }}/static/vendor/fuzzy/fuzzy.js?v={{ buildVersion }}"></script>
+
+    <script src="{{ pathPrefix }}/static/vendor/mustache/mustache.min.js?v={{ buildVersion }}"></script>
+    <script src="{{ pathPrefix }}/static/vendor/js/jquery.selection.js?v={{ buildVersion }}"></script>
+    <!-- <script src="{{ pathPrefix }}/static/vendor/js/jquery.hotkeys.js?v={{ buildVersion }}"></script> -->
+
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script src="{{ pathPrefix }}/static/js/bucket.js?v={{ buildVersion }}"></script>
+
+    <script id="graph_template" type="text/x-handlebars-template"></script>
+
+    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/css/graph.css?v={{ buildVersion }}">
+{{end}}
+
+{{define "content"}}
+    <script type="text/javascript">
+       var blocks = {{.Blocks}},
+           err = {{.Err}},
+           refreshedAt = {{.RefreshedAt}};
+    </script>
+
+    <div id="err" class="container" style="display: none;">
+        <div class="alert alert-warning" role="alert"></div>
+    </div>
+
+    <div class="container-fluid" id="Compactions" style="height: 100%; width: 100%;"></div>
+    <style>
+        text[text-anchor=start] {display: none}
+        html,body {height: 100%;}
+    </style>
+{{end}}

--- a/pkg/ui/templates/bucket.html
+++ b/pkg/ui/templates/bucket.html
@@ -21,6 +21,11 @@
 
     <div class="container-fluid" id="Compactions" style="height: 100%; width: 100%;"></div>
 
+    <!--
+     TODO(jaseemabid): The legend is only a small temporary workaround till we have better ways of showing the labels.
+     See https://github.com/improbable-eng/thanos/issues/1246#issuecomment-506681398 for context.
+    -->
+
     <div id="legend" class="container-fluid" style="display: none; padding-top: 50px;">
         <h4> Legend </h4>
         <table class="table table-striped table-hover table-sm">

--- a/pkg/ui/templates/bucket.html
+++ b/pkg/ui/templates/bucket.html
@@ -1,28 +1,8 @@
 {{define "head"}}
     <meta http-equiv="refresh" content="300"/>
 
-    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/rickshaw/rickshaw.min.css?v={{ buildVersion }}">
-    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.css?v={{ buildVersion }}">
-
-    <script src="{{ pathPrefix }}/static/vendor/rickshaw/vendor/d3.v3.js?v={{ buildVersion }}"></script>
-    <script src="{{ pathPrefix }}/static/vendor/rickshaw/vendor/d3.layout.min.js?v={{ buildVersion }}"></script>
-    <script src="{{ pathPrefix }}/static/vendor/rickshaw/rickshaw.min.js?v={{ buildVersion }}"></script>
-    <script src="{{ pathPrefix }}/static/vendor/moment/moment.min.js?v={{ buildVersion }}"></script>
-    <script src="{{ pathPrefix }}/static/vendor/moment/moment-timezone-with-data.min.js?v={{ buildVersion }}"></script>
-    <script src="{{ pathPrefix }}/static/vendor/eonasdan-bootstrap-datetimepicker/bootstrap-datetimepicker.min.js?v={{ buildVersion }}"></script>
-    <script src="{{ pathPrefix }}/static/vendor/bootstrap3-typeahead/bootstrap3-typeahead.min.js?v={{ buildVersion }}"></script>
-    <script src="{{ pathPrefix }}/static/vendor/fuzzy/fuzzy.js?v={{ buildVersion }}"></script>
-
-    <script src="{{ pathPrefix }}/static/vendor/mustache/mustache.min.js?v={{ buildVersion }}"></script>
-    <script src="{{ pathPrefix }}/static/vendor/js/jquery.selection.js?v={{ buildVersion }}"></script>
-    <!-- <script src="{{ pathPrefix }}/static/vendor/js/jquery.hotkeys.js?v={{ buildVersion }}"></script> -->
-
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script src="{{ pathPrefix }}/static/js/bucket.js?v={{ buildVersion }}"></script>
-
-    <script id="graph_template" type="text/x-handlebars-template"></script>
-
-    <link type="text/css" rel="stylesheet" href="{{ pathPrefix }}/static/css/graph.css?v={{ buildVersion }}">
 {{end}}
 
 {{define "content"}}

--- a/pkg/ui/templates/bucket.html
+++ b/pkg/ui/templates/bucket.html
@@ -27,9 +27,12 @@
 
 {{define "content"}}
     <script type="text/javascript">
-       var blocks = {{.Blocks}},
-           err = {{.Err}},
-           refreshedAt = {{.RefreshedAt}};
+     var thanos = {
+         label: {{.Label}},
+         err: {{.Err}},
+         refreshedAt: {{.RefreshedAt}},
+         blocks: {{.Blocks}}
+     };
     </script>
 
     <div id="err" class="container" style="display: none;">
@@ -37,6 +40,14 @@
     </div>
 
     <div class="container-fluid" id="Compactions" style="height: 100%; width: 100%;"></div>
+
+    <div id="legend" class="container-fluid" style="display: none; padding-top: 50px;">
+        <h4> Legend </h4>
+        <table class="table table-striped table-hover table-sm">
+            <tbody></tbody>
+        </table>
+    </div>
+
     <style>
         text[text-anchor=start] {display: none}
         html,body {height: 100%;}

--- a/pkg/ui/templates/bucket_menu.html
+++ b/pkg/ui/templates/bucket_menu.html
@@ -1,0 +1,17 @@
+{{define "nav"}}
+<nav class="navbar fixed-top navbar-expand-sm navbar-dark bg-dark">
+    <div class="container-fluid">
+        <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#nav-content" aria-expanded="false" aria-controls="nav-content" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <a class="navbar-brand" href="{{ pathPrefix }}/">Thanos Bucket Viewer</a>
+        <div id="nav-content" class="navbar-collapse collapse">
+            <ul class="navbar-nav">
+                <li class="nav-item">
+                    <a class="nav-link" href="https://github.com/improbable-eng/thanos" target="_blank">Help</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+{{end}}

--- a/scripts/genflagdocs.sh
+++ b/scripts/genflagdocs.sh
@@ -39,7 +39,7 @@ for x in "${commands[@]}"; do
     ./thanos "${x}" --help &> "docs/components/flags/${x}.txt"
 done
 
-bucketCommands=("verify" "ls" "inspect")
+bucketCommands=("verify" "ls" "inspect" "web")
 for x in "${bucketCommands[@]}"; do
     ./thanos bucket "${x}" --help &> "docs/components/flags/bucket_${x}.txt"
 done


### PR DESCRIPTION
Exposes a web interface for the state of Thanos buckets just like `pprof web`.
This is an early preview, the code is rough on the edges and could use some
review. See the screenshots for some examples.

**What works?**

- Can display the timeline of blocks per shard
- Can print error messages if any
- Reloads data from remote storage every 30m
- Reloads browser slightly smarter than that

**TODOS**

- Some download code is duplicated from `ls -o json`; refactor as needed
- Some web code is duplicated from query UI; refactor as needed
- Do we need any of the route prefix?
- Unfortunately learned a bit late that the JS libraries cannot be vendored. That sucks :(
- The tooltip is pretty basic and can contain a lot more useful info.
- Allow some kind of filtering and other bells and whistles to the UI, but this can be part of later PR. 

**Notes for the reviewer**

- goimports is slightly off on master, the changes in kingpin is not intentional
- Multiple `client.NewBucket` will panic; the downloader avoids that.
- `downloader` can be rewritten if required
- Asset reloading doesn't work with `DEBUG=1`, I had to add an extra `-debug`

**Default view:** 
<img width="2032" alt="Screenshot 2019-06-12 at 18 07 52" src="https://user-images.githubusercontent.com/601714/59374376-a4e05000-8d43-11e9-9f61-ad0aabab333c.png">

**Loading indication:**
<img width="2032" alt="Screenshot 2019-06-12 at 18 08 05" src="https://user-images.githubusercontent.com/601714/59374377-a4e05000-8d43-11e9-97cc-af3b2961b0ce.png">

**Other errors:**
<img width="1988" alt="Screenshot 2019-06-12 at 18 19 08" src="https://user-images.githubusercontent.com/601714/59374380-a4e05000-8d43-11e9-8d88-64fe25772a8d.png">
