### PR TITLE
pkg/downsample: use a.count

### DIFF
--- a/pkg/compact/downsample/downsample.go
+++ b/pkg/compact/downsample/downsample.go
@@ -460,7 +460,7 @@ func downsampleAggrBatch(chks []*AggrChunk, buf *[]sample, resolution int64) (ch
 		return nil
 	}
 	if err := do(AggrCount, func(a *aggregator) float64 {
-		return a.sum
+		return float64(a.count)
 	}); err != nil {
 		return chk, err
 	}

--- a/pkg/compact/downsample/downsample_test.go
+++ b/pkg/compact/downsample/downsample_test.go
@@ -89,7 +89,7 @@ func TestDownsampleAggr(t *testing.T) {
 				},
 			},
 			output: map[AggrType][]sample{
-				AggrCount:   {{499, 29}, {999, 100}},
+				AggrCount:   {{499, 5}, {999, 2}},
 				AggrSum:     {{499, 29}, {999, 100}},
 				AggrMin:     {{499, -3}, {999, 0}},
 				AggrMax:     {{499, 10}, {999, 100}},


### PR DESCRIPTION
When aggregating downsampled chunks use `a.count` which actually points to
the data that we want to use. I don't know why `a.sum` was used here
before as it seems wrong.

Also, the tests now AFAICT show proper aggregation values.