### PR TITLE
Make it clear, explicit, and fail early on query with just external labels

### DIFF
--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -644,7 +644,7 @@ func TestProxyStore_Series_RegressionFillResponseChannel(t *testing.T) {
 		&storepb.SeriesRequest{
 			MinTime:  1,
 			MaxTime:  300,
-			Matchers: []storepb.LabelMatcher{{Name: "fed", Value: "a", Type: storepb.LabelMatcher_EQ}},
+			Matchers: []storepb.LabelMatcher{{Name: "any", Value: ".*", Type: storepb.LabelMatcher_RE}},
 		}, s,
 	))
 	testutil.Equals(t, 0, len(s.SeriesSet))

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -22,29 +22,29 @@ import (
 // It attaches the provided external labels to all results. It only responds with raw data
 // and does not support downsampling.
 type TSDBStore struct {
-	logger    log.Logger
-	db        *tsdb.DB
-	component component.SourceStoreAPI
-	labels    labels.Labels
+	logger         log.Logger
+	db             *tsdb.DB
+	component      component.SourceStoreAPI
+	externalLabels labels.Labels
 }
 
 // NewTSDBStore creates a new TSDBStore.
-func NewTSDBStore(logger log.Logger, reg prometheus.Registerer, db *tsdb.DB, component component.SourceStoreAPI, externalLabels labels.Labels) *TSDBStore {
+func NewTSDBStore(logger log.Logger, _ prometheus.Registerer, db *tsdb.DB, component component.SourceStoreAPI, externalLabels labels.Labels) *TSDBStore {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 	return &TSDBStore{
-		logger:    logger,
-		db:        db,
-		component: component,
-		labels:    externalLabels,
+		logger:         logger,
+		db:             db,
+		component:      component,
+		externalLabels: externalLabels,
 	}
 }
 
 // Info returns store information about the Prometheus instance.
 func (s *TSDBStore) Info(ctx context.Context, r *storepb.InfoRequest) (*storepb.InfoResponse, error) {
 	res := &storepb.InfoResponse{
-		Labels:    make([]storepb.Label, 0, len(s.labels)),
+		Labels:    make([]storepb.Label, 0, len(s.externalLabels)),
 		StoreType: s.component.ToProto(),
 		MinTime:   0,
 		MaxTime:   math.MaxInt64,
@@ -52,7 +52,7 @@ func (s *TSDBStore) Info(ctx context.Context, r *storepb.InfoRequest) (*storepb.
 	if blocks := s.db.Blocks(); len(blocks) > 0 {
 		res.MinTime = blocks[0].Meta().MinTime
 	}
-	for _, l := range s.labels {
+	for _, l := range s.externalLabels {
 		res.Labels = append(res.Labels, storepb.Label{
 			Name:  l.Name,
 			Value: l.Value,
@@ -73,13 +73,19 @@ func (s *TSDBStore) Info(ctx context.Context, r *storepb.InfoRequest) (*storepb.
 // Series returns all series for a requested time range and label matcher. The returned data may
 // exceed the requested time bounds.
 func (s *TSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
-	match, newMatchers, err := labelsMatches(s.labels, r.Matchers)
+	match, newMatchers, err := matchesExternalLabels(r.Matchers, s.externalLabels)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
+
 	if !match {
 		return nil
 	}
+
+	if len(newMatchers) == 0 {
+		return status.Error(codes.InvalidArgument, errors.New("no matchers specified (excluding external labels)").Error())
+	}
+
 	matchers, err := translateMatchers(newMatchers)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
@@ -113,7 +119,7 @@ func (s *TSDBStore) Series(r *storepb.SeriesRequest, srv storepb.Store_SeriesSer
 			return status.Errorf(codes.Internal, "encode chunk: %s", err)
 		}
 
-		respSeries.Labels = s.translateAndExtendLabels(series.Labels(), s.labels)
+		respSeries.Labels = s.translateAndExtendLabels(series.Labels(), s.externalLabels)
 		respSeries.Chunks = append(respSeries.Chunks[:0], c...)
 
 		if err := srv.Send(storepb.NewSeriesResponse(&respSeries)); err != nil {


### PR DESCRIPTION
Merging it into `master`. I think @bwplotka accidentally merged it into a wrong branch which has a similar name to `master`. Original PR: https://github.com/improbable-eng/thanos/pull/1310

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>