### PR TITLE
pkg/receive: optimize when replication factor is 1

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -313,7 +313,9 @@ func (h *Handler) parallelizeRequests(ctx context.Context, tenant string, replic
 	for endpoint := range wreqs {
 		n++
 		// If the request is not yet replicated, let's replicate it.
-		if !replicas[endpoint].replicated {
+		// If the replication factor isn't greater than 1, let's
+		// just forward the requests.
+		if !replicas[endpoint].replicated && h.options.ReplicationFactor > 1 {
 			go func(endpoint string) {
 				ec <- h.replicate(ctx, tenant, wreqs[endpoint])
 			}(endpoint)


### PR DESCRIPTION
If the replication factor is 1, we can skip the replicate() function
call and directly forward the requests. Replicating to 1 endpoint
still exhibits correct behavior but requires another func call and mem.
Additionally, doing this cleanup means that when a node fails to
store a time series locally, the returned error message is about the
local store rather than about failing to replicate to 1 endpoint.

cc @brancz @bwplotka 