### PR TITLE
pkg/receive: ensure hashring chan closes after ctx

### DIFF
--- a/pkg/receive/hashring.go
+++ b/pkg/receive/hashring.go
@@ -166,13 +166,14 @@ func newMultiHashring(cfg []HashringConfig) Hashring {
 // Which hashring to use for a tenant is determined
 // by the tenants field of the hashring configuration.
 func HashringFromConfig(ctx context.Context, updates chan<- Hashring, cw *ConfigWatcher) {
-	cfgUpdates := make(chan []HashringConfig)
-	defer close(cfgUpdates)
-	go cw.Run(ctx, cfgUpdates)
+	go cw.Run(ctx)
 
 	for {
 		select {
-		case cfg := <-cfgUpdates:
+		case cfg, ok := <-cw.C():
+			if !ok {
+				return
+			}
 			updates <- newMultiHashring(cfg)
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
Currently, it is possible for the hashring configuration update channel
to be closed before the hashring config watcher has completely stopped.
This means that the config watcher can attempt to write on a closed
chan. This commit fixes that by closing the chan only after the config
watcher will never write again to the chan. This also prevents further
errors of this type by changing the ownership of the chan so that the
goroutine writing to the chan is the one closing it.

This commit also ensures that a closed hashring config chan does not
trigger a new hashring to be sent on the update chan.

cc @bwplotka @brancz 