### PR TITLE
Update golang version in requirements

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ Thanos will work in cloud native environments as well as more traditional ones. 
 ## Requirements
 
 * One or more [Prometheus](https://prometheus.io) v2.2.1+ installations
-* golang 1.10+
+* golang 1.12+
 * An object storage bucket (optional)
 
 ## Get Thanos!


### PR DESCRIPTION
While running make I noticed the following error message:

......
building binaries /root/work/bin
thanos
github.com/prometheus/tsdb/goversion/root/work/pkg/mod/github.com/prometheus/tsdb@v0.8.0/goversion/init.go:17:9: undefined: _SoftwareRequiresGOVERSION1_12
......

The requirements in place are 1.10+
After running it with go 1.12.6 (https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz), make succeeded as expected

......
building binaries /root/work/bin
thanos
/root/work/src/github.com/improbable-eng/thanos
[root@8a40500422c4 thanos]# ./thanos --version
thanos, version 0.5.0-master (branch: master, revision: 11d77980618b1df4753eb96006188ea535f3f8a7)
  build user:       root@8a40500422c4
  build date:       20190626-16:31:59
  go version:       go1.12.6
......