### PR TITLE
Remove duplicate closing grpc listener

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -451,7 +451,6 @@ func runQuery(
 			return errors.Wrap(s.Serve(l), "serve gRPC")
 		}, func(error) {
 			s.Stop()
-			runutil.CloseWithLogOnErr(logger, l, "store gRPC listener")
 		})
 	}
 

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -280,9 +280,6 @@ func runReceive(
 			if s != nil {
 				s.Stop()
 			}
-			if l != nil {
-				runutil.CloseWithLogOnErr(logger, l, "store gRPC listener")
-			}
 		})
 	}
 

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -504,7 +504,6 @@ func runRule(
 			return errors.Wrap(s.Serve(l), "serve gRPC")
 		}, func(error) {
 			s.Stop()
-			runutil.CloseWithLogOnErr(logger, l, "store gRPC listener")
 		})
 	}
 	// Start UI & metrics HTTP server.

--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -223,7 +223,6 @@ func runSidecar(
 			return errors.Wrap(s.Serve(l), "serve gRPC")
 		}, func(error) {
 			s.Stop()
-			runutil.CloseWithLogOnErr(logger, l, "store gRPC listener")
 		})
 	}
 

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -181,7 +181,7 @@ func runStore(
 			level.Info(logger).Log("msg", "Listening for StoreAPI gRPC", "address", grpcBindAddr)
 			return errors.Wrap(s.Serve(l), "serve gRPC")
 		}, func(error) {
-			runutil.CloseWithLogOnErr(logger, l, "store gRPC listener")
+			s.Stop()
 		})
 	}
 	if err := metricHTTPListenGroup(g, logger, reg, httpBindAddr); err != nil {


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->

Remove the code `runutil.CloseWithLogOnErr(logger, l, "store gRPC listener")`, because when the grpc server is stopped, the listener who grpc server served will be closed too.

## Verification

<!-- How you tested it? How do you know it works? -->

Send SIGHUP to the thanos components, such as query, store, sidecar. No warning log appeared like this:
`level=warn ts=2019-07-12T04:20:03.867228785Z caller=runutil.go:108 component=sidecar msg="detected close error" err="store gRPC listener: close tcp 0.0.0.0:10901: use of closed network connection"`