### PR TITLE
pkg/receive: register handler metrics

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -89,6 +89,13 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 	readyf := h.testReady
 	router.Post("/api/v1/receive", readyf(h.receive))
 
+	if o.Registry != nil {
+		o.Registry.MustRegister(
+			requestDuration,
+			responseSize,
+		)
+	}
+
 	return h
 }
 


### PR DESCRIPTION
The thanos receive component instruments its handler with some metrics
but these metrics are currently never registered.

## Changes

Register the receive handler metrics with the given registerer during creation. 

## Verification
Scrape the receive component's /metrics endpoint to verify that the handler metrics are now present.

cc @brancz @bwplotka 