### PR TITLE
Fixes #1272: fix map concurrent writes when rendering html templates in ui

### DIFF
--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -75,9 +75,9 @@ func (bu *BaseUI) executeTemplate(w http.ResponseWriter, name string, prefix str
 		return
 	}
 
-	bu.tmplFuncs["pathPrefix"] = func() string { return prefix }
-
-	t, err := template.New("").Funcs(bu.tmplFuncs).Parse(text)
+	t, err := template.New("").Funcs(bu.tmplFuncs).
+		Funcs(template.FuncMap{"pathPrefix": func() string { return prefix }}).
+		Parse(text)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes
* use `template.Funcs` to overwrite prefix rendering function to avoid concurrent map writes
<!-- Enumerate changes you made -->

## Verification
Run `go run github.com/improbable-eng/thanos/cmd/thanos query`
And then concurrently HTTP GET "http://0.0.0.0:10902/graph" 1000 times

Before change:
It panics with concurrent map writes.
After change:
No longer panics.
<!-- How you tested it? How do you know it works? -->