### PR TITLE
sidecar:  wait on ext labels before uploading

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -248,7 +248,7 @@ func runSidecar(
 		g.Add(func() error {
 			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
-			extLabelsTimeout := 2 * time.Minute
+			extLabelsTimeout := 10 * time.Minute
 			extLabelsCtx, _ := context.WithTimeout(ctx, extLabelsTimeout)
 			if err := runutil.Retry(2*time.Second, extLabelsCtx.Done(), func() error {
 				if len(m.Labels()) == 0 {

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -248,6 +248,17 @@ func runSidecar(
 		g.Add(func() error {
 			defer runutil.CloseWithLogOnErr(logger, bkt, "bucket client")
 
+			extLabelsTimeout := 2 * time.Minute
+			extLabelsCtx, _ := context.WithTimeout(ctx, extLabelsTimeout)
+			if err := runutil.Retry(2*time.Second, extLabelsCtx.Done(), func() error {
+				if len(m.Labels()) == 0 {
+					return errors.New("not uploading as no external labels are configured yet - is Prometheus healthy/reachable?")
+				}
+				return nil
+			}); err != nil {
+				return errors.Wrapf(err, "aborting as no external labels found after waiting %s", extLabelsTimeout)
+			}
+
 			var s *shipper.Shipper
 			if uploadCompacted {
 				s = shipper.NewWithCompacted(logger, reg, dataDir, bkt, m.Labels, metadata.SidecarSource)


### PR DESCRIPTION
Addresses https://github.com/improbable-eng/thanos/issues/1239 by adding a step that will force a wait on external labels before starting the shipper (when upload is enabled).

Note that the case of `len(m.Labels())` is already checked in the sidecar when it initially syncs with Prom.  However, we don't currently hard-fail if `len(m.Labels())==0`as we retry indefinitely.  With this PR, we would now hard-fail in that case (after 2 minutes).