### PR TITLE
prober: remove unused componentMtx

### DIFF
--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -24,7 +24,6 @@ const (
 // Prober represents health and readiness status of given component.
 type Prober struct {
 	logger             log.Logger
-	componentMtx       sync.RWMutex
 	component          component.Component
 	readyMtx           sync.RWMutex
 	readiness          error


### PR DESCRIPTION
AFAICT there was an idea to use a general RWMutex componentMtx but then
it was removed in favor of two separate RWMutexes for the readiness and
healthiness probes.

Remove it from the struct to unblock the build.