### PR TITLE
*: Allow exposing multiple label-sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#1248](https://github.com/improbable-eng/thanos/pull/1248) Add a web UI to show the state of remote storage.
 
-- [#1284](https://github.com/improbable-eng/thanos/pull/1284) Add support for multiple label-sets in Info gRPC service. This deprecates the single `Labels` slice of the `InfoResponse`.
+### Changed
+
+- [#1284](https://github.com/improbable-eng/thanos/pull/1284) Add support for multiple label-sets in Info gRPC service. This deprecates the single `Labels` slice of the `InfoResponse`. Old Thanos query components are compatible with new stores, but queriers must not be mixed versions.
 
 ## [v0.5.0](https://github.com/improbable-eng/thanos/releases/tag/v0.5.0) - 2019.06.05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#1248](https://github.com/improbable-eng/thanos/pull/1248) Add a web UI to show the state of remote storage.
 
+- [#1284](https://github.com/improbable-eng/thanos/pull/1284) Add support for multiple label-sets in Info gRPC service. This deprecates the single `Labels` slice of the `InfoResponse`.
+
 ## [v0.5.0](https://github.com/improbable-eng/thanos/releases/tag/v0.5.0) - 2019.06.05
 
 TL;DR: Store LRU cache is no longer leaking, Upgraded Thanos UI to Prometheus 2.9, Fixed auto-downsampling, Moved to Go 1.12.5 and more.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Changed
 
-- [#1284](https://github.com/improbable-eng/thanos/pull/1284) Add support for multiple label-sets in Info gRPC service. This deprecates the single `Labels` slice of the `InfoResponse`. Old Thanos query components are compatible with new stores, but queriers must not be mixed versions.
+- [#1284](https://github.com/improbable-eng/thanos/pull/1284) Add support for multiple label-sets in Info gRPC service. This deprecates the single `Labels` slice of the `InfoResponse`, in a future release backward compatible handling for the single set of Labels will be removed. Upgrading to v0.6.0 or higher is advised.
 
 ## [v0.5.0](https://github.com/improbable-eng/thanos/releases/tag/v0.5.0) - 2019.06.05
 

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/uber/jaeger-client-go v2.16.0+incompatible
 	github.com/uber/jaeger-lib v2.0.0+incompatible
 	go.uber.org/atomic v1.4.0 // indirect
-	golang.org/x/net v0.0.0-20190522155817-f3200d17e092
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -33,7 +33,7 @@ type StoreSpec interface {
 	// If metadata call fails we assume that store is no longer accessible and we should not use it.
 	// NOTE: It is implementation responsibility to retry until context timeout, but a caller responsibility to manage
 	// given store connection.
-	Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []storepb.LabelSet, mint int64, maxt int64, err error)
+	Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []storepb.LabelSet, labels []storepb.Label, mint int64, maxt int64, err error)
 }
 
 type StoreStatus struct {
@@ -63,12 +63,12 @@ func (s *grpcStoreSpec) Addr() string {
 
 // Metadata method for gRPC store API tries to reach host Info method until context timeout. If we are unable to get metadata after
 // that time, we assume that the host is unhealthy and return error.
-func (s *grpcStoreSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []storepb.LabelSet, mint int64, maxt int64, err error) {
+func (s *grpcStoreSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []storepb.LabelSet, labels []storepb.Label, mint int64, maxt int64, err error) {
 	resp, err := client.Info(ctx, &storepb.InfoRequest{}, grpc.FailFast(false))
 	if err != nil {
-		return nil, 0, 0, errors.Wrapf(err, "fetching store info from %s", s.addr)
+		return nil, nil, 0, 0, errors.Wrapf(err, "fetching store info from %s", s.addr)
 	}
-	return resp.LabelSets, resp.MinTime, resp.MaxTime, nil
+	return resp.LabelSets, resp.Labels, resp.MinTime, resp.MaxTime, nil
 }
 
 // StoreSet maintains a set of active stores. It is backed up by Store Specifications that are dynamically fetched on
@@ -171,7 +171,11 @@ type storeRef struct {
 	logger log.Logger
 }
 
-func (s *storeRef) Update(labelSets []storepb.LabelSet, minTime int64, maxTime int64) {
+func (s *storeRef) Update(labelSets []storepb.LabelSet, labels []storepb.Label, minTime int64, maxTime int64) {
+	if len(labelSets) == 0 && len(labels) > 0 {
+		labelSets = []storepb.LabelSet{{Labels: labels}}
+	}
+
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
@@ -292,14 +296,14 @@ func (s *StoreSet) getHealthyStores(ctx context.Context) map[string]*storeRef {
 			store, ok := s.stores[addr]
 			if ok {
 				// Check existing store. Is it healthy? What are current metadata?
-				labelSets, minTime, maxTime, err := spec.Metadata(ctx, store.StoreClient)
+				labelSets, labels, minTime, maxTime, err := spec.Metadata(ctx, store.StoreClient)
 				if err != nil {
 					// Peer unhealthy. Do not include in healthy stores.
 					s.updateStoreStatus(store, err)
 					level.Warn(s.logger).Log("msg", "update of store node failed", "err", err, "address", addr)
 					return
 				}
-				store.Update(labelSets, minTime, maxTime)
+				store.Update(labelSets, labels, minTime, maxTime)
 			} else {
 				// New store or was unhealthy and was removed in the past - create new one.
 				conn, err := grpc.DialContext(ctx, addr, s.dialOpts...)
@@ -319,7 +323,7 @@ func (s *StoreSet) getHealthyStores(ctx context.Context) map[string]*storeRef {
 					return
 				}
 				store.storeType = component.FromProto(resp.StoreType)
-				store.Update(resp.LabelSets, resp.MinTime, resp.MaxTime)
+				store.Update(resp.LabelSets, resp.Labels, resp.MinTime, resp.MaxTime)
 			}
 
 			mtx.Lock()

--- a/pkg/query/storeset.go
+++ b/pkg/query/storeset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,14 +33,14 @@ type StoreSpec interface {
 	// If metadata call fails we assume that store is no longer accessible and we should not use it.
 	// NOTE: It is implementation responsibility to retry until context timeout, but a caller responsibility to manage
 	// given store connection.
-	Metadata(ctx context.Context, client storepb.StoreClient) (labels []storepb.Label, mint int64, maxt int64, err error)
+	Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []storepb.LabelSet, mint int64, maxt int64, err error)
 }
 
 type StoreStatus struct {
 	Name      string
 	LastCheck time.Time
 	LastError error
-	Labels    []storepb.Label
+	LabelSets []storepb.LabelSet
 	StoreType component.StoreAPI
 	MinTime   int64
 	MaxTime   int64
@@ -62,12 +63,12 @@ func (s *grpcStoreSpec) Addr() string {
 
 // Metadata method for gRPC store API tries to reach host Info method until context timeout. If we are unable to get metadata after
 // that time, we assume that the host is unhealthy and return error.
-func (s *grpcStoreSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labels []storepb.Label, mint int64, maxt int64, err error) {
+func (s *grpcStoreSpec) Metadata(ctx context.Context, client storepb.StoreClient) (labelSets []storepb.LabelSet, mint int64, maxt int64, err error) {
 	resp, err := client.Info(ctx, &storepb.InfoRequest{}, grpc.FailFast(false))
 	if err != nil {
 		return nil, 0, 0, errors.Wrapf(err, "fetching store info from %s", s.addr)
 	}
-	return resp.Labels, resp.MinTime, resp.MaxTime, nil
+	return resp.LabelSets, resp.MinTime, resp.MaxTime, nil
 }
 
 // StoreSet maintains a set of active stores. It is backed up by Store Specifications that are dynamically fetched on
@@ -81,13 +82,13 @@ type StoreSet struct {
 	dialOpts            []grpc.DialOption
 	gRPCInfoCallTimeout time.Duration
 
-	mtx                   sync.RWMutex
-	storesStatusesMtx     sync.RWMutex
-	stores                map[string]*storeRef
-	storeNodeConnections  prometheus.Gauge
-	externalLabelStores   map[string]int
-	storeStatuses         map[string]*StoreStatus
-	unhealthyStoreTimeout time.Duration
+	mtx                              sync.RWMutex
+	storesStatusesMtx                sync.RWMutex
+	stores                           map[string]*storeRef
+	storeNodeConnections             prometheus.Gauge
+	externalLabelOccurrencesInStores map[string]int
+	storeStatuses                    map[string]*StoreStatus
+	unhealthyStoreTimeout            time.Duration
 }
 
 type storeSetNodeCollector struct {
@@ -135,12 +136,12 @@ func NewStoreSet(
 	}
 
 	ss := &StoreSet{
-		logger:                log.With(logger, "component", "storeset"),
-		storeSpecs:            storeSpecs,
-		dialOpts:              dialOpts,
-		storeNodeConnections:  storeNodeConnections,
-		gRPCInfoCallTimeout:   10 * time.Second,
-		externalLabelStores:   map[string]int{},
+		logger:                           log.With(logger, "component", "storeset"),
+		storeSpecs:                       storeSpecs,
+		dialOpts:                         dialOpts,
+		storeNodeConnections:             storeNodeConnections,
+		gRPCInfoCallTimeout:              10 * time.Second,
+		externalLabelOccurrencesInStores: map[string]int{},
 		stores:                make(map[string]*storeRef),
 		storeStatuses:         make(map[string]*StoreStatus),
 		unhealthyStoreTimeout: unhealthyStoreTimeout,
@@ -162,7 +163,7 @@ type storeRef struct {
 	addr string
 
 	// Meta (can change during runtime).
-	labels    []storepb.Label
+	labelSets []storepb.LabelSet
 	storeType component.StoreAPI
 	minTime   int64
 	maxTime   int64
@@ -170,19 +171,19 @@ type storeRef struct {
 	logger log.Logger
 }
 
-func (s *storeRef) Update(labels []storepb.Label, minTime int64, maxTime int64) {
-	s.mtx.RLock()
-	defer s.mtx.RUnlock()
+func (s *storeRef) Update(labelSets []storepb.LabelSet, minTime int64, maxTime int64) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 
-	s.labels = labels
+	s.labelSets = labelSets
 	s.minTime = minTime
 	s.maxTime = maxTime
 }
 
-func (s *storeRef) Labels() []storepb.Label {
+func (s *storeRef) LabelSets() []storepb.LabelSet {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
-	return s.labels
+	return s.labelSets
 }
 
 func (s *storeRef) TimeRange() (int64, int64) {
@@ -194,7 +195,7 @@ func (s *storeRef) TimeRange() (int64, int64) {
 
 func (s *storeRef) String() string {
 	mint, maxt := s.TimeRange()
-	return fmt.Sprintf("Addr: %s Labels: %v Mint: %d Maxt: %d", s.addr, s.Labels(), mint, maxt)
+	return fmt.Sprintf("Addr: %s LabelSets: %v Mint: %d Maxt: %d", s.addr, storepb.LabelSetsToString(s.LabelSets()), mint, maxt)
 }
 
 func (s *storeRef) Addr() string {
@@ -211,10 +212,11 @@ func (s *StoreSet) Update(ctx context.Context) {
 	healthyStores := s.getHealthyStores(ctx)
 
 	// Record the number of occurrences of external label combinations for current store slice.
-	externalLabelStores := map[string]int{}
+	externalLabelOccurrencesInStores := map[string]int{}
 	for _, st := range healthyStores {
-		externalLabelStores[externalLabelsFromStore(st)]++
+		externalLabelOccurrencesInStores[externalLabelsFromStore(st)]++
 	}
+	level.Debug(s.logger).Log("msg", "updating healthy stores", "externalLabelOccurrencesInStores", fmt.Sprintf("%#+v", externalLabelOccurrencesInStores))
 
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
@@ -238,10 +240,12 @@ func (s *StoreSet) Update(ctx context.Context) {
 		// No external labels means strictly store gateway or ruler and it is fine to have access to multiple instances of them.
 		//
 		// Sidecar will error out if it will be configured with empty external labels.
-		if len(store.Labels()) > 0 && externalLabelStores[externalLabelsFromStore(store)] != 1 {
+		externalLabels := externalLabelsFromStore(store)
+		storesWithExternalLabels := externalLabelOccurrencesInStores[externalLabels]
+		if len(store.LabelSets()) > 0 && storesWithExternalLabels != 1 {
 			store.close()
 			s.updateStoreStatus(store, errors.New(droppingStoreMessage))
-			level.Warn(s.logger).Log("msg", droppingStoreMessage, "address", addr)
+			level.Warn(s.logger).Log("msg", droppingStoreMessage, "address", addr, "extLset", externalLabels, "duplicates", storesWithExternalLabels)
 			continue
 		}
 
@@ -254,7 +258,7 @@ func (s *StoreSet) Update(ctx context.Context) {
 		s.updateStoreStatus(store, nil)
 		level.Info(s.logger).Log("msg", "adding new store to query storeset", "address", addr)
 	}
-	s.externalLabelStores = externalLabelStores
+	s.externalLabelOccurrencesInStores = externalLabelOccurrencesInStores
 	s.storeNodeConnections.Set(float64(len(s.stores)))
 	s.cleanUpStoreStatuses()
 }
@@ -288,14 +292,14 @@ func (s *StoreSet) getHealthyStores(ctx context.Context) map[string]*storeRef {
 			store, ok := s.stores[addr]
 			if ok {
 				// Check existing store. Is it healthy? What are current metadata?
-				labels, minTime, maxTime, err := spec.Metadata(ctx, store.StoreClient)
+				labelSets, minTime, maxTime, err := spec.Metadata(ctx, store.StoreClient)
 				if err != nil {
 					// Peer unhealthy. Do not include in healthy stores.
 					s.updateStoreStatus(store, err)
 					level.Warn(s.logger).Log("msg", "update of store node failed", "err", err, "address", addr)
 					return
 				}
-				store.Update(labels, minTime, maxTime)
+				store.Update(labelSets, minTime, maxTime)
 			} else {
 				// New store or was unhealthy and was removed in the past - create new one.
 				conn, err := grpc.DialContext(ctx, addr, s.dialOpts...)
@@ -315,7 +319,7 @@ func (s *StoreSet) getHealthyStores(ctx context.Context) map[string]*storeRef {
 					return
 				}
 				store.storeType = component.FromProto(resp.StoreType)
-				store.Update(resp.Labels, resp.MinTime, resp.MaxTime)
+				store.Update(resp.LabelSets, resp.MinTime, resp.MaxTime)
 			}
 
 			mtx.Lock()
@@ -331,16 +335,21 @@ func (s *StoreSet) getHealthyStores(ctx context.Context) map[string]*storeRef {
 }
 
 func externalLabelsFromStore(store *storeRef) string {
-	tsdbLabels := labels.Labels{}
-	for _, l := range store.labels {
-		tsdbLabels = append(tsdbLabels, labels.Label{
-			Name:  l.Name,
-			Value: l.Value,
-		})
+	tsdbLabelSetStrings := make([]string, 0, len(store.labelSets))
+	for _, ls := range store.labelSets {
+		tsdbLabels := labels.Labels{}
+		for _, l := range ls.Labels {
+			tsdbLabels = append(tsdbLabels, labels.Label{
+				Name:  l.Name,
+				Value: l.Value,
+			})
+		}
+		sort.Sort(tsdbLabels)
+		tsdbLabelSetStrings = append(tsdbLabelSetStrings, tsdbLabels.String())
 	}
-	sort.Sort(tsdbLabels)
+	sort.Strings(tsdbLabelSetStrings)
 
-	return tsdbLabels.String()
+	return strings.Join(tsdbLabelSetStrings, ",")
 }
 
 func (s *StoreSet) updateStoreStatus(store *storeRef, err error) {
@@ -357,7 +366,7 @@ func (s *StoreSet) updateStoreStatus(store *storeRef, err error) {
 	status.LastCheck = time.Now()
 
 	if err == nil {
-		status.Labels = store.labels
+		status.LabelSets = store.labelSets
 		status.StoreType = store.storeType
 		status.MinTime = store.minTime
 		status.MaxTime = store.maxTime
@@ -385,8 +394,8 @@ func (s *StoreSet) externalLabelOccurrences() map[string]int {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 
-	r := make(map[string]int, len(s.externalLabelStores))
-	for k, v := range s.externalLabelStores {
+	r := make(map[string]int, len(s.externalLabelOccurrencesInStores))
+	for k, v := range s.externalLabelOccurrencesInStores {
 		r[k] = v
 	}
 

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -98,6 +98,15 @@ func (p *PrometheusStore) Info(ctx context.Context, r *storepb.InfoRequest) (*st
 			Value: l.Value,
 		})
 	}
+
+	// Until we deprecate the single labels in the reply, we just duplicate
+	// them here for migration/compatibility purposes.
+	res.LabelSets = []storepb.LabelSet{}
+	if len(res.Labels) > 0 {
+		res.LabelSets = append(res.LabelSets, storepb.LabelSet{
+			Labels: res.Labels,
+		})
+	}
 	return res, nil
 }
 

--- a/pkg/store/prompb/remote.pb.go
+++ b/pkg/store/prompb/remote.pb.go
@@ -3,14 +3,15 @@
 
 package prompb
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
+import (
+	encoding_binary "encoding/binary"
+	fmt "fmt"
+	io "io"
+	math "math"
 
-import encoding_binary "encoding/binary"
-
-import io "io"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -38,6 +39,7 @@ var LabelMatcher_Type_name = map[int32]string{
 	2: "RE",
 	3: "NRE",
 }
+
 var LabelMatcher_Type_value = map[string]int32{
 	"EQ":  0,
 	"NEQ": 1,
@@ -48,8 +50,9 @@ var LabelMatcher_Type_value = map[string]int32{
 func (x LabelMatcher_Type) String() string {
 	return proto.EnumName(LabelMatcher_Type_name, int32(x))
 }
+
 func (LabelMatcher_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{8, 0}
+	return fileDescriptor_eefc82927d57d89b, []int{8, 0}
 }
 
 type WriteRequest struct {
@@ -63,7 +66,7 @@ func (m *WriteRequest) Reset()         { *m = WriteRequest{} }
 func (m *WriteRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteRequest) ProtoMessage()    {}
 func (*WriteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{0}
+	return fileDescriptor_eefc82927d57d89b, []int{0}
 }
 func (m *WriteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -80,8 +83,8 @@ func (m *WriteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-func (dst *WriteRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_WriteRequest.Merge(dst, src)
+func (m *WriteRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_WriteRequest.Merge(m, src)
 }
 func (m *WriteRequest) XXX_Size() int {
 	return m.Size()
@@ -103,7 +106,7 @@ func (m *ReadRequest) Reset()         { *m = ReadRequest{} }
 func (m *ReadRequest) String() string { return proto.CompactTextString(m) }
 func (*ReadRequest) ProtoMessage()    {}
 func (*ReadRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{1}
+	return fileDescriptor_eefc82927d57d89b, []int{1}
 }
 func (m *ReadRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -120,8 +123,8 @@ func (m *ReadRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
-func (dst *ReadRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReadRequest.Merge(dst, src)
+func (m *ReadRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadRequest.Merge(m, src)
 }
 func (m *ReadRequest) XXX_Size() int {
 	return m.Size()
@@ -144,7 +147,7 @@ func (m *ReadResponse) Reset()         { *m = ReadResponse{} }
 func (m *ReadResponse) String() string { return proto.CompactTextString(m) }
 func (*ReadResponse) ProtoMessage()    {}
 func (*ReadResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{2}
+	return fileDescriptor_eefc82927d57d89b, []int{2}
 }
 func (m *ReadResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -161,8 +164,8 @@ func (m *ReadResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-func (dst *ReadResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReadResponse.Merge(dst, src)
+func (m *ReadResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadResponse.Merge(m, src)
 }
 func (m *ReadResponse) XXX_Size() int {
 	return m.Size()
@@ -187,7 +190,7 @@ func (m *Query) Reset()         { *m = Query{} }
 func (m *Query) String() string { return proto.CompactTextString(m) }
 func (*Query) ProtoMessage()    {}
 func (*Query) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{3}
+	return fileDescriptor_eefc82927d57d89b, []int{3}
 }
 func (m *Query) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -204,8 +207,8 @@ func (m *Query) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *Query) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Query.Merge(dst, src)
+func (m *Query) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Query.Merge(m, src)
 }
 func (m *Query) XXX_Size() int {
 	return m.Size()
@@ -227,7 +230,7 @@ func (m *QueryResult) Reset()         { *m = QueryResult{} }
 func (m *QueryResult) String() string { return proto.CompactTextString(m) }
 func (*QueryResult) ProtoMessage()    {}
 func (*QueryResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{4}
+	return fileDescriptor_eefc82927d57d89b, []int{4}
 }
 func (m *QueryResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -244,8 +247,8 @@ func (m *QueryResult) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
-func (dst *QueryResult) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryResult.Merge(dst, src)
+func (m *QueryResult) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryResult.Merge(m, src)
 }
 func (m *QueryResult) XXX_Size() int {
 	return m.Size()
@@ -268,7 +271,7 @@ func (m *Sample) Reset()         { *m = Sample{} }
 func (m *Sample) String() string { return proto.CompactTextString(m) }
 func (*Sample) ProtoMessage()    {}
 func (*Sample) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{5}
+	return fileDescriptor_eefc82927d57d89b, []int{5}
 }
 func (m *Sample) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -285,8 +288,8 @@ func (m *Sample) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *Sample) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Sample.Merge(dst, src)
+func (m *Sample) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Sample.Merge(m, src)
 }
 func (m *Sample) XXX_Size() int {
 	return m.Size()
@@ -309,7 +312,7 @@ func (m *TimeSeries) Reset()         { *m = TimeSeries{} }
 func (m *TimeSeries) String() string { return proto.CompactTextString(m) }
 func (*TimeSeries) ProtoMessage()    {}
 func (*TimeSeries) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{6}
+	return fileDescriptor_eefc82927d57d89b, []int{6}
 }
 func (m *TimeSeries) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -326,8 +329,8 @@ func (m *TimeSeries) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *TimeSeries) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TimeSeries.Merge(dst, src)
+func (m *TimeSeries) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TimeSeries.Merge(m, src)
 }
 func (m *TimeSeries) XXX_Size() int {
 	return m.Size()
@@ -350,7 +353,7 @@ func (m *Label) Reset()         { *m = Label{} }
 func (m *Label) String() string { return proto.CompactTextString(m) }
 func (*Label) ProtoMessage()    {}
 func (*Label) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{7}
+	return fileDescriptor_eefc82927d57d89b, []int{7}
 }
 func (m *Label) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -367,8 +370,8 @@ func (m *Label) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *Label) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Label.Merge(dst, src)
+func (m *Label) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Label.Merge(m, src)
 }
 func (m *Label) XXX_Size() int {
 	return m.Size()
@@ -393,7 +396,7 @@ func (m *LabelMatcher) Reset()         { *m = LabelMatcher{} }
 func (m *LabelMatcher) String() string { return proto.CompactTextString(m) }
 func (*LabelMatcher) ProtoMessage()    {}
 func (*LabelMatcher) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{8}
+	return fileDescriptor_eefc82927d57d89b, []int{8}
 }
 func (m *LabelMatcher) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -410,8 +413,8 @@ func (m *LabelMatcher) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-func (dst *LabelMatcher) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LabelMatcher.Merge(dst, src)
+func (m *LabelMatcher) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LabelMatcher.Merge(m, src)
 }
 func (m *LabelMatcher) XXX_Size() int {
 	return m.Size()
@@ -436,7 +439,7 @@ func (m *ReadHints) Reset()         { *m = ReadHints{} }
 func (m *ReadHints) String() string { return proto.CompactTextString(m) }
 func (*ReadHints) ProtoMessage()    {}
 func (*ReadHints) Descriptor() ([]byte, []int) {
-	return fileDescriptor_remote_930be8df34ca631b, []int{9}
+	return fileDescriptor_eefc82927d57d89b, []int{9}
 }
 func (m *ReadHints) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -453,8 +456,8 @@ func (m *ReadHints) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *ReadHints) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReadHints.Merge(dst, src)
+func (m *ReadHints) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReadHints.Merge(m, src)
 }
 func (m *ReadHints) XXX_Size() int {
 	return m.Size()
@@ -466,6 +469,7 @@ func (m *ReadHints) XXX_DiscardUnknown() {
 var xxx_messageInfo_ReadHints proto.InternalMessageInfo
 
 func init() {
+	proto.RegisterEnum("prometheus.LabelMatcher_Type", LabelMatcher_Type_name, LabelMatcher_Type_value)
 	proto.RegisterType((*WriteRequest)(nil), "prometheus.WriteRequest")
 	proto.RegisterType((*ReadRequest)(nil), "prometheus.ReadRequest")
 	proto.RegisterType((*ReadResponse)(nil), "prometheus.ReadResponse")
@@ -476,8 +480,48 @@ func init() {
 	proto.RegisterType((*Label)(nil), "prometheus.Label")
 	proto.RegisterType((*LabelMatcher)(nil), "prometheus.LabelMatcher")
 	proto.RegisterType((*ReadHints)(nil), "prometheus.ReadHints")
-	proto.RegisterEnum("prometheus.LabelMatcher_Type", LabelMatcher_Type_name, LabelMatcher_Type_value)
 }
+
+func init() { proto.RegisterFile("remote.proto", fileDescriptor_eefc82927d57d89b) }
+
+var fileDescriptor_eefc82927d57d89b = []byte{
+	// 535 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x53, 0x51, 0x8b, 0xd3, 0x40,
+	0x10, 0xbe, 0x34, 0x6d, 0x72, 0x9d, 0x96, 0x23, 0x0e, 0x77, 0x5e, 0x15, 0xad, 0x47, 0x9e, 0x0a,
+	0x4a, 0x8f, 0xd6, 0x07, 0x41, 0xee, 0x41, 0x0e, 0x8a, 0x82, 0x57, 0xa1, 0x7b, 0x05, 0xc1, 0x97,
+	0x23, 0xbd, 0x8e, 0xd7, 0x4a, 0x36, 0x49, 0xb3, 0x1b, 0xa1, 0x3f, 0xc4, 0xff, 0xd4, 0x47, 0x7f,
+	0x81, 0x68, 0x7f, 0x89, 0xec, 0x6e, 0xd2, 0xae, 0x78, 0x3e, 0xf9, 0x96, 0x99, 0xf9, 0xe6, 0x9b,
+	0xef, 0xdb, 0x99, 0x40, 0x3b, 0x27, 0x9e, 0x4a, 0xea, 0x67, 0x79, 0x2a, 0x53, 0x84, 0x2c, 0x4f,
+	0x39, 0xc9, 0x05, 0x15, 0xe2, 0xf1, 0xf1, 0x5d, 0x7a, 0x97, 0xea, 0xf4, 0xb9, 0xfa, 0x32, 0x88,
+	0xf0, 0x0a, 0xda, 0x1f, 0xf3, 0xa5, 0x24, 0x46, 0xab, 0x82, 0x84, 0xc4, 0x0b, 0x00, 0xb9, 0xe4,
+	0x24, 0x28, 0x5f, 0x92, 0xe8, 0x38, 0x67, 0x6e, 0xaf, 0x35, 0x7c, 0xd8, 0xdf, 0xd3, 0xf4, 0xa7,
+	0x4b, 0x4e, 0xd7, 0xba, 0x7a, 0x59, 0xdf, 0xfc, 0x78, 0x76, 0xc0, 0x2c, 0x7c, 0xf8, 0x06, 0x5a,
+	0x8c, 0xa2, 0x79, 0x45, 0x36, 0x00, 0x7f, 0x55, 0xd8, 0x4c, 0x0f, 0x6c, 0xa6, 0x49, 0x41, 0xf9,
+	0xba, 0x24, 0xa9, 0x70, 0xe1, 0x5b, 0x68, 0x1b, 0x06, 0x91, 0xa5, 0x89, 0x20, 0x7c, 0x05, 0x7e,
+	0x4e, 0xa2, 0x88, 0x65, 0x45, 0x71, 0xfa, 0x17, 0x05, 0xd3, 0xf5, 0x8a, 0xa8, 0x44, 0x87, 0x1b,
+	0x07, 0x1a, 0xba, 0x8c, 0x2f, 0x00, 0x85, 0x8c, 0x72, 0x79, 0xa3, 0x85, 0xca, 0x88, 0x67, 0x37,
+	0x5c, 0xb1, 0x39, 0x3d, 0x97, 0x05, 0xba, 0x32, 0xad, 0x0a, 0x63, 0x81, 0x3d, 0x08, 0x28, 0x99,
+	0xff, 0x89, 0xad, 0x69, 0xec, 0x11, 0x25, 0x73, 0x1b, 0xf9, 0x1a, 0x0e, 0x79, 0x24, 0x6f, 0x17,
+	0x94, 0x8b, 0x8e, 0xab, 0xb5, 0x75, 0x6c, 0x6d, 0x57, 0xd1, 0x8c, 0xe2, 0xb1, 0x01, 0x94, 0xe2,
+	0x76, 0x78, 0x7c, 0x0e, 0x8d, 0xc5, 0x32, 0x91, 0xa2, 0x53, 0x3f, 0x73, 0x7a, 0xad, 0xe1, 0x89,
+	0xdd, 0xa8, 0xfc, 0xbf, 0x53, 0x45, 0x66, 0x30, 0xe1, 0x7b, 0x68, 0x59, 0x46, 0xff, 0x73, 0x45,
+	0x17, 0xe0, 0x5d, 0x47, 0x3c, 0x8b, 0x09, 0x8f, 0xa1, 0xf1, 0x35, 0x8a, 0x0b, 0xd2, 0x4f, 0xe1,
+	0x30, 0x13, 0xe0, 0x13, 0x68, 0xee, 0xbc, 0x97, 0xc6, 0xf7, 0x89, 0x70, 0x05, 0xb0, 0x67, 0xc7,
+	0x73, 0xf0, 0x62, 0xe5, 0xf2, 0xde, 0xf5, 0x6a, 0xff, 0xa5, 0x80, 0x12, 0x86, 0x43, 0xf0, 0x85,
+	0x1e, 0xae, 0xde, 0x54, 0x75, 0xa0, 0xdd, 0x61, 0x74, 0x55, 0x8b, 0x2c, 0x81, 0xe1, 0x00, 0x1a,
+	0x9a, 0x0a, 0x11, 0xea, 0x49, 0xc4, 0x8d, 0xdc, 0x26, 0xd3, 0xdf, 0x7b, 0x0f, 0x35, 0x9d, 0x34,
+	0x41, 0xf8, 0xcd, 0x81, 0xb6, 0xfd, 0xfc, 0x38, 0x80, 0xba, 0x5c, 0x67, 0xa6, 0xf5, 0x68, 0xf8,
+	0xf4, 0x5f, 0x6b, 0xea, 0x4f, 0xd7, 0x19, 0x31, 0x0d, 0xdd, 0x4d, 0xab, 0xdd, 0x37, 0xcd, 0xb5,
+	0xa7, 0xf5, 0xa0, 0xae, 0xfa, 0xd0, 0x83, 0xda, 0x68, 0x12, 0x1c, 0xa0, 0x0f, 0xee, 0x87, 0xd1,
+	0x24, 0x70, 0x54, 0x82, 0x8d, 0x82, 0x9a, 0x4e, 0xb0, 0x51, 0xe0, 0x86, 0x5f, 0xa0, 0xb9, 0x5b,
+	0x2e, 0x9e, 0x82, 0x2f, 0x24, 0x59, 0xb7, 0xe8, 0xa9, 0x70, 0x2c, 0xd4, 0xe4, 0xcf, 0x45, 0x72,
+	0x5b, 0x4d, 0x56, 0xdf, 0xf8, 0x08, 0x0e, 0xcd, 0x0d, 0x73, 0xa1, 0x87, 0xbb, 0xcc, 0xd7, 0xf1,
+	0x58, 0xe0, 0x09, 0x78, 0xea, 0x60, 0xb9, 0xb9, 0x25, 0x97, 0x35, 0x28, 0x99, 0x8f, 0xc5, 0x65,
+	0x67, 0xf3, 0xab, 0x7b, 0xb0, 0xd9, 0x76, 0x9d, 0xef, 0xdb, 0xae, 0xf3, 0x73, 0xdb, 0x75, 0x3e,
+	0x79, 0xca, 0x75, 0x36, 0x9b, 0x79, 0xfa, 0xcf, 0x7f, 0xf9, 0x3b, 0x00, 0x00, 0xff, 0xff, 0xe5,
+	0xcf, 0xa9, 0xcb, 0x2b, 0x04, 0x00, 0x00,
+}
+
 func (m *WriteRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1100,7 +1144,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1128,7 +1172,7 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1137,6 +1181,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1152,6 +1199,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -1182,7 +1232,7 @@ func (m *ReadRequest) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1210,7 +1260,7 @@ func (m *ReadRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1219,6 +1269,9 @@ func (m *ReadRequest) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1234,6 +1287,9 @@ func (m *ReadRequest) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -1264,7 +1320,7 @@ func (m *ReadResponse) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1292,7 +1348,7 @@ func (m *ReadResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1301,6 +1357,9 @@ func (m *ReadResponse) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1316,6 +1375,9 @@ func (m *ReadResponse) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -1346,7 +1408,7 @@ func (m *Query) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1374,7 +1436,7 @@ func (m *Query) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.StartTimestampMs |= (int64(b) & 0x7F) << shift
+				m.StartTimestampMs |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1393,7 +1455,7 @@ func (m *Query) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.EndTimestampMs |= (int64(b) & 0x7F) << shift
+				m.EndTimestampMs |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1412,7 +1474,7 @@ func (m *Query) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1421,6 +1483,9 @@ func (m *Query) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1443,7 +1508,7 @@ func (m *Query) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1452,6 +1517,9 @@ func (m *Query) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1469,6 +1537,9 @@ func (m *Query) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -1499,7 +1570,7 @@ func (m *QueryResult) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1527,7 +1598,7 @@ func (m *QueryResult) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1536,6 +1607,9 @@ func (m *QueryResult) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1551,6 +1625,9 @@ func (m *QueryResult) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -1581,7 +1658,7 @@ func (m *Sample) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1620,7 +1697,7 @@ func (m *Sample) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Timestamp |= (int64(b) & 0x7F) << shift
+				m.Timestamp |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1632,6 +1709,9 @@ func (m *Sample) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -1662,7 +1742,7 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1690,7 +1770,7 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1699,6 +1779,9 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1721,7 +1804,7 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1730,6 +1813,9 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1745,6 +1831,9 @@ func (m *TimeSeries) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -1775,7 +1864,7 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1803,7 +1892,7 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1813,6 +1902,9 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1832,7 +1924,7 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1842,6 +1934,9 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1854,6 +1949,9 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -1884,7 +1982,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1912,7 +2010,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Type |= (LabelMatcher_Type(b) & 0x7F) << shift
+				m.Type |= LabelMatcher_Type(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1931,7 +2029,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1941,6 +2039,9 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1960,7 +2061,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1970,6 +2071,9 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1982,6 +2086,9 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -2012,7 +2119,7 @@ func (m *ReadHints) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2040,7 +2147,7 @@ func (m *ReadHints) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.StepMs |= (int64(b) & 0x7F) << shift
+				m.StepMs |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2059,7 +2166,7 @@ func (m *ReadHints) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2069,6 +2176,9 @@ func (m *ReadHints) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRemote
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRemote
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2088,7 +2198,7 @@ func (m *ReadHints) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.StartMs |= (int64(b) & 0x7F) << shift
+				m.StartMs |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2107,7 +2217,7 @@ func (m *ReadHints) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.EndMs |= (int64(b) & 0x7F) << shift
+				m.EndMs |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2119,6 +2229,9 @@ func (m *ReadHints) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRemote
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRemote
 			}
 			if (iNdEx + skippy) > l {
@@ -2188,8 +2301,11 @@ func skipRemote(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			iNdEx += length
 			if length < 0 {
+				return 0, ErrInvalidLengthRemote
+			}
+			iNdEx += length
+			if iNdEx < 0 {
 				return 0, ErrInvalidLengthRemote
 			}
 			return iNdEx, nil
@@ -2220,6 +2336,9 @@ func skipRemote(dAtA []byte) (n int, err error) {
 					return 0, err
 				}
 				iNdEx = start + next
+				if iNdEx < 0 {
+					return 0, ErrInvalidLengthRemote
+				}
 			}
 			return iNdEx, nil
 		case 4:
@@ -2238,43 +2357,3 @@ var (
 	ErrInvalidLengthRemote = fmt.Errorf("proto: negative length found during unmarshaling")
 	ErrIntOverflowRemote   = fmt.Errorf("proto: integer overflow")
 )
-
-func init() { proto.RegisterFile("remote.proto", fileDescriptor_remote_930be8df34ca631b) }
-
-var fileDescriptor_remote_930be8df34ca631b = []byte{
-	// 535 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x53, 0x51, 0x8b, 0xd3, 0x40,
-	0x10, 0xbe, 0x34, 0x6d, 0x72, 0x9d, 0x96, 0x23, 0x0e, 0x77, 0x5e, 0x15, 0xad, 0x47, 0x9e, 0x0a,
-	0x4a, 0x8f, 0xd6, 0x07, 0x41, 0xee, 0x41, 0x0e, 0x8a, 0x82, 0x57, 0xa1, 0x7b, 0x05, 0xc1, 0x97,
-	0x23, 0xbd, 0x8e, 0xd7, 0x4a, 0x36, 0x49, 0xb3, 0x1b, 0xa1, 0x3f, 0xc4, 0xff, 0xd4, 0x47, 0x7f,
-	0x81, 0x68, 0x7f, 0x89, 0xec, 0x6e, 0xd2, 0xae, 0x78, 0x3e, 0xf9, 0x96, 0x99, 0xf9, 0xe6, 0x9b,
-	0xef, 0xdb, 0x99, 0x40, 0x3b, 0x27, 0x9e, 0x4a, 0xea, 0x67, 0x79, 0x2a, 0x53, 0x84, 0x2c, 0x4f,
-	0x39, 0xc9, 0x05, 0x15, 0xe2, 0xf1, 0xf1, 0x5d, 0x7a, 0x97, 0xea, 0xf4, 0xb9, 0xfa, 0x32, 0x88,
-	0xf0, 0x0a, 0xda, 0x1f, 0xf3, 0xa5, 0x24, 0x46, 0xab, 0x82, 0x84, 0xc4, 0x0b, 0x00, 0xb9, 0xe4,
-	0x24, 0x28, 0x5f, 0x92, 0xe8, 0x38, 0x67, 0x6e, 0xaf, 0x35, 0x7c, 0xd8, 0xdf, 0xd3, 0xf4, 0xa7,
-	0x4b, 0x4e, 0xd7, 0xba, 0x7a, 0x59, 0xdf, 0xfc, 0x78, 0x76, 0xc0, 0x2c, 0x7c, 0xf8, 0x06, 0x5a,
-	0x8c, 0xa2, 0x79, 0x45, 0x36, 0x00, 0x7f, 0x55, 0xd8, 0x4c, 0x0f, 0x6c, 0xa6, 0x49, 0x41, 0xf9,
-	0xba, 0x24, 0xa9, 0x70, 0xe1, 0x5b, 0x68, 0x1b, 0x06, 0x91, 0xa5, 0x89, 0x20, 0x7c, 0x05, 0x7e,
-	0x4e, 0xa2, 0x88, 0x65, 0x45, 0x71, 0xfa, 0x17, 0x05, 0xd3, 0xf5, 0x8a, 0xa8, 0x44, 0x87, 0x1b,
-	0x07, 0x1a, 0xba, 0x8c, 0x2f, 0x00, 0x85, 0x8c, 0x72, 0x79, 0xa3, 0x85, 0xca, 0x88, 0x67, 0x37,
-	0x5c, 0xb1, 0x39, 0x3d, 0x97, 0x05, 0xba, 0x32, 0xad, 0x0a, 0x63, 0x81, 0x3d, 0x08, 0x28, 0x99,
-	0xff, 0x89, 0xad, 0x69, 0xec, 0x11, 0x25, 0x73, 0x1b, 0xf9, 0x1a, 0x0e, 0x79, 0x24, 0x6f, 0x17,
-	0x94, 0x8b, 0x8e, 0xab, 0xb5, 0x75, 0x6c, 0x6d, 0x57, 0xd1, 0x8c, 0xe2, 0xb1, 0x01, 0x94, 0xe2,
-	0x76, 0x78, 0x7c, 0x0e, 0x8d, 0xc5, 0x32, 0x91, 0xa2, 0x53, 0x3f, 0x73, 0x7a, 0xad, 0xe1, 0x89,
-	0xdd, 0xa8, 0xfc, 0xbf, 0x53, 0x45, 0x66, 0x30, 0xe1, 0x7b, 0x68, 0x59, 0x46, 0xff, 0x73, 0x45,
-	0x17, 0xe0, 0x5d, 0x47, 0x3c, 0x8b, 0x09, 0x8f, 0xa1, 0xf1, 0x35, 0x8a, 0x0b, 0xd2, 0x4f, 0xe1,
-	0x30, 0x13, 0xe0, 0x13, 0x68, 0xee, 0xbc, 0x97, 0xc6, 0xf7, 0x89, 0x70, 0x05, 0xb0, 0x67, 0xc7,
-	0x73, 0xf0, 0x62, 0xe5, 0xf2, 0xde, 0xf5, 0x6a, 0xff, 0xa5, 0x80, 0x12, 0x86, 0x43, 0xf0, 0x85,
-	0x1e, 0xae, 0xde, 0x54, 0x75, 0xa0, 0xdd, 0x61, 0x74, 0x55, 0x8b, 0x2c, 0x81, 0xe1, 0x00, 0x1a,
-	0x9a, 0x0a, 0x11, 0xea, 0x49, 0xc4, 0x8d, 0xdc, 0x26, 0xd3, 0xdf, 0x7b, 0x0f, 0x35, 0x9d, 0x34,
-	0x41, 0xf8, 0xcd, 0x81, 0xb6, 0xfd, 0xfc, 0x38, 0x80, 0xba, 0x5c, 0x67, 0xa6, 0xf5, 0x68, 0xf8,
-	0xf4, 0x5f, 0x6b, 0xea, 0x4f, 0xd7, 0x19, 0x31, 0x0d, 0xdd, 0x4d, 0xab, 0xdd, 0x37, 0xcd, 0xb5,
-	0xa7, 0xf5, 0xa0, 0xae, 0xfa, 0xd0, 0x83, 0xda, 0x68, 0x12, 0x1c, 0xa0, 0x0f, 0xee, 0x87, 0xd1,
-	0x24, 0x70, 0x54, 0x82, 0x8d, 0x82, 0x9a, 0x4e, 0xb0, 0x51, 0xe0, 0x86, 0x5f, 0xa0, 0xb9, 0x5b,
-	0x2e, 0x9e, 0x82, 0x2f, 0x24, 0x59, 0xb7, 0xe8, 0xa9, 0x70, 0x2c, 0xd4, 0xe4, 0xcf, 0x45, 0x72,
-	0x5b, 0x4d, 0x56, 0xdf, 0xf8, 0x08, 0x0e, 0xcd, 0x0d, 0x73, 0xa1, 0x87, 0xbb, 0xcc, 0xd7, 0xf1,
-	0x58, 0xe0, 0x09, 0x78, 0xea, 0x60, 0xb9, 0xb9, 0x25, 0x97, 0x35, 0x28, 0x99, 0x8f, 0xc5, 0x65,
-	0x67, 0xf3, 0xab, 0x7b, 0xb0, 0xd9, 0x76, 0x9d, 0xef, 0xdb, 0xae, 0xf3, 0x73, 0xdb, 0x75, 0x3e,
-	0x79, 0xca, 0x75, 0x36, 0x9b, 0x79, 0xfa, 0xcf, 0x7f, 0xf9, 0x3b, 0x00, 0x00, 0xff, 0xff, 0xe5,
-	0xcf, 0xa9, 0xcb, 0x2b, 0x04, 0x00, 0x00,
-}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -30,7 +30,7 @@ type Client interface {
 	// Client to access the store.
 	storepb.StoreClient
 
-	// Labels that apply to all data exposed by the backing store.
+	// LabelSets that each apply to some data exposed by the backing store.
 	LabelSets() []storepb.LabelSet
 
 	// Minimum and maximum time range of data in the store.

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -128,6 +128,14 @@ func (s *ProxyStore) Info(ctx context.Context, r *storepb.InfoRequest) (*storepb
 		res.LabelSets = append(res.LabelSets, storepb.LabelSet{Labels: v})
 	}
 
+	// We always want to enforce announcing the subset of data that
+	// selector-labels represents. If no label-sets are announced by the
+	// store-proxy's discovered stores, then we still want to enforce
+	// announcing this subset by announcing the selector as the label-set.
+	if len(res.LabelSets) == 0 && len(res.Labels) > 0 {
+		res.LabelSets = append(res.LabelSets, storepb.LabelSet{Labels: res.Labels})
+	}
+
 	return res, nil
 }
 

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -893,6 +893,39 @@ func TestStoreMatches(t *testing.T) {
 			},
 			ok: true,
 		},
+		{
+			s: &testClient{labelSets: []storepb.LabelSet{
+				{Labels: []storepb.Label{{Name: "a", Value: "b"}}},
+				{Labels: []storepb.Label{{Name: "a", Value: "c"}}},
+				{Labels: []storepb.Label{{Name: "a", Value: "d"}}},
+			}},
+			ms: []storepb.LabelMatcher{
+				{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "e"},
+			},
+			ok: false,
+		},
+		{
+			s: &testClient{labelSets: []storepb.LabelSet{
+				{Labels: []storepb.Label{{Name: "a", Value: "b"}}},
+				{Labels: []storepb.Label{{Name: "a", Value: "c"}}},
+				{Labels: []storepb.Label{{Name: "a", Value: "d"}}},
+			}},
+			ms: []storepb.LabelMatcher{
+				{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "c"},
+			},
+			ok: true,
+		},
+		{
+			s: &testClient{labelSets: []storepb.LabelSet{
+				{Labels: []storepb.Label{{Name: "a", Value: "b"}}},
+				{Labels: []storepb.Label{{Name: "a", Value: "c"}}},
+				{Labels: []storepb.Label{{Name: "a", Value: "d"}}},
+			}},
+			ms: []storepb.LabelMatcher{
+				{Type: storepb.LabelMatcher_NEQ, Name: "a", Value: ""},
+			},
+			ok: true,
+		},
 	}
 
 	for i, c := range cases {

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -26,13 +27,13 @@ type testClient struct {
 	// Just to pass interface check.
 	storepb.StoreClient
 
-	labels  []storepb.Label
-	minTime int64
-	maxTime int64
+	labelSets []storepb.LabelSet
+	minTime   int64
+	maxTime   int64
 }
 
-func (c *testClient) Labels() []storepb.Label {
-	return c.labels
+func (c *testClient) LabelSets() []storepb.LabelSet {
+	return c.labelSets
 }
 
 func (c *testClient) TimeRange() (int64, int64) {
@@ -60,7 +61,7 @@ func TestProxyStore_Info(t *testing.T) {
 
 	resp, err := q.Info(ctx, &storepb.InfoRequest{})
 	testutil.Ok(t, err)
-	testutil.Equals(t, []storepb.Label{}, resp.Labels)
+	testutil.Equals(t, []storepb.LabelSet(nil), resp.LabelSets)
 	testutil.Equals(t, storepb.StoreType_QUERY, resp.StoreType)
 	testutil.Equals(t, int64(0), resp.MinTime)
 	testutil.Equals(t, int64(math.MaxInt64), resp.MaxTime)
@@ -118,9 +119,9 @@ func TestProxyStore_Series(t *testing.T) {
 							storeSeriesResponse(t, labels.FromStrings("a", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
 						},
 					},
-					minTime: 1,
-					maxTime: 300,
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
+					minTime:   1,
+					maxTime:   300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
 				},
 			},
 			req: &storepb.SeriesRequest{
@@ -139,9 +140,9 @@ func TestProxyStore_Series(t *testing.T) {
 							storeSeriesResponse(t, labels.FromStrings("a", "a"), []sample{{0, 0}, {2, 1}, {3, 2}}),
 						},
 					},
-					minTime: 1,
-					maxTime: 300,
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
+					minTime:   1,
+					maxTime:   300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
 				},
 			},
 			req: &storepb.SeriesRequest{
@@ -309,9 +310,9 @@ func TestProxyStore_Series(t *testing.T) {
 							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
 						},
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 				&testClient{
 					StoreClient: &mockedStoreAPI{
@@ -319,9 +320,9 @@ func TestProxyStore_Series(t *testing.T) {
 							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 11}, {2, 22}, {3, 33}}),
 						},
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 			},
 			req: &storepb.SeriesRequest{
@@ -346,17 +347,17 @@ func TestProxyStore_Series(t *testing.T) {
 							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
 						},
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 				&testClient{
 					StoreClient: &mockedStoreAPI{
 						RespError: errors.New("error!"),
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 			},
 			req: &storepb.SeriesRequest{
@@ -382,17 +383,17 @@ func TestProxyStore_Series(t *testing.T) {
 							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
 						},
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 				&testClient{
 					StoreClient: &mockedStoreAPI{
 						RespError: errors.New("error!"),
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 			},
 			req: &storepb.SeriesRequest{
@@ -462,9 +463,9 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 						},
 						RespDuration: 10 * time.Second,
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 				&testClient{
 					StoreClient: &mockedStoreAPI{
@@ -473,9 +474,9 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
 						},
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 			},
 			req: &storepb.SeriesRequest{
@@ -496,9 +497,9 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 							storeSeriesResponse(t, labels.FromStrings("a", "b"), []sample{{1, 1}, {2, 2}, {3, 3}}),
 						},
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 				&testClient{
 					StoreClient: &mockedStoreAPI{
@@ -508,9 +509,9 @@ func TestProxyStore_SeriesSlowStores(t *testing.T) {
 						},
 						RespDuration: 10 * time.Second,
 					},
-					labels:  []storepb.Label{{Name: "ext", Value: "1"}},
-					minTime: 1,
-					maxTime: 300,
+					labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
+					minTime:   1,
+					maxTime:   300,
 				},
 			},
 			req: &storepb.SeriesRequest{
@@ -565,7 +566,7 @@ func TestProxyStore_Series_RequestParamsProxied(t *testing.T) {
 	cls := []Client{
 		&testClient{
 			StoreClient: m,
-			labels:      []storepb.Label{{Name: "ext", Value: "1"}},
+			labelSets:   []storepb.LabelSet{{Labels: []storepb.Label{{Name: "ext", Value: "1"}}}},
 			minTime:     1,
 			maxTime:     300,
 		},
@@ -676,7 +677,7 @@ func TestProxyStore_LabelValues(t *testing.T) {
 
 	ctx := context.Background()
 	req := &storepb.LabelValuesRequest{
-		Label:                   "a",
+		Label: "a",
 		PartialResponseDisabled: true,
 	}
 	resp, err := q.LabelValues(ctx, req)
@@ -834,7 +835,7 @@ func TestStoreMatches(t *testing.T) {
 		ok         bool
 	}{
 		{
-			s: &testClient{labels: []storepb.Label{{Name: "a", Value: "b"}}},
+			s: &testClient{labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "a", Value: "b"}}}}},
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_EQ, Name: "b", Value: "1"},
 			},
@@ -865,28 +866,28 @@ func TestStoreMatches(t *testing.T) {
 			ok:   true,
 		},
 		{
-			s: &testClient{labels: []storepb.Label{{Name: "a", Value: "b"}}},
+			s: &testClient{labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "a", Value: "b"}}}}},
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "b"},
 			},
 			ok: true,
 		},
 		{
-			s: &testClient{labels: []storepb.Label{{Name: "a", Value: "b"}}},
+			s: &testClient{labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "a", Value: "b"}}}}},
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "c"},
 			},
 			ok: false,
 		},
 		{
-			s: &testClient{labels: []storepb.Label{{Name: "a", Value: "b"}}},
+			s: &testClient{labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "a", Value: "b"}}}}},
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_RE, Name: "a", Value: "b|c"},
 			},
 			ok: true,
 		},
 		{
-			s: &testClient{labels: []storepb.Label{{Name: "a", Value: "b"}}},
+			s: &testClient{labelSets: []storepb.LabelSet{{Labels: []storepb.Label{{Name: "a", Value: "b"}}}}},
 			ms: []storepb.LabelMatcher{
 				{Type: storepb.LabelMatcher_NEQ, Name: "a", Value: ""},
 			},
@@ -1014,4 +1015,17 @@ func storeSeriesResponse(t testing.TB, lset labels.Labels, smpls []sample) *stor
 		Raw:     &storepb.Chunk{Type: storepb.Chunk_XOR, Data: c.Bytes()},
 	})
 	return storepb.NewSeriesResponse(&s)
+}
+
+func TestMergeLabels(t *testing.T) {
+	ls := []storepb.Label{{Name: "a", Value: "b"}, {Name: "b", Value: "c"}}
+	selector := tlabels.Labels{{Name: "a", Value: "c"}, {Name: "c", Value: "d"}}
+	expected := labels.Labels{{Name: "a", Value: "c"}, {Name: "b", Value: "c"}, {Name: "c", Value: "d"}}
+
+	res := mergeLabels(ls, selector)
+	resLabels := storepb.LabelsToPromLabels(res)
+	sort.Sort(expected)
+	sort.Sort(resLabels)
+
+	testutil.Equals(t, expected, resLabels)
 }

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -177,3 +177,11 @@ func LabelsToString(lset []Label) string {
 	}
 	return "[" + strings.Join(s, ",") + "]"
 }
+
+func LabelSetsToString(lsets []LabelSet) string {
+	s := []string{}
+	for _, ls := range lsets {
+		s = append(s, LabelsToString(ls.Labels))
+	}
+	return strings.Join(s, "")
+}

--- a/pkg/store/storepb/rpc.pb.go
+++ b/pkg/store/storepb/rpc.pb.go
@@ -174,10 +174,11 @@ var xxx_messageInfo_InfoRequest proto.InternalMessageInfo
 
 type InfoResponse struct {
 	// Deprecated. Use label_sets instead.
-	Labels               []Label    `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels"`
-	MinTime              int64      `protobuf:"varint,2,opt,name=min_time,json=minTime,proto3" json:"min_time,omitempty"`
-	MaxTime              int64      `protobuf:"varint,3,opt,name=max_time,json=maxTime,proto3" json:"max_time,omitempty"`
-	StoreType            StoreType  `protobuf:"varint,4,opt,name=storeType,proto3,enum=thanos.StoreType" json:"storeType,omitempty"`
+	Labels    []Label   `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels"`
+	MinTime   int64     `protobuf:"varint,2,opt,name=min_time,json=minTime,proto3" json:"min_time,omitempty"`
+	MaxTime   int64     `protobuf:"varint,3,opt,name=max_time,json=maxTime,proto3" json:"max_time,omitempty"`
+	StoreType StoreType `protobuf:"varint,4,opt,name=storeType,proto3,enum=thanos.StoreType" json:"storeType,omitempty"`
+	// label_sets is an unsorted list of `LabelSet`s.
 	LabelSets            []LabelSet `protobuf:"bytes,5,rep,name=label_sets,json=labelSets,proto3" json:"label_sets"`
 	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
 	XXX_unrecognized     []byte     `json:"-"`

--- a/pkg/store/storepb/rpc.pb.go
+++ b/pkg/store/storepb/rpc.pb.go
@@ -3,17 +3,16 @@
 
 package storepb
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-
 import (
-	context "golang.org/x/net/context"
+	context "context"
+	fmt "fmt"
+	io "io"
+	math "math"
+
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
 	grpc "google.golang.org/grpc"
 )
-
-import io "io"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -45,6 +44,7 @@ var StoreType_name = map[int32]string{
 	4: "STORE",
 	5: "RECEIVE",
 }
+
 var StoreType_value = map[string]int32{
 	"UNKNOWN": 0,
 	"QUERY":   1,
@@ -57,14 +57,24 @@ var StoreType_value = map[string]int32{
 func (x StoreType) String() string {
 	return proto.EnumName(StoreType_name, int32(x))
 }
+
 func (StoreType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{0}
+	return fileDescriptor_77a6da22d6a3feb1, []int{0}
 }
 
+/// PartialResponseStrategy controls partial response handling.
 type PartialResponseStrategy int32
 
 const (
-	PartialResponseStrategy_WARN  PartialResponseStrategy = 0
+	/// WARN strategy tells server to treat any error that will related to single StoreAPI (e.g missing chunk series because of underlying
+	/// storeAPI is temporarily not available) as warning which will not fail the whole query (still OK response).
+	/// Server should produce those as a warnings field in response.
+	PartialResponseStrategy_WARN PartialResponseStrategy = 0
+	/// ABORT strategy tells server to treat any error that will related to single StoreAPI (e.g missing chunk series because of underlying
+	/// storeAPI is temporarily not available) as the gRPC error that aborts the query.
+	///
+	/// This is especially useful for any rule/alert evaluations on top of StoreAPI which usually does not tolerate partial
+	/// errors.
 	PartialResponseStrategy_ABORT PartialResponseStrategy = 1
 )
 
@@ -72,6 +82,7 @@ var PartialResponseStrategy_name = map[int32]string{
 	0: "WARN",
 	1: "ABORT",
 }
+
 var PartialResponseStrategy_value = map[string]int32{
 	"WARN":  0,
 	"ABORT": 1,
@@ -80,8 +91,9 @@ var PartialResponseStrategy_value = map[string]int32{
 func (x PartialResponseStrategy) String() string {
 	return proto.EnumName(PartialResponseStrategy_name, int32(x))
 }
+
 func (PartialResponseStrategy) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{1}
+	return fileDescriptor_77a6da22d6a3feb1, []int{1}
 }
 
 type Aggr int32
@@ -103,6 +115,7 @@ var Aggr_name = map[int32]string{
 	4: "MAX",
 	5: "COUNTER",
 }
+
 var Aggr_value = map[string]int32{
 	"RAW":     0,
 	"COUNT":   1,
@@ -115,8 +128,9 @@ var Aggr_value = map[string]int32{
 func (x Aggr) String() string {
 	return proto.EnumName(Aggr_name, int32(x))
 }
+
 func (Aggr) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{2}
+	return fileDescriptor_77a6da22d6a3feb1, []int{2}
 }
 
 type InfoRequest struct {
@@ -129,7 +143,7 @@ func (m *InfoRequest) Reset()         { *m = InfoRequest{} }
 func (m *InfoRequest) String() string { return proto.CompactTextString(m) }
 func (*InfoRequest) ProtoMessage()    {}
 func (*InfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{0}
+	return fileDescriptor_77a6da22d6a3feb1, []int{0}
 }
 func (m *InfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -146,8 +160,8 @@ func (m *InfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return b[:n], nil
 	}
 }
-func (dst *InfoRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_InfoRequest.Merge(dst, src)
+func (m *InfoRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_InfoRequest.Merge(m, src)
 }
 func (m *InfoRequest) XXX_Size() int {
 	return m.Size()
@@ -159,20 +173,22 @@ func (m *InfoRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_InfoRequest proto.InternalMessageInfo
 
 type InfoResponse struct {
-	Labels               []Label   `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels"`
-	MinTime              int64     `protobuf:"varint,2,opt,name=min_time,json=minTime,proto3" json:"min_time,omitempty"`
-	MaxTime              int64     `protobuf:"varint,3,opt,name=max_time,json=maxTime,proto3" json:"max_time,omitempty"`
-	StoreType            StoreType `protobuf:"varint,4,opt,name=storeType,proto3,enum=thanos.StoreType" json:"storeType,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
-	XXX_unrecognized     []byte    `json:"-"`
-	XXX_sizecache        int32     `json:"-"`
+	// Deprecated. Use label_sets instead.
+	Labels               []Label    `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels"`
+	MinTime              int64      `protobuf:"varint,2,opt,name=min_time,json=minTime,proto3" json:"min_time,omitempty"`
+	MaxTime              int64      `protobuf:"varint,3,opt,name=max_time,json=maxTime,proto3" json:"max_time,omitempty"`
+	StoreType            StoreType  `protobuf:"varint,4,opt,name=storeType,proto3,enum=thanos.StoreType" json:"storeType,omitempty"`
+	LabelSets            []LabelSet `protobuf:"bytes,5,rep,name=label_sets,json=labelSets,proto3" json:"label_sets"`
+	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
+	XXX_unrecognized     []byte     `json:"-"`
+	XXX_sizecache        int32      `json:"-"`
 }
 
 func (m *InfoResponse) Reset()         { *m = InfoResponse{} }
 func (m *InfoResponse) String() string { return proto.CompactTextString(m) }
 func (*InfoResponse) ProtoMessage()    {}
 func (*InfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{1}
+	return fileDescriptor_77a6da22d6a3feb1, []int{1}
 }
 func (m *InfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -189,8 +205,8 @@ func (m *InfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-func (dst *InfoResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_InfoResponse.Merge(dst, src)
+func (m *InfoResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_InfoResponse.Merge(m, src)
 }
 func (m *InfoResponse) XXX_Size() int {
 	return m.Size()
@@ -201,6 +217,46 @@ func (m *InfoResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_InfoResponse proto.InternalMessageInfo
 
+type LabelSet struct {
+	Labels               []Label  `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *LabelSet) Reset()         { *m = LabelSet{} }
+func (m *LabelSet) String() string { return proto.CompactTextString(m) }
+func (*LabelSet) ProtoMessage()    {}
+func (*LabelSet) Descriptor() ([]byte, []int) {
+	return fileDescriptor_77a6da22d6a3feb1, []int{2}
+}
+func (m *LabelSet) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *LabelSet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_LabelSet.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalTo(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *LabelSet) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LabelSet.Merge(m, src)
+}
+func (m *LabelSet) XXX_Size() int {
+	return m.Size()
+}
+func (m *LabelSet) XXX_DiscardUnknown() {
+	xxx_messageInfo_LabelSet.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LabelSet proto.InternalMessageInfo
+
 type SeriesRequest struct {
 	MinTime             int64          `protobuf:"varint,1,opt,name=min_time,json=minTime,proto3" json:"min_time,omitempty"`
 	MaxTime             int64          `protobuf:"varint,2,opt,name=max_time,json=maxTime,proto3" json:"max_time,omitempty"`
@@ -208,7 +264,8 @@ type SeriesRequest struct {
 	MaxResolutionWindow int64          `protobuf:"varint,4,opt,name=max_resolution_window,json=maxResolutionWindow,proto3" json:"max_resolution_window,omitempty"`
 	Aggregates          []Aggr         `protobuf:"varint,5,rep,packed,name=aggregates,proto3,enum=thanos.Aggr" json:"aggregates,omitempty"`
 	// Deprecated. Use partial_response_strategy instead.
-	PartialResponseDisabled bool                    `protobuf:"varint,6,opt,name=partial_response_disabled,json=partialResponseDisabled,proto3" json:"partial_response_disabled,omitempty"`
+	PartialResponseDisabled bool `protobuf:"varint,6,opt,name=partial_response_disabled,json=partialResponseDisabled,proto3" json:"partial_response_disabled,omitempty"`
+	// TODO(bwplotka): Move Thanos components to use strategy instead. Inlcuding QueryAPI.
 	PartialResponseStrategy PartialResponseStrategy `protobuf:"varint,7,opt,name=partial_response_strategy,json=partialResponseStrategy,proto3,enum=thanos.PartialResponseStrategy" json:"partial_response_strategy,omitempty"`
 	XXX_NoUnkeyedLiteral    struct{}                `json:"-"`
 	XXX_unrecognized        []byte                  `json:"-"`
@@ -219,7 +276,7 @@ func (m *SeriesRequest) Reset()         { *m = SeriesRequest{} }
 func (m *SeriesRequest) String() string { return proto.CompactTextString(m) }
 func (*SeriesRequest) ProtoMessage()    {}
 func (*SeriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{2}
+	return fileDescriptor_77a6da22d6a3feb1, []int{3}
 }
 func (m *SeriesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -236,8 +293,8 @@ func (m *SeriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return b[:n], nil
 	}
 }
-func (dst *SeriesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SeriesRequest.Merge(dst, src)
+func (m *SeriesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SeriesRequest.Merge(m, src)
 }
 func (m *SeriesRequest) XXX_Size() int {
 	return m.Size()
@@ -262,7 +319,7 @@ func (m *SeriesResponse) Reset()         { *m = SeriesResponse{} }
 func (m *SeriesResponse) String() string { return proto.CompactTextString(m) }
 func (*SeriesResponse) ProtoMessage()    {}
 func (*SeriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{3}
+	return fileDescriptor_77a6da22d6a3feb1, []int{4}
 }
 func (m *SeriesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -279,8 +336,8 @@ func (m *SeriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return b[:n], nil
 	}
 }
-func (dst *SeriesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SeriesResponse.Merge(dst, src)
+func (m *SeriesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SeriesResponse.Merge(m, src)
 }
 func (m *SeriesResponse) XXX_Size() int {
 	return m.Size()
@@ -399,17 +456,19 @@ func _SeriesResponse_OneofSizer(msg proto.Message) (n int) {
 }
 
 type LabelNamesRequest struct {
-	PartialResponseDisabled bool     `protobuf:"varint,1,opt,name=partial_response_disabled,json=partialResponseDisabled,proto3" json:"partial_response_disabled,omitempty"`
-	XXX_NoUnkeyedLiteral    struct{} `json:"-"`
-	XXX_unrecognized        []byte   `json:"-"`
-	XXX_sizecache           int32    `json:"-"`
+	PartialResponseDisabled bool `protobuf:"varint,1,opt,name=partial_response_disabled,json=partialResponseDisabled,proto3" json:"partial_response_disabled,omitempty"`
+	// TODO(bwplotka): Move Thanos components to use strategy instead. Inlcuding QueryAPI.
+	PartialResponseStrategy PartialResponseStrategy `protobuf:"varint,2,opt,name=partial_response_strategy,json=partialResponseStrategy,proto3,enum=thanos.PartialResponseStrategy" json:"partial_response_strategy,omitempty"`
+	XXX_NoUnkeyedLiteral    struct{}                `json:"-"`
+	XXX_unrecognized        []byte                  `json:"-"`
+	XXX_sizecache           int32                   `json:"-"`
 }
 
 func (m *LabelNamesRequest) Reset()         { *m = LabelNamesRequest{} }
 func (m *LabelNamesRequest) String() string { return proto.CompactTextString(m) }
 func (*LabelNamesRequest) ProtoMessage()    {}
 func (*LabelNamesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{4}
+	return fileDescriptor_77a6da22d6a3feb1, []int{5}
 }
 func (m *LabelNamesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -426,8 +485,8 @@ func (m *LabelNamesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return b[:n], nil
 	}
 }
-func (dst *LabelNamesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LabelNamesRequest.Merge(dst, src)
+func (m *LabelNamesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LabelNamesRequest.Merge(m, src)
 }
 func (m *LabelNamesRequest) XXX_Size() int {
 	return m.Size()
@@ -450,7 +509,7 @@ func (m *LabelNamesResponse) Reset()         { *m = LabelNamesResponse{} }
 func (m *LabelNamesResponse) String() string { return proto.CompactTextString(m) }
 func (*LabelNamesResponse) ProtoMessage()    {}
 func (*LabelNamesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{5}
+	return fileDescriptor_77a6da22d6a3feb1, []int{6}
 }
 func (m *LabelNamesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -467,8 +526,8 @@ func (m *LabelNamesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-func (dst *LabelNamesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LabelNamesResponse.Merge(dst, src)
+func (m *LabelNamesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LabelNamesResponse.Merge(m, src)
 }
 func (m *LabelNamesResponse) XXX_Size() int {
 	return m.Size()
@@ -480,18 +539,20 @@ func (m *LabelNamesResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_LabelNamesResponse proto.InternalMessageInfo
 
 type LabelValuesRequest struct {
-	Label                   string   `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
-	PartialResponseDisabled bool     `protobuf:"varint,2,opt,name=partial_response_disabled,json=partialResponseDisabled,proto3" json:"partial_response_disabled,omitempty"`
-	XXX_NoUnkeyedLiteral    struct{} `json:"-"`
-	XXX_unrecognized        []byte   `json:"-"`
-	XXX_sizecache           int32    `json:"-"`
+	Label                   string `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
+	PartialResponseDisabled bool   `protobuf:"varint,2,opt,name=partial_response_disabled,json=partialResponseDisabled,proto3" json:"partial_response_disabled,omitempty"`
+	// TODO(bwplotka): Move Thanos components to use strategy instead. Inlcuding QueryAPI.
+	PartialResponseStrategy PartialResponseStrategy `protobuf:"varint,3,opt,name=partial_response_strategy,json=partialResponseStrategy,proto3,enum=thanos.PartialResponseStrategy" json:"partial_response_strategy,omitempty"`
+	XXX_NoUnkeyedLiteral    struct{}                `json:"-"`
+	XXX_unrecognized        []byte                  `json:"-"`
+	XXX_sizecache           int32                   `json:"-"`
 }
 
 func (m *LabelValuesRequest) Reset()         { *m = LabelValuesRequest{} }
 func (m *LabelValuesRequest) String() string { return proto.CompactTextString(m) }
 func (*LabelValuesRequest) ProtoMessage()    {}
 func (*LabelValuesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{6}
+	return fileDescriptor_77a6da22d6a3feb1, []int{7}
 }
 func (m *LabelValuesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -508,8 +569,8 @@ func (m *LabelValuesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return b[:n], nil
 	}
 }
-func (dst *LabelValuesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LabelValuesRequest.Merge(dst, src)
+func (m *LabelValuesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LabelValuesRequest.Merge(m, src)
 }
 func (m *LabelValuesRequest) XXX_Size() int {
 	return m.Size()
@@ -532,7 +593,7 @@ func (m *LabelValuesResponse) Reset()         { *m = LabelValuesResponse{} }
 func (m *LabelValuesResponse) String() string { return proto.CompactTextString(m) }
 func (*LabelValuesResponse) ProtoMessage()    {}
 func (*LabelValuesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_rpc_f4f04914f1106c76, []int{7}
+	return fileDescriptor_77a6da22d6a3feb1, []int{8}
 }
 func (m *LabelValuesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -549,8 +610,8 @@ func (m *LabelValuesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte,
 		return b[:n], nil
 	}
 }
-func (dst *LabelValuesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LabelValuesResponse.Merge(dst, src)
+func (m *LabelValuesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LabelValuesResponse.Merge(m, src)
 }
 func (m *LabelValuesResponse) XXX_Size() int {
 	return m.Size()
@@ -562,17 +623,73 @@ func (m *LabelValuesResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_LabelValuesResponse proto.InternalMessageInfo
 
 func init() {
+	proto.RegisterEnum("thanos.StoreType", StoreType_name, StoreType_value)
+	proto.RegisterEnum("thanos.PartialResponseStrategy", PartialResponseStrategy_name, PartialResponseStrategy_value)
+	proto.RegisterEnum("thanos.Aggr", Aggr_name, Aggr_value)
 	proto.RegisterType((*InfoRequest)(nil), "thanos.InfoRequest")
 	proto.RegisterType((*InfoResponse)(nil), "thanos.InfoResponse")
+	proto.RegisterType((*LabelSet)(nil), "thanos.LabelSet")
 	proto.RegisterType((*SeriesRequest)(nil), "thanos.SeriesRequest")
 	proto.RegisterType((*SeriesResponse)(nil), "thanos.SeriesResponse")
 	proto.RegisterType((*LabelNamesRequest)(nil), "thanos.LabelNamesRequest")
 	proto.RegisterType((*LabelNamesResponse)(nil), "thanos.LabelNamesResponse")
 	proto.RegisterType((*LabelValuesRequest)(nil), "thanos.LabelValuesRequest")
 	proto.RegisterType((*LabelValuesResponse)(nil), "thanos.LabelValuesResponse")
-	proto.RegisterEnum("thanos.StoreType", StoreType_name, StoreType_value)
-	proto.RegisterEnum("thanos.PartialResponseStrategy", PartialResponseStrategy_name, PartialResponseStrategy_value)
-	proto.RegisterEnum("thanos.Aggr", Aggr_name, Aggr_value)
+}
+
+func init() { proto.RegisterFile("rpc.proto", fileDescriptor_77a6da22d6a3feb1) }
+
+var fileDescriptor_77a6da22d6a3feb1 = []byte{
+	// 772 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x55, 0x4f, 0x6f, 0xfa, 0x46,
+	0x10, 0x65, 0x6d, 0x30, 0x78, 0x48, 0x90, 0xb3, 0x21, 0x89, 0x71, 0x25, 0x82, 0x38, 0xa1, 0xb4,
+	0x22, 0x2d, 0x55, 0x5b, 0xb5, 0x37, 0x20, 0x8e, 0x82, 0x9a, 0x40, 0xbb, 0x40, 0xe8, 0x9f, 0x03,
+	0x35, 0xc9, 0xd6, 0xb1, 0x64, 0x6c, 0xea, 0x35, 0x4d, 0x72, 0xed, 0xe7, 0xe9, 0xb7, 0xe8, 0x25,
+	0xc7, 0x5e, 0x7b, 0xa9, 0xda, 0x7c, 0x8a, 0x1e, 0x2b, 0xaf, 0xd7, 0x80, 0xdb, 0x24, 0xd2, 0x4f,
+	0xdc, 0x76, 0xde, 0x1b, 0xcf, 0xec, 0x7b, 0x3b, 0xbb, 0x06, 0x35, 0x58, 0xdc, 0x34, 0x17, 0x81,
+	0x1f, 0xfa, 0x58, 0x09, 0xef, 0x2c, 0xcf, 0x67, 0x46, 0x31, 0x7c, 0x5c, 0x50, 0x16, 0x83, 0x46,
+	0xd9, 0xf6, 0x6d, 0x9f, 0x2f, 0x4f, 0xa3, 0x55, 0x8c, 0xd6, 0x77, 0xa1, 0xd8, 0xf3, 0x7e, 0xf4,
+	0x09, 0xfd, 0x69, 0x49, 0x59, 0x58, 0xff, 0x03, 0xc1, 0x4e, 0x1c, 0xb3, 0x85, 0xef, 0x31, 0x8a,
+	0xdf, 0x07, 0xc5, 0xb5, 0x66, 0xd4, 0x65, 0x3a, 0xaa, 0xc9, 0x8d, 0x62, 0x6b, 0xb7, 0x19, 0xd7,
+	0x6e, 0x5e, 0x46, 0x68, 0x27, 0xfb, 0xf4, 0xe7, 0x71, 0x86, 0x88, 0x14, 0x5c, 0x81, 0xc2, 0xdc,
+	0xf1, 0xa6, 0xa1, 0x33, 0xa7, 0xba, 0x54, 0x43, 0x0d, 0x99, 0xe4, 0xe7, 0x8e, 0x37, 0x72, 0xe6,
+	0x94, 0x53, 0xd6, 0x43, 0x4c, 0xc9, 0x82, 0xb2, 0x1e, 0x38, 0x75, 0x0a, 0x2a, 0x0b, 0xfd, 0x80,
+	0x8e, 0x1e, 0x17, 0x54, 0xcf, 0xd6, 0x50, 0xa3, 0xd4, 0xda, 0x4b, 0xba, 0x0c, 0x13, 0x82, 0xac,
+	0x73, 0xf0, 0x27, 0x00, 0xbc, 0xe1, 0x94, 0xd1, 0x90, 0xe9, 0x39, 0xbe, 0x2f, 0x2d, 0xb5, 0xaf,
+	0x21, 0x0d, 0xc5, 0xd6, 0x54, 0x57, 0xc4, 0xac, 0xfe, 0x19, 0x14, 0x12, 0xf2, 0x9d, 0x64, 0xd5,
+	0xff, 0x91, 0x60, 0x77, 0x48, 0x03, 0x87, 0x32, 0x61, 0x53, 0x4a, 0x28, 0x7a, 0x5d, 0xa8, 0x94,
+	0x16, 0xfa, 0x69, 0x44, 0x85, 0x37, 0x77, 0x34, 0x60, 0xba, 0xcc, 0xdb, 0x96, 0x53, 0x6d, 0xaf,
+	0x62, 0x52, 0x74, 0x5f, 0xe5, 0xe2, 0x16, 0x1c, 0x44, 0x25, 0x03, 0xca, 0x7c, 0x77, 0x19, 0x3a,
+	0xbe, 0x37, 0xbd, 0x77, 0xbc, 0x5b, 0xff, 0x9e, 0x9b, 0x25, 0x93, 0xfd, 0xb9, 0xf5, 0x40, 0x56,
+	0xdc, 0x84, 0x53, 0xf8, 0x03, 0x00, 0xcb, 0xb6, 0x03, 0x6a, 0x5b, 0x21, 0x8d, 0x3d, 0x2a, 0xb5,
+	0x76, 0x92, 0x6e, 0x6d, 0xdb, 0x0e, 0xc8, 0x06, 0x8f, 0xbf, 0x80, 0xca, 0xc2, 0x0a, 0x42, 0xc7,
+	0x72, 0xa3, 0x2e, 0xfc, 0xe4, 0xa7, 0xb7, 0x0e, 0xb3, 0x66, 0x2e, 0xbd, 0xd5, 0x95, 0x1a, 0x6a,
+	0x14, 0xc8, 0x91, 0x48, 0x48, 0x26, 0xe3, 0x4c, 0xd0, 0xf8, 0xfb, 0x17, 0xbe, 0x65, 0x61, 0x60,
+	0x85, 0xd4, 0x7e, 0xd4, 0xf3, 0xfc, 0x38, 0x8f, 0x93, 0xc6, 0x5f, 0xa5, 0x6b, 0x0c, 0x45, 0xda,
+	0xff, 0x8a, 0x27, 0x44, 0xfd, 0x07, 0x28, 0x25, 0xce, 0x8b, 0x81, 0x6c, 0x80, 0xc2, 0x38, 0xc2,
+	0x8d, 0x2f, 0xb6, 0x4a, 0xab, 0x51, 0xe1, 0xe8, 0x45, 0x86, 0x08, 0x1e, 0x1b, 0x90, 0xbf, 0xb7,
+	0x02, 0xcf, 0xf1, 0x6c, 0x7e, 0x10, 0xea, 0x45, 0x86, 0x24, 0x40, 0xa7, 0x00, 0x4a, 0x40, 0xd9,
+	0xd2, 0x0d, 0xeb, 0xbf, 0x22, 0xd8, 0xe3, 0xee, 0xf7, 0xad, 0xf9, 0xfa, 0x80, 0xdf, 0x34, 0x04,
+	0x6d, 0x61, 0x88, 0xb4, 0xa5, 0x21, 0xe7, 0x80, 0x37, 0x77, 0x2b, 0x4c, 0x29, 0x43, 0xce, 0x8b,
+	0x00, 0x3e, 0xcd, 0x2a, 0x89, 0x03, 0x6c, 0x40, 0x41, 0xe8, 0x65, 0xba, 0xc4, 0x89, 0x55, 0x5c,
+	0xff, 0x0d, 0x89, 0x42, 0xd7, 0x96, 0xbb, 0x5c, 0xeb, 0x2e, 0x43, 0x8e, 0x0f, 0x3d, 0xd7, 0xa8,
+	0x92, 0x38, 0x78, 0xdb, 0x0d, 0x69, 0x0b, 0x37, 0xe4, 0x2d, 0xdd, 0xe8, 0xc1, 0x7e, 0x4a, 0x84,
+	0xb0, 0xe3, 0x10, 0x94, 0x9f, 0x39, 0x22, 0xfc, 0x10, 0xd1, 0x5b, 0x86, 0x9c, 0x10, 0x50, 0x57,
+	0x8f, 0x0d, 0x2e, 0x42, 0x7e, 0xdc, 0xff, 0xb2, 0x3f, 0x98, 0xf4, 0xb5, 0x0c, 0x56, 0x21, 0xf7,
+	0xf5, 0xd8, 0x24, 0xdf, 0x6a, 0x08, 0x17, 0x20, 0x4b, 0xc6, 0x97, 0xa6, 0x26, 0x45, 0x19, 0xc3,
+	0xde, 0x99, 0xd9, 0x6d, 0x13, 0x4d, 0x8e, 0x32, 0x86, 0xa3, 0x01, 0x31, 0xb5, 0x6c, 0x84, 0x13,
+	0xb3, 0x6b, 0xf6, 0xae, 0x4d, 0x2d, 0x77, 0xd2, 0x84, 0xa3, 0x57, 0x24, 0x45, 0x95, 0x26, 0x6d,
+	0x22, 0xca, 0xb7, 0x3b, 0x03, 0x32, 0xd2, 0xd0, 0x49, 0x07, 0xb2, 0xd1, 0xd5, 0xc4, 0x79, 0x90,
+	0x49, 0x7b, 0x12, 0x73, 0xdd, 0xc1, 0xb8, 0x3f, 0xd2, 0x50, 0x84, 0x0d, 0xc7, 0x57, 0x9a, 0x14,
+	0x2d, 0xae, 0x7a, 0x7d, 0x4d, 0xe6, 0x8b, 0xf6, 0x37, 0x71, 0x4f, 0x9e, 0x65, 0x12, 0x2d, 0xd7,
+	0xfa, 0x45, 0x82, 0x1c, 0x17, 0x82, 0x3f, 0x82, 0x6c, 0xf4, 0x94, 0xe3, 0xfd, 0xc4, 0xde, 0x8d,
+	0x87, 0xde, 0x28, 0xa7, 0x41, 0x61, 0xdc, 0xe7, 0xa0, 0xc4, 0xd7, 0x08, 0x1f, 0xa4, 0xaf, 0x55,
+	0xf2, 0xd9, 0xe1, 0x7f, 0xe1, 0xf8, 0xc3, 0x0f, 0x11, 0xee, 0x02, 0xac, 0x07, 0x13, 0x57, 0x52,
+	0x0f, 0xdb, 0xe6, 0xd5, 0x32, 0x8c, 0x97, 0x28, 0xd1, 0xff, 0x1c, 0x8a, 0x1b, 0xe7, 0x89, 0xd3,
+	0xa9, 0xa9, 0x49, 0x35, 0xde, 0x7b, 0x91, 0x8b, 0xeb, 0x74, 0x2a, 0x4f, 0x7f, 0x57, 0x33, 0x4f,
+	0xcf, 0x55, 0xf4, 0xfb, 0x73, 0x15, 0xfd, 0xf5, 0x5c, 0x45, 0xdf, 0xe5, 0xf9, 0xef, 0x63, 0x31,
+	0x9b, 0x29, 0xfc, 0xbf, 0xf7, 0xf1, 0xbf, 0x01, 0x00, 0x00, 0xff, 0xff, 0xe8, 0xcb, 0x18, 0x01,
+	0x2f, 0x07, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -587,15 +704,15 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type StoreClient interface {
-	// / Info returns meta information about a store e.g labels that makes that store unique as well as time range that is
-	// / available.
+	/// Info returns meta information about a store e.g labels that makes that store unique as well as time range that is
+	/// available.
 	Info(ctx context.Context, in *InfoRequest, opts ...grpc.CallOption) (*InfoResponse, error)
-	// / Series streams each Series (Labels and chunk/downsampling chunk) for given label matchers and time range.
+	/// Series streams each Series (Labels and chunk/downsampling chunk) for given label matchers and time range.
 	Series(ctx context.Context, in *SeriesRequest, opts ...grpc.CallOption) (Store_SeriesClient, error)
-	// / LabelNames returns all label names that is available.
-	// / Currently unimplemented in all Thanos implementations, because Query API does not implement this either.
+	/// LabelNames returns all label names that is available.
+	/// Currently unimplemented in all Thanos implementations, because Query API does not implement this either.
 	LabelNames(ctx context.Context, in *LabelNamesRequest, opts ...grpc.CallOption) (*LabelNamesResponse, error)
-	// / LabelValues returns all label values for given label name.
+	/// LabelValues returns all label values for given label name.
 	LabelValues(ctx context.Context, in *LabelValuesRequest, opts ...grpc.CallOption) (*LabelValuesResponse, error)
 }
 
@@ -668,15 +785,15 @@ func (c *storeClient) LabelValues(ctx context.Context, in *LabelValuesRequest, o
 
 // StoreServer is the server API for Store service.
 type StoreServer interface {
-	// / Info returns meta information about a store e.g labels that makes that store unique as well as time range that is
-	// / available.
+	/// Info returns meta information about a store e.g labels that makes that store unique as well as time range that is
+	/// available.
 	Info(context.Context, *InfoRequest) (*InfoResponse, error)
-	// / Series streams each Series (Labels and chunk/downsampling chunk) for given label matchers and time range.
+	/// Series streams each Series (Labels and chunk/downsampling chunk) for given label matchers and time range.
 	Series(*SeriesRequest, Store_SeriesServer) error
-	// / LabelNames returns all label names that is available.
-	// / Currently unimplemented in all Thanos implementations, because Query API does not implement this either.
+	/// LabelNames returns all label names that is available.
+	/// Currently unimplemented in all Thanos implementations, because Query API does not implement this either.
 	LabelNames(context.Context, *LabelNamesRequest) (*LabelNamesResponse, error)
-	// / LabelValues returns all label values for given label name.
+	/// LabelValues returns all label values for given label name.
 	LabelValues(context.Context, *LabelValuesRequest) (*LabelValuesResponse, error)
 }
 
@@ -849,6 +966,51 @@ func (m *InfoResponse) MarshalTo(dAtA []byte) (int, error) {
 		i++
 		i = encodeVarintRpc(dAtA, i, uint64(m.StoreType))
 	}
+	if len(m.LabelSets) > 0 {
+		for _, msg := range m.LabelSets {
+			dAtA[i] = 0x2a
+			i++
+			i = encodeVarintRpc(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		i += copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	return i, nil
+}
+
+func (m *LabelSet) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LabelSet) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Labels) > 0 {
+		for _, msg := range m.Labels {
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintRpc(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -1010,6 +1172,11 @@ func (m *LabelNamesRequest) MarshalTo(dAtA []byte) (int, error) {
 		}
 		i++
 	}
+	if m.PartialResponseStrategy != 0 {
+		dAtA[i] = 0x10
+		i++
+		i = encodeVarintRpc(dAtA, i, uint64(m.PartialResponseStrategy))
+	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
 	}
@@ -1097,6 +1264,11 @@ func (m *LabelValuesRequest) MarshalTo(dAtA []byte) (int, error) {
 			dAtA[i] = 0
 		}
 		i++
+	}
+	if m.PartialResponseStrategy != 0 {
+		dAtA[i] = 0x18
+		i++
+		i = encodeVarintRpc(dAtA, i, uint64(m.PartialResponseStrategy))
 	}
 	if m.XXX_unrecognized != nil {
 		i += copy(dAtA[i:], m.XXX_unrecognized)
@@ -1197,6 +1369,30 @@ func (m *InfoResponse) Size() (n int) {
 	if m.StoreType != 0 {
 		n += 1 + sovRpc(uint64(m.StoreType))
 	}
+	if len(m.LabelSets) > 0 {
+		for _, e := range m.LabelSets {
+			l = e.Size()
+			n += 1 + l + sovRpc(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *LabelSet) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Labels) > 0 {
+		for _, e := range m.Labels {
+			l = e.Size()
+			n += 1 + l + sovRpc(uint64(l))
+		}
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -1289,6 +1485,9 @@ func (m *LabelNamesRequest) Size() (n int) {
 	if m.PartialResponseDisabled {
 		n += 2
 	}
+	if m.PartialResponseStrategy != 0 {
+		n += 1 + sovRpc(uint64(m.PartialResponseStrategy))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -1331,6 +1530,9 @@ func (m *LabelValuesRequest) Size() (n int) {
 	}
 	if m.PartialResponseDisabled {
 		n += 2
+	}
+	if m.PartialResponseStrategy != 0 {
+		n += 1 + sovRpc(uint64(m.PartialResponseStrategy))
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -1390,7 +1592,7 @@ func (m *InfoRequest) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1411,6 +1613,9 @@ func (m *InfoRequest) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -1441,7 +1646,7 @@ func (m *InfoResponse) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1469,7 +1674,7 @@ func (m *InfoResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1478,6 +1683,9 @@ func (m *InfoResponse) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRpc
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1500,7 +1708,7 @@ func (m *InfoResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MinTime |= (int64(b) & 0x7F) << shift
+				m.MinTime |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1519,7 +1727,7 @@ func (m *InfoResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MaxTime |= (int64(b) & 0x7F) << shift
+				m.MaxTime |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1538,11 +1746,45 @@ func (m *InfoResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.StoreType |= (StoreType(b) & 0x7F) << shift
+				m.StoreType |= StoreType(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LabelSets", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRpc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRpc
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.LabelSets = append(m.LabelSets, LabelSet{})
+			if err := m.LabelSets[len(m.LabelSets)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipRpc(dAtA[iNdEx:])
@@ -1550,6 +1792,97 @@ func (m *InfoResponse) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *LabelSet) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowRpc
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: LabelSet: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: LabelSet: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRpc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthRpc
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Labels = append(m.Labels, Label{})
+			if err := m.Labels[len(m.Labels)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipRpc(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -1580,7 +1913,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1608,7 +1941,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MinTime |= (int64(b) & 0x7F) << shift
+				m.MinTime |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1627,7 +1960,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MaxTime |= (int64(b) & 0x7F) << shift
+				m.MaxTime |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1646,7 +1979,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1655,6 +1988,9 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRpc
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1677,7 +2013,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MaxResolutionWindow |= (int64(b) & 0x7F) << shift
+				m.MaxResolutionWindow |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1694,7 +2030,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					v |= (Aggr(b) & 0x7F) << shift
+					v |= Aggr(b&0x7F) << shift
 					if b < 0x80 {
 						break
 					}
@@ -1711,7 +2047,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					packedLen |= (int(b) & 0x7F) << shift
+					packedLen |= int(b&0x7F) << shift
 					if b < 0x80 {
 						break
 					}
@@ -1720,6 +2056,9 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 					return ErrInvalidLengthRpc
 				}
 				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return ErrInvalidLengthRpc
+				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
@@ -1738,7 +2077,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 						}
 						b := dAtA[iNdEx]
 						iNdEx++
-						v |= (Aggr(b) & 0x7F) << shift
+						v |= Aggr(b&0x7F) << shift
 						if b < 0x80 {
 							break
 						}
@@ -1762,7 +2101,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1782,7 +2121,7 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.PartialResponseStrategy |= (PartialResponseStrategy(b) & 0x7F) << shift
+				m.PartialResponseStrategy |= PartialResponseStrategy(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1794,6 +2133,9 @@ func (m *SeriesRequest) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -1824,7 +2166,7 @@ func (m *SeriesResponse) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1852,7 +2194,7 @@ func (m *SeriesResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1861,6 +2203,9 @@ func (m *SeriesResponse) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRpc
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1884,7 +2229,7 @@ func (m *SeriesResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1894,6 +2239,9 @@ func (m *SeriesResponse) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRpc
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1906,6 +2254,9 @@ func (m *SeriesResponse) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -1936,7 +2287,7 @@ func (m *LabelNamesRequest) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1964,12 +2315,31 @@ func (m *LabelNamesRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
 			m.PartialResponseDisabled = bool(v != 0)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PartialResponseStrategy", wireType)
+			}
+			m.PartialResponseStrategy = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRpc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.PartialResponseStrategy |= PartialResponseStrategy(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipRpc(dAtA[iNdEx:])
@@ -1977,6 +2347,9 @@ func (m *LabelNamesRequest) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -2007,7 +2380,7 @@ func (m *LabelNamesResponse) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2035,7 +2408,7 @@ func (m *LabelNamesResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2045,6 +2418,9 @@ func (m *LabelNamesResponse) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRpc
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2064,7 +2440,7 @@ func (m *LabelNamesResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2074,6 +2450,9 @@ func (m *LabelNamesResponse) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRpc
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2086,6 +2465,9 @@ func (m *LabelNamesResponse) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -2116,7 +2498,7 @@ func (m *LabelValuesRequest) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2144,7 +2526,7 @@ func (m *LabelValuesRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2154,6 +2536,9 @@ func (m *LabelValuesRequest) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRpc
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2173,12 +2558,31 @@ func (m *LabelValuesRequest) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
 			m.PartialResponseDisabled = bool(v != 0)
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PartialResponseStrategy", wireType)
+			}
+			m.PartialResponseStrategy = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowRpc
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.PartialResponseStrategy |= PartialResponseStrategy(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipRpc(dAtA[iNdEx:])
@@ -2186,6 +2590,9 @@ func (m *LabelValuesRequest) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -2216,7 +2623,7 @@ func (m *LabelValuesResponse) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2244,7 +2651,7 @@ func (m *LabelValuesResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2254,6 +2661,9 @@ func (m *LabelValuesResponse) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRpc
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2273,7 +2683,7 @@ func (m *LabelValuesResponse) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2283,6 +2693,9 @@ func (m *LabelValuesResponse) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthRpc
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthRpc
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2295,6 +2708,9 @@ func (m *LabelValuesResponse) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthRpc
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthRpc
 			}
 			if (iNdEx + skippy) > l {
@@ -2364,8 +2780,11 @@ func skipRpc(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			iNdEx += length
 			if length < 0 {
+				return 0, ErrInvalidLengthRpc
+			}
+			iNdEx += length
+			if iNdEx < 0 {
 				return 0, ErrInvalidLengthRpc
 			}
 			return iNdEx, nil
@@ -2396,6 +2815,9 @@ func skipRpc(dAtA []byte) (n int, err error) {
 					return 0, err
 				}
 				iNdEx = start + next
+				if iNdEx < 0 {
+					return 0, ErrInvalidLengthRpc
+				}
 			}
 			return iNdEx, nil
 		case 4:
@@ -2414,55 +2836,3 @@ var (
 	ErrInvalidLengthRpc = fmt.Errorf("proto: negative length found during unmarshaling")
 	ErrIntOverflowRpc   = fmt.Errorf("proto: integer overflow")
 )
-
-func init() { proto.RegisterFile("rpc.proto", fileDescriptor_rpc_f4f04914f1106c76) }
-
-var fileDescriptor_rpc_f4f04914f1106c76 = []byte{
-	// 729 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x54, 0xcf, 0x6e, 0xda, 0x4e,
-	0x10, 0xc6, 0x36, 0x18, 0x18, 0x12, 0xe4, 0x6c, 0x48, 0x62, 0xfc, 0x93, 0x08, 0xe2, 0x84, 0xf2,
-	0xab, 0x48, 0x4b, 0xa5, 0x4a, 0xed, 0x0d, 0x88, 0xa3, 0xa0, 0x26, 0xd0, 0x2e, 0x10, 0xfa, 0xe7,
-	0x90, 0x9a, 0x64, 0xe3, 0x58, 0x02, 0x9b, 0x7a, 0x4d, 0x93, 0x5c, 0xfb, 0x28, 0x7d, 0x9a, 0x1c,
-	0xfb, 0x04, 0x55, 0x9b, 0xa7, 0xe8, 0xb1, 0xda, 0xf5, 0x1a, 0x70, 0x9b, 0x70, 0xdb, 0xfd, 0xbe,
-	0xf1, 0xcc, 0xb7, 0x33, 0x9f, 0x07, 0xb2, 0xfe, 0xf4, 0xbc, 0x36, 0xf5, 0xbd, 0xc0, 0x43, 0x6a,
-	0x70, 0x65, 0xb9, 0x1e, 0x35, 0x72, 0xc1, 0xed, 0x94, 0xd0, 0x10, 0x34, 0x0a, 0xb6, 0x67, 0x7b,
-	0xfc, 0xb8, 0xcf, 0x4e, 0x21, 0x5a, 0x59, 0x87, 0x5c, 0xdb, 0xbd, 0xf4, 0x30, 0xf9, 0x3c, 0x23,
-	0x34, 0xa8, 0x7c, 0x93, 0x60, 0x2d, 0xbc, 0xd3, 0xa9, 0xe7, 0x52, 0x82, 0xfe, 0x07, 0x75, 0x6c,
-	0x8d, 0xc8, 0x98, 0xea, 0x52, 0x59, 0xa9, 0xe6, 0xea, 0xeb, 0xb5, 0x30, 0x77, 0xed, 0x98, 0xa1,
-	0xcd, 0xe4, 0xdd, 0x8f, 0xdd, 0x04, 0x16, 0x21, 0xa8, 0x08, 0x99, 0x89, 0xe3, 0x9e, 0x05, 0xce,
-	0x84, 0xe8, 0x72, 0x59, 0xaa, 0x2a, 0x38, 0x3d, 0x71, 0xdc, 0xbe, 0x33, 0x21, 0x9c, 0xb2, 0x6e,
-	0x42, 0x4a, 0x11, 0x94, 0x75, 0xc3, 0xa9, 0x7d, 0xc8, 0xd2, 0xc0, 0xf3, 0x49, 0xff, 0x76, 0x4a,
-	0xf4, 0x64, 0x59, 0xaa, 0xe6, 0xeb, 0x1b, 0x51, 0x95, 0x5e, 0x44, 0xe0, 0x45, 0x4c, 0xe5, 0xb7,
-	0x0c, 0xeb, 0x3d, 0xe2, 0x3b, 0x84, 0x0a, 0xd9, 0xb1, 0xc2, 0xd2, 0xe3, 0x85, 0xe5, 0x78, 0xe1,
-	0x17, 0x8c, 0x0a, 0xce, 0xaf, 0x88, 0x4f, 0x75, 0x85, 0xbf, 0xae, 0x10, 0x7b, 0xdd, 0x49, 0x48,
-	0x8a, 0x47, 0xce, 0x63, 0x51, 0x1d, 0xb6, 0x58, 0x4a, 0x9f, 0x50, 0x6f, 0x3c, 0x0b, 0x1c, 0xcf,
-	0x3d, 0xbb, 0x76, 0xdc, 0x0b, 0xef, 0x9a, 0x8b, 0x57, 0xf0, 0xe6, 0xc4, 0xba, 0xc1, 0x73, 0x6e,
-	0xc8, 0x29, 0xf4, 0x04, 0xc0, 0xb2, 0x6d, 0x9f, 0xd8, 0x56, 0x40, 0xa8, 0x9e, 0x2a, 0x2b, 0xd5,
-	0x7c, 0x7d, 0x2d, 0xaa, 0xd6, 0xb0, 0x6d, 0x1f, 0x2f, 0xf1, 0xe8, 0x15, 0x14, 0xa7, 0x96, 0x1f,
-	0x38, 0xd6, 0x98, 0x55, 0xe1, 0x93, 0x38, 0xbb, 0x70, 0xa8, 0x35, 0x1a, 0x93, 0x0b, 0x5d, 0x2d,
-	0x4b, 0xd5, 0x0c, 0xde, 0x11, 0x01, 0xd1, 0xa4, 0x0e, 0x04, 0x8d, 0x3e, 0x3e, 0xf0, 0x2d, 0x0d,
-	0x7c, 0x2b, 0x20, 0xf6, 0xad, 0x9e, 0xe6, 0xed, 0xdd, 0x8d, 0x0a, 0xbf, 0x89, 0xe7, 0xe8, 0x89,
-	0xb0, 0x7f, 0x92, 0x47, 0x44, 0xe5, 0x13, 0xe4, 0xa3, 0xce, 0x0b, 0x83, 0x54, 0x41, 0xa5, 0x1c,
-	0xe1, 0x8d, 0xcf, 0xd5, 0xf3, 0xf3, 0xd1, 0x71, 0xf4, 0x28, 0x81, 0x05, 0x8f, 0x0c, 0x48, 0x5f,
-	0x5b, 0xbe, 0xeb, 0xb8, 0x36, 0x1f, 0x44, 0xf6, 0x28, 0x81, 0x23, 0xa0, 0x99, 0x01, 0xd5, 0x27,
-	0x74, 0x36, 0x0e, 0x2a, 0x5d, 0xd8, 0xe0, 0xcd, 0xef, 0x58, 0x93, 0xc5, 0x7c, 0x57, 0xf6, 0x43,
-	0x5a, 0xd9, 0x8f, 0xca, 0x21, 0xa0, 0xe5, 0x84, 0x42, 0x76, 0x01, 0x52, 0x2e, 0x03, 0xb8, 0xad,
-	0xb3, 0x38, 0xbc, 0x20, 0x03, 0x32, 0x42, 0x11, 0xd5, 0x65, 0x4e, 0xcc, 0xef, 0x95, 0x4b, 0x91,
-	0xe7, 0xd4, 0x1a, 0xcf, 0x16, 0xca, 0x0a, 0x90, 0xe2, 0xe6, 0xe7, 0x2a, 0xb2, 0x38, 0xbc, 0xac,
-	0xd6, 0x2b, 0xaf, 0xd6, 0xdb, 0x86, 0xcd, 0x58, 0x1d, 0x21, 0x78, 0x1b, 0xd4, 0x2f, 0x1c, 0x11,
-	0x8a, 0xc5, 0x6d, 0x95, 0xe4, 0x3d, 0x0c, 0xd9, 0xf9, 0x0f, 0x84, 0x72, 0x90, 0x1e, 0x74, 0x5e,
-	0x77, 0xba, 0xc3, 0x8e, 0x96, 0x40, 0x59, 0x48, 0xbd, 0x1d, 0x98, 0xf8, 0xbd, 0x26, 0xa1, 0x0c,
-	0x24, 0xf1, 0xe0, 0xd8, 0xd4, 0x64, 0x16, 0xd1, 0x6b, 0x1f, 0x98, 0xad, 0x06, 0xd6, 0x14, 0x16,
-	0xd1, 0xeb, 0x77, 0xb1, 0xa9, 0x25, 0x19, 0x8e, 0xcd, 0x96, 0xd9, 0x3e, 0x35, 0xb5, 0xd4, 0x5e,
-	0x0d, 0x76, 0x1e, 0x71, 0x0d, 0xcb, 0x34, 0x6c, 0x60, 0x91, 0xbe, 0xd1, 0xec, 0xe2, 0xbe, 0x26,
-	0xed, 0x35, 0x21, 0xc9, 0xec, 0x8d, 0xd2, 0xa0, 0xe0, 0xc6, 0x30, 0xe4, 0x5a, 0xdd, 0x41, 0xa7,
-	0xaf, 0x49, 0x0c, 0xeb, 0x0d, 0x4e, 0x34, 0x99, 0x1d, 0x4e, 0xda, 0x1d, 0x4d, 0xe1, 0x87, 0xc6,
-	0xbb, 0xb0, 0x26, 0x8f, 0x32, 0xb1, 0x96, 0xaa, 0x7f, 0x95, 0x21, 0xc5, 0x1f, 0x82, 0x9e, 0x41,
-	0x92, 0xad, 0x27, 0xb4, 0x19, 0xb9, 0x6c, 0x69, 0x79, 0x19, 0x85, 0x38, 0x28, 0x1a, 0xf7, 0x12,
-	0xd4, 0xd0, 0x8a, 0x68, 0x2b, 0x6e, 0xcd, 0xe8, 0xb3, 0xed, 0xbf, 0xe1, 0xf0, 0xc3, 0xa7, 0x12,
-	0x6a, 0x01, 0x2c, 0xac, 0x83, 0x8a, 0xb1, 0xe5, 0xb0, 0xec, 0x4f, 0xc3, 0x78, 0x88, 0x12, 0xf5,
-	0x0f, 0x21, 0xb7, 0x34, 0x4f, 0x14, 0x0f, 0x8d, 0x99, 0xc9, 0xf8, 0xef, 0x41, 0x2e, 0xcc, 0xd3,
-	0x2c, 0xde, 0xfd, 0x2a, 0x25, 0xee, 0xee, 0x4b, 0xd2, 0xf7, 0xfb, 0x92, 0xf4, 0xf3, 0xbe, 0x24,
-	0x7d, 0x48, 0xf3, 0x95, 0x38, 0x1d, 0x8d, 0x54, 0xbe, 0xcb, 0x9f, 0xff, 0x09, 0x00, 0x00, 0xff,
-	0xff, 0x92, 0x5a, 0x97, 0xd8, 0x03, 0x06, 0x00, 0x00,
-}

--- a/pkg/store/storepb/rpc.proto
+++ b/pkg/store/storepb/rpc.proto
@@ -41,10 +41,16 @@ enum StoreType {
 }
 
 message InfoResponse {
+  // Deprecated. Use label_sets instead.
   repeated Label labels = 1 [(gogoproto.nullable) = false];
-  int64 min_time        = 2;
-  int64 max_time        = 3;
-  StoreType storeType   = 4;
+  int64 min_time = 2;
+  int64 max_time = 3;
+  StoreType storeType  = 4;
+  repeated LabelSet label_sets = 5 [(gogoproto.nullable) = false];
+}
+
+message LabelSet {
+  repeated Label labels = 1 [(gogoproto.nullable) = false];
 }
 
 /// PartialResponseStrategy controls partial response handling.

--- a/pkg/store/storepb/rpc.proto
+++ b/pkg/store/storepb/rpc.proto
@@ -46,6 +46,7 @@ message InfoResponse {
   int64 min_time = 2;
   int64 max_time = 3;
   StoreType storeType  = 4;
+  // label_sets is an unsorted list of `LabelSet`s.
   repeated LabelSet label_sets = 5 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/store/storepb/types.pb.go
+++ b/pkg/store/storepb/types.pb.go
@@ -3,12 +3,14 @@
 
 package storepb
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
+import (
+	fmt "fmt"
+	io "io"
+	math "math"
 
-import io "io"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -30,6 +32,7 @@ const (
 var Chunk_Encoding_name = map[int32]string{
 	0: "XOR",
 }
+
 var Chunk_Encoding_value = map[string]int32{
 	"XOR": 0,
 }
@@ -37,8 +40,9 @@ var Chunk_Encoding_value = map[string]int32{
 func (x Chunk_Encoding) String() string {
 	return proto.EnumName(Chunk_Encoding_name, int32(x))
 }
+
 func (Chunk_Encoding) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_60e135d4a4f03620, []int{1, 0}
+	return fileDescriptor_d938547f84707355, []int{1, 0}
 }
 
 type LabelMatcher_Type int32
@@ -56,6 +60,7 @@ var LabelMatcher_Type_name = map[int32]string{
 	2: "RE",
 	3: "NRE",
 }
+
 var LabelMatcher_Type_value = map[string]int32{
 	"EQ":  0,
 	"NEQ": 1,
@@ -66,8 +71,9 @@ var LabelMatcher_Type_value = map[string]int32{
 func (x LabelMatcher_Type) String() string {
 	return proto.EnumName(LabelMatcher_Type_name, int32(x))
 }
+
 func (LabelMatcher_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_types_60e135d4a4f03620, []int{4, 0}
+	return fileDescriptor_d938547f84707355, []int{4, 0}
 }
 
 type Label struct {
@@ -82,7 +88,7 @@ func (m *Label) Reset()         { *m = Label{} }
 func (m *Label) String() string { return proto.CompactTextString(m) }
 func (*Label) ProtoMessage()    {}
 func (*Label) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_60e135d4a4f03620, []int{0}
+	return fileDescriptor_d938547f84707355, []int{0}
 }
 func (m *Label) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -99,8 +105,8 @@ func (m *Label) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *Label) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Label.Merge(dst, src)
+func (m *Label) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Label.Merge(m, src)
 }
 func (m *Label) XXX_Size() int {
 	return m.Size()
@@ -123,7 +129,7 @@ func (m *Chunk) Reset()         { *m = Chunk{} }
 func (m *Chunk) String() string { return proto.CompactTextString(m) }
 func (*Chunk) ProtoMessage()    {}
 func (*Chunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_60e135d4a4f03620, []int{1}
+	return fileDescriptor_d938547f84707355, []int{1}
 }
 func (m *Chunk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -140,8 +146,8 @@ func (m *Chunk) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *Chunk) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Chunk.Merge(dst, src)
+func (m *Chunk) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Chunk.Merge(m, src)
 }
 func (m *Chunk) XXX_Size() int {
 	return m.Size()
@@ -164,7 +170,7 @@ func (m *Series) Reset()         { *m = Series{} }
 func (m *Series) String() string { return proto.CompactTextString(m) }
 func (*Series) ProtoMessage()    {}
 func (*Series) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_60e135d4a4f03620, []int{2}
+	return fileDescriptor_d938547f84707355, []int{2}
 }
 func (m *Series) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -181,8 +187,8 @@ func (m *Series) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *Series) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Series.Merge(dst, src)
+func (m *Series) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Series.Merge(m, src)
 }
 func (m *Series) XXX_Size() int {
 	return m.Size()
@@ -211,7 +217,7 @@ func (m *AggrChunk) Reset()         { *m = AggrChunk{} }
 func (m *AggrChunk) String() string { return proto.CompactTextString(m) }
 func (*AggrChunk) ProtoMessage()    {}
 func (*AggrChunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_60e135d4a4f03620, []int{3}
+	return fileDescriptor_d938547f84707355, []int{3}
 }
 func (m *AggrChunk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -228,8 +234,8 @@ func (m *AggrChunk) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *AggrChunk) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AggrChunk.Merge(dst, src)
+func (m *AggrChunk) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AggrChunk.Merge(m, src)
 }
 func (m *AggrChunk) XXX_Size() int {
 	return m.Size()
@@ -254,7 +260,7 @@ func (m *LabelMatcher) Reset()         { *m = LabelMatcher{} }
 func (m *LabelMatcher) String() string { return proto.CompactTextString(m) }
 func (*LabelMatcher) ProtoMessage()    {}
 func (*LabelMatcher) Descriptor() ([]byte, []int) {
-	return fileDescriptor_types_60e135d4a4f03620, []int{4}
+	return fileDescriptor_d938547f84707355, []int{4}
 }
 func (m *LabelMatcher) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -271,8 +277,8 @@ func (m *LabelMatcher) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return b[:n], nil
 	}
 }
-func (dst *LabelMatcher) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LabelMatcher.Merge(dst, src)
+func (m *LabelMatcher) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LabelMatcher.Merge(m, src)
 }
 func (m *LabelMatcher) XXX_Size() int {
 	return m.Size()
@@ -284,14 +290,48 @@ func (m *LabelMatcher) XXX_DiscardUnknown() {
 var xxx_messageInfo_LabelMatcher proto.InternalMessageInfo
 
 func init() {
+	proto.RegisterEnum("thanos.Chunk_Encoding", Chunk_Encoding_name, Chunk_Encoding_value)
+	proto.RegisterEnum("thanos.LabelMatcher_Type", LabelMatcher_Type_name, LabelMatcher_Type_value)
 	proto.RegisterType((*Label)(nil), "thanos.Label")
 	proto.RegisterType((*Chunk)(nil), "thanos.Chunk")
 	proto.RegisterType((*Series)(nil), "thanos.Series")
 	proto.RegisterType((*AggrChunk)(nil), "thanos.AggrChunk")
 	proto.RegisterType((*LabelMatcher)(nil), "thanos.LabelMatcher")
-	proto.RegisterEnum("thanos.Chunk_Encoding", Chunk_Encoding_name, Chunk_Encoding_value)
-	proto.RegisterEnum("thanos.LabelMatcher_Type", LabelMatcher_Type_name, LabelMatcher_Type_value)
 }
+
+func init() { proto.RegisterFile("types.proto", fileDescriptor_d938547f84707355) }
+
+var fileDescriptor_d938547f84707355 = []byte{
+	// 432 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x92, 0xdd, 0x6e, 0xd3, 0x30,
+	0x14, 0xc7, 0xeb, 0x7c, 0x76, 0x67, 0x03, 0x05, 0x33, 0x21, 0x97, 0x8b, 0xae, 0x0a, 0x17, 0x54,
+	0x20, 0x32, 0x31, 0x9e, 0x80, 0xa1, 0xdc, 0xf1, 0xa1, 0x99, 0x5d, 0x20, 0x84, 0x84, 0xdc, 0xce,
+	0xa4, 0x11, 0x8d, 0x5d, 0xc5, 0x0e, 0x74, 0x8f, 0x81, 0x78, 0xa9, 0x5e, 0xf2, 0x04, 0x08, 0xfa,
+	0x24, 0xc8, 0x27, 0x0d, 0x5b, 0xa5, 0xdc, 0x1d, 0x9f, 0xff, 0xef, 0x7c, 0xc8, 0xe7, 0x0f, 0x87,
+	0xf6, 0x7a, 0x25, 0x4d, 0xb6, 0xaa, 0xb5, 0xd5, 0x34, 0xb2, 0x0b, 0xa1, 0xb4, 0x79, 0x78, 0x5c,
+	0xe8, 0x42, 0x63, 0xea, 0xd4, 0x45, 0xad, 0x9a, 0x3e, 0x87, 0xf0, 0xb5, 0x98, 0xc9, 0x25, 0xa5,
+	0x10, 0x28, 0x51, 0x49, 0x46, 0x26, 0x64, 0x7a, 0xc0, 0x31, 0xa6, 0xc7, 0x10, 0x7e, 0x13, 0xcb,
+	0x46, 0x32, 0x0f, 0x93, 0xed, 0x23, 0xfd, 0x04, 0xe1, 0xab, 0x45, 0xa3, 0xbe, 0xd2, 0x27, 0x10,
+	0xb8, 0x41, 0x58, 0x72, 0xf7, 0xec, 0x41, 0xd6, 0x0e, 0xca, 0x50, 0xcc, 0x72, 0x35, 0xd7, 0x57,
+	0xa5, 0x2a, 0x38, 0x32, 0xae, 0xfd, 0x95, 0xb0, 0x02, 0x3b, 0x1d, 0x71, 0x8c, 0xd3, 0xfb, 0x30,
+	0xec, 0x28, 0x1a, 0x83, 0xff, 0xe1, 0x1d, 0x4f, 0x06, 0xe9, 0x17, 0x88, 0xde, 0xcb, 0xba, 0x94,
+	0x86, 0x3e, 0x85, 0x68, 0xe9, 0x56, 0x33, 0x8c, 0x4c, 0xfc, 0xe9, 0xe1, 0xd9, 0x9d, 0x6e, 0x00,
+	0x2e, 0x7c, 0x1e, 0x6c, 0x7e, 0x9f, 0x0c, 0xf8, 0x0e, 0xa1, 0xa7, 0x10, 0xcd, 0xdd, 0x5c, 0xc3,
+	0x3c, 0x84, 0xef, 0x75, 0xf0, 0xcb, 0xa2, 0xa8, 0x71, 0xa3, 0xae, 0xa0, 0xc5, 0xd2, 0x9f, 0x1e,
+	0x1c, 0xfc, 0xd7, 0xe8, 0x08, 0x86, 0x55, 0xa9, 0x3e, 0xdb, 0x72, 0xf7, 0x03, 0x3e, 0x8f, 0xab,
+	0x52, 0x5d, 0x96, 0x95, 0x44, 0x49, 0xac, 0x5b, 0xc9, 0xdb, 0x49, 0x62, 0x8d, 0xd2, 0x09, 0xf8,
+	0xb5, 0xf8, 0xce, 0xfc, 0x09, 0xb9, 0xbd, 0x1e, 0x76, 0xe4, 0x4e, 0xa1, 0x8f, 0x20, 0x9c, 0xeb,
+	0x46, 0x59, 0x16, 0xf4, 0x21, 0xad, 0xe6, 0xba, 0x98, 0xa6, 0x62, 0x61, 0x6f, 0x17, 0xd3, 0x54,
+	0x0e, 0xa8, 0x4a, 0xc5, 0xa2, 0x5e, 0xa0, 0x2a, 0x15, 0x02, 0x62, 0xcd, 0xe2, 0x7e, 0x40, 0xac,
+	0xe9, 0x63, 0x88, 0x71, 0x96, 0xac, 0xd9, 0xb0, 0x0f, 0xea, 0xd4, 0xf4, 0x07, 0x81, 0x23, 0xfc,
+	0xde, 0x37, 0xc2, 0xce, 0x17, 0xb2, 0xa6, 0xcf, 0xf6, 0x6e, 0x3c, 0xda, 0x3b, 0xc1, 0x8e, 0xc9,
+	0x2e, 0xaf, 0x57, 0xf2, 0xe6, 0xcc, 0xe8, 0x22, 0xaf, 0xcf, 0x45, 0xfe, 0x6d, 0x17, 0x4d, 0x21,
+	0x70, 0x75, 0x34, 0x02, 0x2f, 0xbf, 0x48, 0x06, 0xce, 0x00, 0x6f, 0xf3, 0x8b, 0x84, 0xb8, 0x04,
+	0xcf, 0x13, 0x0f, 0x13, 0x3c, 0x4f, 0xfc, 0xf3, 0xd1, 0xe6, 0xef, 0x78, 0xb0, 0xd9, 0x8e, 0xc9,
+	0xaf, 0xed, 0x98, 0xfc, 0xd9, 0x8e, 0xc9, 0xc7, 0xd8, 0x58, 0x5d, 0xcb, 0xd5, 0x6c, 0x16, 0xa1,
+	0x89, 0x5f, 0xfc, 0x0b, 0x00, 0x00, 0xff, 0xff, 0x46, 0x5a, 0xe2, 0x68, 0xf1, 0x02, 0x00, 0x00,
+}
+
 func (m *Label) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -696,7 +736,7 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -724,7 +764,7 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -734,6 +774,9 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -753,7 +796,7 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -763,6 +806,9 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -775,6 +821,9 @@ func (m *Label) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -805,7 +854,7 @@ func (m *Chunk) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -833,7 +882,7 @@ func (m *Chunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Type |= (Chunk_Encoding(b) & 0x7F) << shift
+				m.Type |= Chunk_Encoding(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -852,7 +901,7 @@ func (m *Chunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -861,6 +910,9 @@ func (m *Chunk) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -876,6 +928,9 @@ func (m *Chunk) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -906,7 +961,7 @@ func (m *Series) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -934,7 +989,7 @@ func (m *Series) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -943,6 +998,9 @@ func (m *Series) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -965,7 +1023,7 @@ func (m *Series) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -974,6 +1032,9 @@ func (m *Series) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -989,6 +1050,9 @@ func (m *Series) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -1019,7 +1083,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1047,7 +1111,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MinTime |= (int64(b) & 0x7F) << shift
+				m.MinTime |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1066,7 +1130,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MaxTime |= (int64(b) & 0x7F) << shift
+				m.MaxTime |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1085,7 +1149,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1094,6 +1158,9 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1118,7 +1185,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1127,6 +1194,9 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1151,7 +1221,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1160,6 +1230,9 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1184,7 +1257,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1193,6 +1266,9 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1217,7 +1293,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1226,6 +1302,9 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1250,7 +1329,7 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1259,6 +1338,9 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1276,6 +1358,9 @@ func (m *AggrChunk) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -1306,7 +1391,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1334,7 +1419,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Type |= (LabelMatcher_Type(b) & 0x7F) << shift
+				m.Type |= LabelMatcher_Type(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1353,7 +1438,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1363,6 +1448,9 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1382,7 +1470,7 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1392,6 +1480,9 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthTypes
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTypes
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1404,6 +1495,9 @@ func (m *LabelMatcher) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthTypes
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthTypes
 			}
 			if (iNdEx + skippy) > l {
@@ -1473,8 +1567,11 @@ func skipTypes(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			iNdEx += length
 			if length < 0 {
+				return 0, ErrInvalidLengthTypes
+			}
+			iNdEx += length
+			if iNdEx < 0 {
 				return 0, ErrInvalidLengthTypes
 			}
 			return iNdEx, nil
@@ -1505,6 +1602,9 @@ func skipTypes(dAtA []byte) (n int, err error) {
 					return 0, err
 				}
 				iNdEx = start + next
+				if iNdEx < 0 {
+					return 0, ErrInvalidLengthTypes
+				}
 			}
 			return iNdEx, nil
 		case 4:
@@ -1523,36 +1623,3 @@ var (
 	ErrInvalidLengthTypes = fmt.Errorf("proto: negative length found during unmarshaling")
 	ErrIntOverflowTypes   = fmt.Errorf("proto: integer overflow")
 )
-
-func init() { proto.RegisterFile("types.proto", fileDescriptor_types_60e135d4a4f03620) }
-
-var fileDescriptor_types_60e135d4a4f03620 = []byte{
-	// 432 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x92, 0xdd, 0x6e, 0xd3, 0x30,
-	0x14, 0xc7, 0xeb, 0x7c, 0x76, 0x67, 0x03, 0x05, 0x33, 0x21, 0x97, 0x8b, 0xae, 0x0a, 0x17, 0x54,
-	0x20, 0x32, 0x31, 0x9e, 0x80, 0xa1, 0xdc, 0xf1, 0xa1, 0x99, 0x5d, 0x20, 0x84, 0x84, 0xdc, 0xce,
-	0xa4, 0x11, 0x8d, 0x5d, 0xc5, 0x0e, 0x74, 0x8f, 0x81, 0x78, 0xa9, 0x5e, 0xf2, 0x04, 0x08, 0xfa,
-	0x24, 0xc8, 0x27, 0x0d, 0x5b, 0xa5, 0xdc, 0x1d, 0x9f, 0xff, 0xef, 0x7c, 0xc8, 0xe7, 0x0f, 0x87,
-	0xf6, 0x7a, 0x25, 0x4d, 0xb6, 0xaa, 0xb5, 0xd5, 0x34, 0xb2, 0x0b, 0xa1, 0xb4, 0x79, 0x78, 0x5c,
-	0xe8, 0x42, 0x63, 0xea, 0xd4, 0x45, 0xad, 0x9a, 0x3e, 0x87, 0xf0, 0xb5, 0x98, 0xc9, 0x25, 0xa5,
-	0x10, 0x28, 0x51, 0x49, 0x46, 0x26, 0x64, 0x7a, 0xc0, 0x31, 0xa6, 0xc7, 0x10, 0x7e, 0x13, 0xcb,
-	0x46, 0x32, 0x0f, 0x93, 0xed, 0x23, 0xfd, 0x04, 0xe1, 0xab, 0x45, 0xa3, 0xbe, 0xd2, 0x27, 0x10,
-	0xb8, 0x41, 0x58, 0x72, 0xf7, 0xec, 0x41, 0xd6, 0x0e, 0xca, 0x50, 0xcc, 0x72, 0x35, 0xd7, 0x57,
-	0xa5, 0x2a, 0x38, 0x32, 0xae, 0xfd, 0x95, 0xb0, 0x02, 0x3b, 0x1d, 0x71, 0x8c, 0xd3, 0xfb, 0x30,
-	0xec, 0x28, 0x1a, 0x83, 0xff, 0xe1, 0x1d, 0x4f, 0x06, 0xe9, 0x17, 0x88, 0xde, 0xcb, 0xba, 0x94,
-	0x86, 0x3e, 0x85, 0x68, 0xe9, 0x56, 0x33, 0x8c, 0x4c, 0xfc, 0xe9, 0xe1, 0xd9, 0x9d, 0x6e, 0x00,
-	0x2e, 0x7c, 0x1e, 0x6c, 0x7e, 0x9f, 0x0c, 0xf8, 0x0e, 0xa1, 0xa7, 0x10, 0xcd, 0xdd, 0x5c, 0xc3,
-	0x3c, 0x84, 0xef, 0x75, 0xf0, 0xcb, 0xa2, 0xa8, 0x71, 0xa3, 0xae, 0xa0, 0xc5, 0xd2, 0x9f, 0x1e,
-	0x1c, 0xfc, 0xd7, 0xe8, 0x08, 0x86, 0x55, 0xa9, 0x3e, 0xdb, 0x72, 0xf7, 0x03, 0x3e, 0x8f, 0xab,
-	0x52, 0x5d, 0x96, 0x95, 0x44, 0x49, 0xac, 0x5b, 0xc9, 0xdb, 0x49, 0x62, 0x8d, 0xd2, 0x09, 0xf8,
-	0xb5, 0xf8, 0xce, 0xfc, 0x09, 0xb9, 0xbd, 0x1e, 0x76, 0xe4, 0x4e, 0xa1, 0x8f, 0x20, 0x9c, 0xeb,
-	0x46, 0x59, 0x16, 0xf4, 0x21, 0xad, 0xe6, 0xba, 0x98, 0xa6, 0x62, 0x61, 0x6f, 0x17, 0xd3, 0x54,
-	0x0e, 0xa8, 0x4a, 0xc5, 0xa2, 0x5e, 0xa0, 0x2a, 0x15, 0x02, 0x62, 0xcd, 0xe2, 0x7e, 0x40, 0xac,
-	0xe9, 0x63, 0x88, 0x71, 0x96, 0xac, 0xd9, 0xb0, 0x0f, 0xea, 0xd4, 0xf4, 0x07, 0x81, 0x23, 0xfc,
-	0xde, 0x37, 0xc2, 0xce, 0x17, 0xb2, 0xa6, 0xcf, 0xf6, 0x6e, 0x3c, 0xda, 0x3b, 0xc1, 0x8e, 0xc9,
-	0x2e, 0xaf, 0x57, 0xf2, 0xe6, 0xcc, 0xe8, 0x22, 0xaf, 0xcf, 0x45, 0xfe, 0x6d, 0x17, 0x4d, 0x21,
-	0x70, 0x75, 0x34, 0x02, 0x2f, 0xbf, 0x48, 0x06, 0xce, 0x00, 0x6f, 0xf3, 0x8b, 0x84, 0xb8, 0x04,
-	0xcf, 0x13, 0x0f, 0x13, 0x3c, 0x4f, 0xfc, 0xf3, 0xd1, 0xe6, 0xef, 0x78, 0xb0, 0xd9, 0x8e, 0xc9,
-	0xaf, 0xed, 0x98, 0xfc, 0xd9, 0x8e, 0xc9, 0xc7, 0xd8, 0x58, 0x5d, 0xcb, 0xd5, 0x6c, 0x16, 0xa1,
-	0x89, 0x5f, 0xfc, 0x0b, 0x00, 0x00, 0xff, 0xff, 0x46, 0x5a, 0xe2, 0x68, 0xf1, 0x02, 0x00, 0x00,
-}

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -58,6 +58,15 @@ func (s *TSDBStore) Info(ctx context.Context, r *storepb.InfoRequest) (*storepb.
 			Value: l.Value,
 		})
 	}
+
+	// Until we deprecate the single labels in the reply, we just duplicate
+	// them here for migration/compatibility purposes.
+	res.LabelSets = []storepb.LabelSet{}
+	if len(res.Labels) > 0 {
+		res.LabelSets = append(res.LabelSets, storepb.LabelSet{
+			Labels: res.Labels,
+		})
+	}
 	return res, nil
 }
 

--- a/pkg/ui/templates/stores.html
+++ b/pkg/ui/templates/stores.html
@@ -15,7 +15,7 @@
         <tr>
             <th>Endpoint</th>
             <th>Status</th>
-            <th>Announced Labels</th>
+            <th>Announced LabelSets</th>
             <th>Min Time</th>
             <th>Max Time</th>
             <th>Last Health Check</th>
@@ -38,8 +38,10 @@
                 {{end}}
             </td>
             <td>
-            {{range $label := $store.Labels}}
-                <span class="badge badge-primary">{{$label.Name}}="{{$label.Value}}"</span>
+            {{range $labelSets := $store.LabelSets}}
+                {{range $label := $labelSets.Labels}}
+                    <span class="badge badge-primary">{{$label.Name}}="{{$label.Value}}"</span>
+                {{end}}
             {{end}}
             </td>
             <td>{{formatTimestamp $store.MinTime}}</td>

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -84,6 +84,8 @@ EOF
     --storage.tsdb.path   data/prom${i} \
     --log.level           warn \
     --web.enable-lifecycle \
+    --storage.tsdb.min-block-duration=2h \
+    --storage.tsdb.max-block-duration=2h \
     --web.listen-address  0.0.0.0:909${i} &
 
   sleep 0.25
@@ -106,8 +108,7 @@ do
     --http-address              0.0.0.0:1919${i} \
     --prometheus.url            http://localhost:909${i} \
     --tsdb.path                 data/prom${i} \
-    ${OBJSTORECFG} \
-    --cluster.disable &
+    ${OBJSTORECFG} &
 
   STORES="${STORES} --store 127.0.0.1:1909${i}"
 
@@ -124,8 +125,7 @@ then
     --grpc-address              0.0.0.0:19691 \
     --http-address              0.0.0.0:19791 \
     --data-dir                  data/store \
-    ${OBJSTORECFG} \
-    --cluster.disable &
+    ${OBJSTORECFG} &
 
   STORES="${STORES} --store 127.0.0.1:19691"
 fi
@@ -172,8 +172,8 @@ do
     --debug.name                query-${i} \
     --grpc-address              0.0.0.0:1999${i} \
     --http-address              0.0.0.0:1949${i} \
-    ${STORES} \
-    --cluster.disable &
+    --query.replica-label       prometheus \
+    ${STORES} &
 done
 
 wait

--- a/test/e2e/rule_test.go
+++ b/test/e2e/rule_test.go
@@ -241,6 +241,24 @@ func (a *failingStoreAPI) Info(context.Context, *storepb.InfoRequest) (*storepb.
 				Value: "store_api",
 			},
 		},
+		LabelSets: []storepb.LabelSet{
+			{
+				Labels: []storepb.Label{
+					{
+						Name:  "magic",
+						Value: "store_api",
+					},
+				},
+			},
+			{
+				Labels: []storepb.Label{
+					{
+						Name:  "magicmarker",
+						Value: "store_api",
+					},
+				},
+			},
+		},
 	}, nil
 }
 
@@ -258,7 +276,7 @@ func (a *failingStoreAPI) LabelValues(context.Context, *storepb.LabelValuesReque
 
 // Test Ruler behaviour on different storepb.PartialResponseStrategy when having partial response from single `failingStoreAPI`.
 func TestRulePartialResponse(t *testing.T) {
-	const expectedWarning = "receive series from Addr: 127.0.0.1:21091 Labels: [{magic store_api {} [] 0}] Mint: -9223372036854775808 Maxt: 9223372036854775807: rpc error: code = Unknown desc = I always fail. No reason. I am just offended StoreAPI. Don't touch me"
+	const expectedWarning = "receive series from Addr: 127.0.0.1:21091 LabelSets: [name:\"magic\" value:\"store_api\" ][name:\"magicmarker\" value:\"store_api\" ] Mint: -9223372036854775808 Maxt: 9223372036854775807: rpc error: code = Unknown desc = I always fail. No reason. I am just offended StoreAPI. Don't touch me"
 
 	dir, err := ioutil.TempDir("", "test_rulepartial_respn")
 	testutil.Ok(t, err)


### PR DESCRIPTION
## Changes 

This PR adds that the Info gRPC service now exposes potentially multiple label-sets. For all store types except `proxy` this doesn't change anything for now, it just adds the currently single label-set as the only entry in the list of label-sets. The `proxy` type, from now exposes it's stores' labels merged with its configured selector.

I'd like to ask that the `proxy.go` changes are particularly carefully reviewed.

## Verification

Adapted all tests and see them passing.

@squat @bwplotka @GiedriusS @povilasv @domgreen 