### PR TITLE
Docs update on prometheus_rule_group_iterations_missed_total metric f…

### DIFF
--- a/docs/components/rule.md
+++ b/docs/components/rule.md
@@ -93,8 +93,8 @@ too complex query expression in rule.
 value as "warn", this metric will tell you how many evaluation ended up with some kind of warning. To see the actual warnings
 see WARN log level. This might suggest that those evaluations return partial response and might not be accurate.
 
-* `rule_group_iterations_missed_total_total`. With all the networking overhead of thanos - you might end up in a situation when actual group evaluation
-time is bigger than the evaluation interval which leads to an incomplete data set. If you see this metric incrementing - you most likely need to tune
+* `prometheus_rule_group_last_duration_seconds > prometheus_rule_group_interval_seconds`. With all the networking overhead of thanos - you might end up in a situation when actual group evaluation
+time is bigger than the evaluation interval which leads to an incomplete data set. If you see this alert firing - you most likely need to tune
 evaluation interval or divide rules to smaller groups. (Rules within one group are executed sequentially and different groups are executed in parallel)
 
 Those metrics are important for vanilla Prometheus as well, but even more important when we rely on (sometimes WAN) network.


### PR DESCRIPTION
Signed-off-by: Ivan Kiselev <kiselev_ivan@pm.me>

## Changes

A little doc update on the ruler that comes from here https://improbable-eng.slack.com/archives/CA4UWKEEN/p1560784841270000

Mentioned metric `rule_group_iterations_missed_total_total ` helps to avoid a picture like this: 

Left part indicates a situation when eval interval is lower than actual eval time

![Screenshot 2019-06-20 at 13 57 58](https://user-images.githubusercontent.com/10528835/59923853-bbb62f00-9434-11e9-9c59-14e4951daf70.png)


