### PR TITLE
query/querier: fix sum() inflated values problem

### DIFF
--- a/pkg/query/iter.go
+++ b/pkg/query/iter.go
@@ -123,7 +123,7 @@ func (s *chunkSeries) Iterator() storage.SeriesIterator {
 		sit = newChunkSeriesIterator(its)
 	case resAggrSum:
 		for _, c := range s.chunks {
-			its = append(its, getFirstIterator(c.Raw, c.Sum))
+			its = append(its, getFirstIterator(c.Sum, c.Raw))
 		}
 		sit = newChunkSeriesIterator(its)
 	case resAggrMin:

--- a/pkg/query/iter.go
+++ b/pkg/query/iter.go
@@ -123,7 +123,7 @@ func (s *chunkSeries) Iterator() storage.SeriesIterator {
 		sit = newChunkSeriesIterator(its)
 	case resAggrSum:
 		for _, c := range s.chunks {
-			its = append(its, getFirstIterator(c.Sum, c.Raw))
+			its = append(its, getFirstIterator(c.Raw, c.Sum))
 		}
 		sit = newChunkSeriesIterator(its)
 	case resAggrMin:

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -157,6 +157,7 @@ func aggrsFromFunc(f string) ([]storepb.Aggr, resAggr) {
 	if f == "count" || strings.HasPrefix(f, "count_") {
 		return []storepb.Aggr{storepb.Aggr_COUNT}, resAggrCount
 	}
+	// f == "sum" falls through here since we want the actual samples
 	if strings.HasPrefix(f, "sum_") {
 		return []storepb.Aggr{storepb.Aggr_SUM}, resAggrSum
 	}

--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -157,7 +157,7 @@ func aggrsFromFunc(f string) ([]storepb.Aggr, resAggr) {
 	if f == "count" || strings.HasPrefix(f, "count_") {
 		return []storepb.Aggr{storepb.Aggr_COUNT}, resAggrCount
 	}
-	if f == "sum" || strings.HasPrefix(f, "sum_") {
+	if strings.HasPrefix(f, "sum_") {
 		return []storepb.Aggr{storepb.Aggr_SUM}, resAggrSum
 	}
 	if f == "increase" || f == "rate" {

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -48,7 +48,8 @@ func TestQuerier_DownsampledData(t *testing.T) {
 			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "a"), int(resAggrSum), []sample{{99, 1}, {199, 5}}),  // SUM chunk from Store
 			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "b"), int(resAggrSum), []sample{{99, 3}, {199, 8}}),  // SUM chunk from Store
 			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "c"), int(resAggrSum), []sample{{99, 5}, {199, 15}}), // SUM chunk from Store
-			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "d"), -1, []sample{{22, 5}, {44, 8}, {199, 15}}),     // RAW one from Sidecar
+
+			storeSeriesResponse(t, labels.FromStrings("__name__", "a", "zzz", "d"), -1, []sample{{22, 5}, {44, 8}, {199, 15}}), // RAW one from Sidecar
 		},
 	}
 
@@ -86,13 +87,14 @@ func TestQuerier_DownsampledData(t *testing.T) {
 	testutil.Ok(t, err)
 	ser := []promql.Series(m)
 
+	// Prometheus code returns the latest value in a time range. It needs to do that otherwise the conversion
+	// between RAW data and pre-aggregated would not work.
 	testutil.Assert(t, len(ser) == 1, "should return 1 series (got %d)", len(ser))
 	testutil.Assert(t, ser[0].Points[0].T == 100, "expected first point to be at 100ms (got %v)", ser[0].Points[0].T)
-	testutil.Assert(t, ser[0].Points[0].V == 22, "expected first point to be 22 (got %v)", ser[0].Points[0].V)
+	testutil.Assert(t, ser[0].Points[0].V == 17, "expected first point to be 17 (got %v)", ser[0].Points[0].V)
 
 	testutil.Assert(t, ser[0].Points[1].T == 200, "expected second point to be at 200ms", ser[0].Points[1].T)
 	testutil.Assert(t, ser[0].Points[1].V == 43, "expected second point to be 43 (got %v)", ser[0].Points[1].V)
-
 }
 
 func TestQuerier_Series(t *testing.T) {


### PR DESCRIPTION
Fixes the problem with `sum` and inflated values as outlined here: https://github.com/improbable-eng/thanos/issues/922.

The problem was the following: `sum` selects the last value of each time series in each window and adds the different dimensions up however our code asks for the downsampled sum value which is equal to all samples added up in either a 5m or 1h window, and adding those up, obviously, results in an inflated value. The practical result was that as if we applied `sum_over_time(...[5m])` on top. So the fix is to ask for the last sample in each window in the case of `sum` instead of the aggregated value.

Also adds an E2E test for a typical setup of one Sidecar connected + one or more
Thanos Store nodes. Tests and shows how the whole thing with `sum` really works.

Testing: wrote a query like `sum(kafka_log_log_value{topic="iam"})` with identical Sidecar/Store nodes and selected `Max 5m/1h downsampling`. With this fix the values look sane, without - not (it jumps up very high after the downsampled data comes into play).

![Screenshot from 2019-06-26 10-43-51](https://user-images.githubusercontent.com/2377233/60161040-5af57080-97ff-11e9-9e14-502a2d3c4b5b.png)
![Screenshot from 2019-06-26 10-44-01](https://user-images.githubusercontent.com/2377233/60161044-5df06100-97ff-11e9-96f3-36d7221a205f.png)
