### PR TITLE
api/series: return an empty array iff no results

### DIFF
--- a/pkg/query/api/v1.go
+++ b/pkg/query/api/v1.go
@@ -543,7 +543,7 @@ func (api *API) series(r *http.Request) (interface{}, []error, *ApiError) {
 
 	set := storage.NewMergeSeriesSet(sets, nil)
 
-	var metrics []labels.Labels
+	metrics := []labels.Labels{}
 	for set.Next() {
 		metrics = append(metrics, set.At().Labels())
 	}

--- a/pkg/query/api/v1_test.go
+++ b/pkg/query/api/v1_test.go
@@ -302,6 +302,14 @@ func TestEndpoints(t *testing.T) {
 				labels.FromStrings("__name__", "test_metric2", "foo", "boo"),
 			},
 		},
+		// Series that does not exist should return an empty array.
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`foobar`},
+			},
+			response: []labels.Labels{},
+		},
 		{
 			endpoint: api.series,
 			query: url.Values{
@@ -337,7 +345,7 @@ func TestEndpoints(t *testing.T) {
 				"start":   []string{"-2"},
 				"end":     []string{"-1"},
 			},
-			response: []labels.Labels(nil),
+			response: []labels.Labels{},
 		},
 		// Start and end after series ends.
 		{
@@ -347,7 +355,7 @@ func TestEndpoints(t *testing.T) {
 				"start":   []string{"100000"},
 				"end":     []string{"100001"},
 			},
-			response: []labels.Labels(nil),
+			response: []labels.Labels{},
 		},
 		// Start before series starts, end after series ends.
 		{
@@ -458,7 +466,7 @@ func TestEndpoints(t *testing.T) {
 				"start":   []string{"-2"},
 				"end":     []string{"-1"},
 			},
-			response: []labels.Labels(nil),
+			response: []labels.Labels{},
 		},
 		// Start and end after series ends.
 		{
@@ -468,7 +476,7 @@ func TestEndpoints(t *testing.T) {
 				"start":   []string{"100000"},
 				"end":     []string{"100001"},
 			},
-			response: []labels.Labels(nil),
+			response: []labels.Labels{},
 		},
 		// Start before series starts, end after series ends.
 		{


### PR DESCRIPTION
Prometheus' /series end-point returns an empty array no matter what: if
there were results or not. We need to follow the same principle in
Thanos as well because our users depend on it.

The same fix has been applied as here:
https://github.com/prometheus/prometheus/blob/fef150f1b5e48652ec6779e2129ae9a0cf13db8a/web/api/v1/api.go#L506

Tests have been updated to account for this difference and plus one test
has been added just for this case.

Closes #1325.