### PR TITLE
docs: add integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Concretely the aims of the project are:
 * [Introduction blog post](https://improbable.io/games/blog/thanos-prometheus-at-scale)
 * [Benchmarks](https://github.com/improbable-eng/thanos/tree/master/benchmark)
 * [Proposals](docs/proposals)
-* [Integrations](docs/integrations)
+* [Integrations](docs/integrations.md)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Concretely the aims of the project are:
 * [Introduction blog post](https://improbable.io/games/blog/thanos-prometheus-at-scale)
 * [Benchmarks](https://github.com/improbable-eng/thanos/tree/master/benchmark)
 * [Proposals](docs/proposals)
+* [Integrations](docs/integrations.md)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Concretely the aims of the project are:
 * [Introduction blog post](https://improbable.io/games/blog/thanos-prometheus-at-scale)
 * [Benchmarks](https://github.com/improbable-eng/thanos/tree/master/benchmark)
 * [Proposals](docs/proposals)
-* [Integrations](docs/integrations.md)
+* [Integrations](docs/integrations)
 
 ## Features
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -7,11 +7,15 @@ slug: /integrations.md
 
 # Integrations 
 
-[StoreAPI](https://github.com/improbable-eng/thanos/blob/master/pkg/store/storepb/rpc.proto) is a common proto interface for gRPC component that can connect to [Querier](docs/components/query) in order to fetch the metric series. Natively Thanos implements [Sidecar](docs/components/sidecar) (local Prometheus data), [Ruler](docs/components/rule) and [Store gateway](docs/components/store). This solves fetching series from Prometheus or Prometheus TSDB format, however same interface can be used to fetch metrics from other storages. 
+## StoreAPI 
+
+[StoreAPI](https://github.com/improbable-eng/thanos/blob/master/pkg/store/storepb/rpc.proto) is a common proto interface for gRPC component that can connect to [Querier](components/query.md) in order to fetch the metric series. Natively Thanos implements [Sidecar](components/sidecar.md) (local Prometheus data), [Ruler](components/rule.md) and [Store gateway](components/store.md). This solves fetching series from Prometheus or Prometheus TSDB format, however same interface can be used to fetch metrics from other storages. 
 
 Below you can find some public integrations with other systems through StoreAPI:
 
 ### OpenTSDB
 
-[Geras](https://github.com/G-Research/geras) is an OpenTSDB integration service which can connect your OpenTSDB cluster to Thanos. Geras exposes the Thanos Storage  API, thus other Thanos components can query OpenTSDB via Geras, providing a unified  query interface over OpenTSDB and Prometheus. 
+[Geras](https://github.com/G-Research/geras) is an OpenTSDB integration service which can connect your OpenTSDB cluster to Thanos. Geras exposes the Thanos Storage  API, thus other Thanos components can query OpenTSDB via Geras, providing a unified  query interface over OpenTSDB and Prometheus.
+
+Although OpenTSDB is able to aggregte the data, it's not supported by Geras at the moment. 
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,9 @@
+# Integrations 
+
+## Geras (OpenTSDB integration)
+
+[Geras](https://github.com/G-Research/geras) is an OpenTSDB integration service which 
+can connect your OpenTSDB cluster to Thanos. Geras exposes the Thanos Storage 
+API, thus other Thanos components can query OpenTSDB via Geras, providing a unified 
+query interface over OpenTSDB and Prometheus. 
+

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,9 +1,17 @@
+---
+title: Integrations
+type: docs
+menu: thanos
+slug: /integrations.md
+---
+
 # Integrations 
 
-## Geras (OpenTSDB integration)
+[StoreAPI](https://github.com/improbable-eng/thanos/blob/master/pkg/store/storepb/rpc.proto) is a common proto interface for gRPC component that can connect to [Querier](docs/components/query.md) in order to fetch the metric series. Natively Thanos implements [Sidecar](ldocs/components/sidecar.md) (local Prometheus data), [Ruler](docs/components/rule.md) and [Store gateway](docs/components/store.md). This solves fetching series from Prometheus or Prometheus TSDB format, however same interface can be used to fetch metrics from other storages. 
 
-[Geras](https://github.com/G-Research/geras) is an OpenTSDB integration service which 
-can connect your OpenTSDB cluster to Thanos. Geras exposes the Thanos Storage 
-API, thus other Thanos components can query OpenTSDB via Geras, providing a unified 
-query interface over OpenTSDB and Prometheus. 
+Below you can find some public integrations with other systems through StoreAPI:
+
+### OpenTSDB
+
+[Geras](https://github.com/G-Research/geras) is an OpenTSDB integration service which can connect your OpenTSDB cluster to Thanos. Geras exposes the Thanos Storage  API, thus other Thanos components can query OpenTSDB via Geras, providing a unified  query interface over OpenTSDB and Prometheus. 
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -7,7 +7,7 @@ slug: /integrations.md
 
 # Integrations 
 
-[StoreAPI](https://github.com/improbable-eng/thanos/blob/master/pkg/store/storepb/rpc.proto) is a common proto interface for gRPC component that can connect to [Querier](docs/components/query.md) in order to fetch the metric series. Natively Thanos implements [Sidecar](ldocs/components/sidecar.md) (local Prometheus data), [Ruler](docs/components/rule.md) and [Store gateway](docs/components/store.md). This solves fetching series from Prometheus or Prometheus TSDB format, however same interface can be used to fetch metrics from other storages. 
+[StoreAPI](https://github.com/improbable-eng/thanos/blob/master/pkg/store/storepb/rpc.proto) is a common proto interface for gRPC component that can connect to [Querier](docs/components/query) in order to fetch the metric series. Natively Thanos implements [Sidecar](docs/components/sidecar) (local Prometheus data), [Ruler](docs/components/rule) and [Store gateway](docs/components/store). This solves fetching series from Prometheus or Prometheus TSDB format, however same interface can be used to fetch metrics from other storages. 
 
 Below you can find some public integrations with other systems through StoreAPI:
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

I am happy to add more information about the integration, but I believe if something is missing it  should be added to the original documentation of Geras.

## Changes

* add link to integrations.md from the main README.md
* start integrations.md doc
